### PR TITLE
Adding info that SCORPIO was derived from PIO

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Software for Caching Output and Reads for Parallel I/O (SCORPIO)
 
-A high-level Parallel I/O Library for structured grid applications
+A high-level Parallel I/O Library for structured grid applications. This library was derived from the [Parallel I/O library](https://github.com/NCAR/ParallelIO).
 
 ## Website
 


### PR DESCRIPTION
Including info in README that SCORPIO is derived from PIO. The
documentation already has this information.