### PR TITLE
Avoid assigning character fillvalue to integer

### DIFF
--- a/src/flib/pio_types.F90
+++ b/src/flib/pio_types.F90
@@ -250,7 +250,7 @@ module pio_types
    integer, public, parameter :: PIO_NOWRITE = 21
    integer, public, parameter :: PIO_64BIT_OFFSET = 0
    integer, public, parameter :: PIO_64BIT_DATA = 0
-   integer, public, parameter :: PIO_FILL_CHAR = achar(0);
+   integer, public, parameter :: PIO_FILL_CHAR = 0;
    integer, public, parameter :: PIO_FILL_INT = -2147483647;
    real, public, parameter :: PIO_FILL_FLOAT =  9.9692099683868690e+36;
    double precision, public, parameter :: PIO_FILL_DOUBLE = 9.9692099683868690e+36;


### PR DESCRIPTION
Initializing PIO character fillvalue to the same value (0) as
nf_fill_char.

See Issue #251