### PR TITLE
Fix type conv error when converting idx 2 dim list

### DIFF
--- a/src/clib/pio_rearrange.c
+++ b/src/clib/pio_rearrange.c
@@ -57,7 +57,7 @@ inline void idx_to_dim_list(int ndims, const int *gdimlen, PIO_Offset idx,
     /* Easiest to start from the right and move left. */
     for (int i = ndims - 1; i >= 0; --i)
     {
-        int next_idx;
+        PIO_Offset next_idx;
 
         /* This way of doing div/mod is slightly faster than using "/"
          * and "%". */


### PR DESCRIPTION
Fixing type conversion error when converting a 1d index to
multi-dim index.

Fixes #243