### PR TITLE
Add a new Fortran unit test for PIO_initdecomp_bc

### DIFF
--- a/tests/general/pio_decomp_tests_1d.F90.in
+++ b/tests/general/pio_decomp_tests_1d.F90.in
@@ -317,6 +317,123 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_wr_rd_1d_bc
   end do !rd_rearr_opt_idx=1,size(enable_rd_rearr)
 PIO_TF_AUTO_TEST_SUB_END nc_wr_rd_1d_bc
 
+! Test PIO_initdecomp_bc using start and count
+! Write with one decomp and read with another
+! Test all combs
+! - no rearrage read + no rearrange write
+! - rearrage read + no rearrange write
+! - no rearrage read + rearrange write
+! - rearrage read + rearrange write
+PIO_TF_TEMPLATE<PIO_TF_PREDEF_TYPENAME PIO_TF_DATA_TYPE, PIO_TF_PREDEF_TYPENAME PIO_TF_FC_DATA_TYPE>
+PIO_TF_AUTO_TEST_SUB_BEGIN nc_wr_rd_1d_bc_start_count
+  implicit none
+  type(var_desc_t)  :: pio_var
+  type(file_desc_t) :: pio_file
+  character(len=PIO_TF_MAX_STR_LEN) :: filename
+  character(len=*), parameter :: PIO_VAR_NAME = 'PIO_TF_test_var'
+  type(io_desc_t) :: wr_iodesc, rd_iodesc
+  integer, dimension(1) :: start, count
+  integer(pio_offset_kind), dimension(1) :: compstart, compcount
+  PIO_TF_FC_DATA_TYPE, dimension(:), allocatable :: rbuf, wbuf, exp_val
+  integer, dimension(1) :: dims
+  integer :: pio_dim
+  integer :: i, ierr
+  ! iotypes = valid io types
+  integer, dimension(:), allocatable :: iotypes
+  character(len=PIO_TF_MAX_STR_LEN), dimension(:), allocatable :: iotype_descs
+  integer :: num_iotypes
+  logical, dimension(2) :: enable_rd_rearr = (/.false., .true./)
+  integer :: rd_rearr_opt_idx
+  logical, dimension(2) :: enable_wr_rearr = (/.false., .true./)
+  integer :: wr_rearr_opt_idx
+
+  do rd_rearr_opt_idx=1,size(enable_rd_rearr)
+    do wr_rearr_opt_idx=1,size(enable_wr_rearr)
+      PIO_TF_LOG(0, *) "Testing Rd rearr =", enable_rd_rearr(rd_rearr_opt_idx), ",Write rearr=", enable_wr_rearr(wr_rearr_opt_idx)
+      ! Set the decomposition for writing data - forcing rearrangement
+      call get_1d_bc_info(pio_tf_world_rank_, pio_tf_world_sz_, dims,&
+             start, count, enable_wr_rearr(wr_rearr_opt_idx))
+      allocate(wbuf(count(1)))
+      do i=1,count(1)
+        wbuf(i) = start(1) + i - 1
+      end do
+
+      compstart = start
+      compcount = count
+      call PIO_initdecomp(pio_tf_iosystem_, PIO_TF_DATA_TYPE, dims, compstart, compcount, wr_iodesc)
+
+      ! Set the decomposition for reading data - different from the write decomp
+      call get_1d_bc_info(pio_tf_world_rank_, pio_tf_world_sz_, dims,&
+             start, count, enable_rd_rearr(rd_rearr_opt_idx))
+      allocate(rbuf(count(1)))
+      allocate(exp_val(count(1)))
+      do i=1,count(1)
+        ! Expected value, after reading
+        exp_val(i) = start(1) + i - 1
+      end do
+
+      compstart = start
+      compcount = count
+      call PIO_initdecomp(pio_tf_iosystem_, PIO_TF_DATA_TYPE, dims, compstart, compcount, rd_iodesc)
+
+      num_iotypes = 0
+      call PIO_TF_Get_nc_iotypes(iotypes, iotype_descs, num_iotypes)
+      filename = "test_pio_decomp_simple_tests.testfile"
+      do i=1,num_iotypes
+        PIO_TF_LOG(0,*) "Testing : PIO_TF_DATA_TYPE : ", iotype_descs(i)
+        ierr = PIO_createfile(pio_tf_iosystem_, pio_file, iotypes(i), filename, PIO_CLOBBER)
+        PIO_TF_CHECK_ERR(ierr, "Could not create file " // trim(filename))
+
+        ierr = PIO_def_dim(pio_file, 'PIO_TF_test_dim', dims(1), pio_dim)
+        PIO_TF_CHECK_ERR(ierr, "Failed to define a dim : " // trim(filename))
+
+        ierr = PIO_def_var(pio_file, PIO_VAR_NAME, PIO_TF_DATA_TYPE, (/pio_dim/), pio_var)
+        PIO_TF_CHECK_ERR(ierr, "Failed to define a var : " // trim(filename))
+
+        ierr = PIO_enddef(pio_file)
+        PIO_TF_CHECK_ERR(ierr, "Failed to end redef mode : " // trim(filename))
+
+        ! Write the variable out
+        call PIO_write_darray(pio_file, pio_var, wr_iodesc, wbuf, ierr)
+        PIO_TF_CHECK_ERR(ierr, "Failed to write darray : " // trim(filename))
+
+#ifdef PIO_TEST_CLOSE_OPEN_FOR_SYNC
+        call PIO_closefile(pio_file)
+
+        ierr = PIO_openfile(pio_tf_iosystem_, pio_file, iotypes(i), filename, PIO_nowrite)
+        PIO_TF_CHECK_ERR(ierr, "Could not reopen file " // trim(filename))
+
+        ierr = PIO_inq_varid(pio_file, PIO_VAR_NAME, pio_var)
+        PIO_TF_CHECK_ERR(ierr, "Could not inq var : " // trim(filename))
+#else
+        call PIO_syncfile(pio_file)
+#endif
+
+        rbuf = 0
+        call PIO_read_darray(pio_file, pio_var, rd_iodesc, rbuf, ierr)
+        PIO_TF_CHECK_ERR(ierr, "Failed to read darray : " // trim(filename))
+
+        PIO_TF_CHECK_VAL((rbuf, exp_val), "Got wrong val")
+
+        call PIO_closefile(pio_file)
+
+        call PIO_deletefile(pio_tf_iosystem_, filename);
+      end do
+
+      if(allocated(iotypes)) then
+        deallocate(iotypes)
+        deallocate(iotype_descs)
+      end if
+
+      call PIO_freedecomp(pio_tf_iosystem_, rd_iodesc)
+      call PIO_freedecomp(pio_tf_iosystem_, wr_iodesc)
+      deallocate(exp_val)
+      deallocate(rbuf)
+      deallocate(wbuf)
+    end do !wr_rearr_opt_idx=1,size(enable_wr_rearr)
+  end do !rd_rearr_opt_idx=1,size(enable_rd_rearr)
+PIO_TF_AUTO_TEST_SUB_END nc_wr_rd_1d_bc_start_count
+
 ! Test write/read of a variable where each proc writes/reads multiple regions
 ! of the data
 PIO_TF_TEMPLATE<PIO_TF_PREDEF_TYPENAME PIO_TF_DATA_TYPE, PIO_TF_PREDEF_TYPENAME PIO_TF_FC_DATA_TYPE>


### PR DESCRIPTION
Interface PIO_initdecomp has 3 module procedures:
PIO_initdecomp_dof_i4
PIO_initdecomp_dof_i8
PIO_initdecomp_bc

However, PIO_initdecomp_bc is not covered by any existing Fortran
tests, including nc_wr_rd_1d_bc.

This test can show a bug caused by a typo in subroutine
PIO_initdecomp_bc, where cstart is assigned twice while ccount
is never assigned.

This test can also reproduce an off-by-one error in C API
PIOc_InitDecomp_bc(), which is reported in PR 1606 of
NCAR/ParallelIO.