### PR TITLE
Fix two bugs related to PIO_initdecomp_bc overload

### DIFF
--- a/src/clib/pioc.c
+++ b/src/clib/pioc.c
@@ -876,7 +876,7 @@ int PIOc_InitDecomp_bc(int iosysid, int pio_type, int ndims, const int *gdimlen,
     }
     for (i = 0; i < maplen; i++)
     {
-        compmap[i] = 0;
+        compmap[i] = 1;
         for (n = ndims - 1; n >= 0; n--)
             compmap[i] += (start[n] + loc[n]) * prod[n];
 

--- a/src/flib/piolib_mod.F90
+++ b/src/flib/piolib_mod.F90
@@ -480,7 +480,7 @@ contains
     do i=1,ndims
        cdims(i) = dims(ndims-i+1)
        cstart(i)  = compstart(ndims-i+1)-1
-       cstart(i)  = compcount(ndims-i+1)
+       ccount(i)  = compcount(ndims-i+1)
     end do
 
     ierr = PIOc_InitDecomp_bc(iosystem%iosysid, basepiotype, ndims, cdims, &


### PR DESCRIPTION
This PR fixed a typo in subroutine PIO_initdecomp_bc and
an off-by-one error in PIOc_InitDecomp_bc().

1) These bugs can be reproduced with the new Fortran unit test
nc_wr_rd_1d_bc_start_count.

2) The off-by-one error was originally reported and fixed in PR
1606 of NCAR/ParallelIO.

3) PIO_initdecomp_bc overload is not currently used by E3SM.