### PR TITLE
Check and process the return code from the flush_output_buffer() function

### DIFF
--- a/src/clib/pio_darray.c
+++ b/src/clib/pio_darray.c
@@ -219,7 +219,14 @@ int PIOc_write_darray_multi(int ncid, const int *varids, int ioid, int nvars,
 
     /* if the buffer is already in use in pnetcdf we need to flush first */
     if (file->iotype == PIO_IOTYPE_PNETCDF && file->iobuf[ioid - PIO_IODESC_START_ID])
-	flush_output_buffer(file, 1, 0);
+    {
+        ierr = flush_output_buffer(file, true, 0);
+        if (ierr != PIO_NOERR)
+        {
+            return pio_err(ios, file, ierr, __FILE__, __LINE__,
+                            "Writing multiple variables to file (%s, ncid=%d) failed. Flushing data to disk (PIO_IOTYPE_PNETCDF) failed", pio_get_fname_from_file(file), ncid);
+        }
+    }
 
     pioassert(!file->iobuf[ioid - PIO_IODESC_START_ID], "buffer overwrite",__FILE__, __LINE__);
 

--- a/src/clib/pio_file.c
+++ b/src/clib/pio_file.c
@@ -315,7 +315,7 @@ static int sync_file(int ncid)
 #endif
 #ifdef _PNETCDF
             case PIO_IOTYPE_PNETCDF:
-                flush_output_buffer(file, true, 0);
+                ierr = flush_output_buffer(file, true, 0);
                 break;
 #endif
             default:

--- a/src/clib/pio_getput_int.c
+++ b/src/clib/pio_getput_int.c
@@ -1320,8 +1320,11 @@ int PIOc_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
                     *request = PIO_REQ_NULL;
 
                 vdesc->nreqs++;
-                flush_output_buffer(file, false, 0);
-                LOG((2, "PIOc_put_vars_tc flushed output buffer"));
+                if (ierr == PIO_NOERR)
+                {
+                    ierr = flush_output_buffer(file, false, 0);
+                    LOG((2, "PIOc_put_vars_tc flushed output buffer, ierr=%d", ierr));
+                }
             }
             else
             {
@@ -1378,8 +1381,11 @@ int PIOc_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
                     *request = PIO_REQ_NULL;
 
                 vdesc->nreqs++;
-                flush_output_buffer(file, false, 0);
-                LOG((2, "PIOc_put_vars_tc flushed output buffer"));
+                if (ierr == PIO_NOERR)
+                {
+                    ierr = flush_output_buffer(file, false, 0);
+                    LOG((2, "PIOc_put_vars_tc flushed output buffer, ierr=%d", ierr));
+                }
 
                 /* Free malloced resources. */
                 if (!stride_present)

--- a/src/clib/pio_varm.c
+++ b/src/clib/pio_varm.c
@@ -64,7 +64,10 @@ int PIOc_put_varm (int ncid, int varid, const PIO_Offset start[], const PIO_Offs
                 *request = PIO_REQ_NULL;
             }
             vdesc->nreqs++;
-            flush_output_buffer(file, false, 0);
+            if (ierr == PIO_NOERR)
+            {
+                ierr = flush_output_buffer(file, false, 0);
+            }
             break;
 #endif
         default:
@@ -135,7 +138,10 @@ int PIOc_put_varm_uchar (int ncid, int varid, const PIO_Offset start[], const PI
                 *request = PIO_REQ_NULL;
             }
             vdesc->nreqs++;
-            flush_output_buffer(file, false, 0);
+            if (ierr == PIO_NOERR)
+            {
+                ierr = flush_output_buffer(file, false, 0);
+            }
             break;
 #endif
         default:
@@ -206,7 +212,10 @@ int PIOc_put_varm_short (int ncid, int varid, const PIO_Offset start[], const PI
                 *request = PIO_REQ_NULL;
             }
             vdesc->nreqs++;
-            flush_output_buffer(file, false, 0);
+            if (ierr == PIO_NOERR)
+            {
+                ierr = flush_output_buffer(file, false, 0);
+            }
             break;
 #endif
         default:
@@ -278,7 +287,10 @@ int PIOc_put_varm_text (int ncid, int varid, const PIO_Offset start[], const PIO
                 *request = PIO_REQ_NULL;
             }
             vdesc->nreqs++;
-            flush_output_buffer(file, false, 0);
+            if (ierr == PIO_NOERR)
+            {
+                ierr = flush_output_buffer(file, false, 0);
+            }
             break;
 #endif
         default:
@@ -351,7 +363,10 @@ int PIOc_put_varm_ushort (int ncid, int varid, const PIO_Offset start[], const P
                 *request = PIO_REQ_NULL;
             }
             vdesc->nreqs++;
-            flush_output_buffer(file, false, 0);
+            if (ierr == PIO_NOERR)
+            {
+                ierr = flush_output_buffer(file, false, 0);
+            }
             break;
 #endif
         default:
@@ -424,7 +439,10 @@ int PIOc_put_varm_ulonglong (int ncid, int varid, const PIO_Offset start[], cons
                 *request = PIO_REQ_NULL;
             }
             vdesc->nreqs++;
-            flush_output_buffer(file, false, 0);
+            if (ierr == PIO_NOERR)
+            {
+                ierr = flush_output_buffer(file, false, 0);
+            }
             break;
 #endif
         default:
@@ -496,7 +514,10 @@ int PIOc_put_varm_int (int ncid, int varid, const PIO_Offset start[], const PIO_
                 *request = PIO_REQ_NULL;
             }
             vdesc->nreqs++;
-            flush_output_buffer(file, false, 0);
+            if (ierr == PIO_NOERR)
+            {
+                ierr = flush_output_buffer(file, false, 0);
+            }
             break;
 #endif
         default:
@@ -569,7 +590,10 @@ int PIOc_put_varm_float (int ncid, int varid, const PIO_Offset start[], const PI
                 *request = PIO_REQ_NULL;
             }
             vdesc->nreqs++;
-            flush_output_buffer(file, false, 0);
+            if (ierr == PIO_NOERR)
+            {
+                ierr = flush_output_buffer(file, false, 0);
+            }
             break;
 #endif
         default:
@@ -641,7 +665,10 @@ int PIOc_put_varm_long (int ncid, int varid, const PIO_Offset start[], const PIO
                 *request = PIO_REQ_NULL;
             }
             vdesc->nreqs++;
-            flush_output_buffer(file, false, 0);
+            if (ierr == PIO_NOERR)
+            {
+                ierr = flush_output_buffer(file, false, 0);
+            }
             break;
 #endif
         default:
@@ -715,7 +742,10 @@ int PIOc_put_varm_uint (int ncid, int varid, const PIO_Offset start[], const PIO
                 *request = PIO_REQ_NULL;
             }
             vdesc->nreqs++;
-            flush_output_buffer(file, false, 0);
+            if (ierr == PIO_NOERR)
+            {
+                ierr = flush_output_buffer(file, false, 0);
+            }
             break;
 #endif
         default:
@@ -788,7 +818,10 @@ int PIOc_put_varm_double (int ncid, int varid, const PIO_Offset start[], const P
                 *request = PIO_REQ_NULL;
             }
             vdesc->nreqs++;
-            flush_output_buffer(file, false, 0);
+            if (ierr == PIO_NOERR)
+            {
+                ierr = flush_output_buffer(file, false, 0);
+            }
             break;
 #endif
         default:
@@ -860,7 +893,10 @@ int PIOc_put_varm_schar (int ncid, int varid, const PIO_Offset start[], const PI
                 *request = PIO_REQ_NULL;
             }
             vdesc->nreqs++;
-            flush_output_buffer(file, false, 0);
+            if (ierr == PIO_NOERR)
+            {
+                ierr = flush_output_buffer(file, false, 0);
+            }
             break;
 #endif
         default:
@@ -931,7 +967,10 @@ int PIOc_put_varm_longlong (int ncid, int varid, const PIO_Offset start[], const
                 *request = PIO_REQ_NULL;
             }
             vdesc->nreqs++;
-            flush_output_buffer(file, false, 0);
+            if (ierr == PIO_NOERR)
+            {
+                ierr = flush_output_buffer(file, false, 0);
+            }
             break;
 #endif
         default:


### PR DESCRIPTION
Check and process the return code from the flush_output_buffer()
function.

The return code from the flush_output_buffer() function was being
ignored in scorpio and hence the case where that function fails
was not being handled correctly.