### PR TITLE
Add PnetCDF block wait support

### DIFF
--- a/src/clib/pio.h
+++ b/src/clib/pio.h
@@ -312,8 +312,12 @@ typedef struct var_desc_t
      * unlimited dimension. */
     int record;
 
+    /** FIXME: Combine request related members to a separate struct */
     /** ID of each outstanding pnetcdf request for this variable. */
     int *request;
+
+    /** Size of each outstanding pnetcdf request for this variable */
+    PIO_Offset *request_sz;
 
     /** Number of requests bending with pnetcdf. */
     int nreqs;

--- a/src/clib/pio_darray_int.c
+++ b/src/clib/pio_darray_int.c
@@ -9,6 +9,7 @@
  * @author Jim Edwards
  */
 
+#include <limits.h>
 #include <config.h>
 #include <pio.h>
 #include <pio_internal.h>
@@ -346,8 +347,22 @@ int write_darray_multi_par(file_desc_t *file, int nvars, int fndims, const int *
                                 return pio_err(ios, file, PIO_ENOMEM, __FILE__, __LINE__,
                                           "Writing variables (number of variables = %d) to file (%s, ncid=%d) using PIO_IOTYPE_PNETCDF iotype failed. Out of memory reallocing buffer (%lld bytes) for array to store pnetcdf request handles", nvars, pio_get_fname_from_file(file), file->pio_ncid, (long long int) (sizeof(int) * (vdesc->nreqs + PIO_REQUEST_ALLOC_CHUNK)));
 
+                            vdesc->request_sz = realloc(vdesc->request_sz,
+                                                  sizeof(PIO_Offset) *
+                                                  (vdesc->nreqs +
+                                                    PIO_REQUEST_ALLOC_CHUNK));
+                            if(vdesc->request_sz == NULL)
+                            {
+                                return pio_err(ios, file, PIO_ENOMEM,
+                                          __FILE__, __LINE__,
+                                          "Writing variables (number of variables = %d) to file (%s, ncid=%d) using PIO_IOTYPE_PNETCDF iotype failed. Out of memory reallocing buffer (%lld bytes) for array to store pending pnetcdf request sizes", nvars, pio_get_fname_from_file(file), file->pio_ncid, (long long int) (sizeof(PIO_Offset) * (vdesc->nreqs + PIO_REQUEST_ALLOC_CHUNK)));
+                            }
+
                             for (int i = vdesc->nreqs; i < vdesc->nreqs + PIO_REQUEST_ALLOC_CHUNK; i++)
+                            {
                                 vdesc->request[i] = NC_REQ_NULL;
+                                vdesc->request_sz[i] = 0;
+                            }
                         }
 
                         /* Write, in non-blocking fashion, a list of subarrays. */
@@ -358,7 +373,13 @@ int write_darray_multi_par(file_desc_t *file, int nvars, int fndims, const int *
 
                         /* keeps wait calls in sync */
                         if (vdesc->request[vdesc->nreqs] == NC_REQ_NULL)
+                        {
                             vdesc->request[vdesc->nreqs] = PIO_REQ_NULL;
+                        }
+                        else
+                        {
+                            vdesc->request_sz[vdesc->nreqs] = llen * iodesc->mpitype_size;
+                        }
 
                         vdesc->nreqs++;
                     }
@@ -1425,6 +1446,309 @@ int pio_read_darray_nc_serial(file_desc_t *file, int fndims, io_desc_t *iodesc, 
     return PIO_NOERR;
 }
 
+/* Max size of cached requests (in bytes) that we wait on
+ * in a single wait call.
+ * This is only valid for PIO_IOTYPE_PNETCDF iotype
+ * PnetCDF has a limitation on the aggregate size of requests
+ * from a single rank (due to inherent limitations in the MPI
+ * I/O libraries) that it cannot exceed INT_MAX
+ */
+PIO_Offset file_req_block_sz_limit = INT_MAX;
+
+/* Set the aggregate size of requests used in a single blocking
+ * wait call
+ * This setting is only used for PIO_IOTYPE_PNETCDF iotype
+ */
+int set_file_req_block_size_limit(file_desc_t *file, PIO_Offset sz)
+{
+  assert(file && (sz > 0));
+  file_req_block_sz_limit = sz;
+
+  return PIO_NOERR;
+}
+
+/**
+ * Convert the pending requests on a file to blocks of size
+ * < file_req_block_sz_limit . The function returns multiple blocks
+ * {[req_block_starts[0], req_block_ends[0]], ...} such
+ * that each block size <= file_req_block_sz_limit. If any single
+ * request is > file_req_block_sz_limit it is allocated an
+ * individual block and a warning is printed out
+ * 
+ * The array *preq_block_ranges contains start and end indices
+ * to the *preqs array indicating multiple blocks of requests.
+ * The first half ( [0, nreq_blocks) ) of the array includes
+ * the start indices and the latter half
+ * ( [nreq_blocks, 2 * nreq_blocks) ) of the array includes
+ * the end indices of each block.
+ * The request block i in the file->varlist array is
+ * determined by the range,
+ * [(*preq_block_ranges)[i],
+ *    (*preq_block_ranges)[i + nreq_blocks]]
+ * (the end index is also part of the block)
+ *
+ * Collective on all I/O processes (in the I/O system associated
+ * with the file)
+ * This function is only used by the PIO_IOTYPE_PNETCDF
+ *
+ * @param file Pointer to file descriptor of the file
+ * @param preqs Pointer to a buffer that will contain
+ *          pending requests on this file
+ * @param nreqs Pointer to integer that will contain the number
+ *          of pending requests on this file
+ * @param nvars_with_reqs Pointer to integer that will contain
+ *          the number of variables that have valid pending
+            requests
+ * @param last_var_with_req Pointer to integer that will contain
+ *          the index of the last variable in file->varlist that
+ *          contains pending requests
+ * @param preq_block_ranges Pointer to buffer that will contain
+ *          the block ranges
+ *          The initial half of the buffer contains start
+ *          indices and the latter half the end indices of
+ *          the block ranges
+ *          i.e., (*preq_block_ranges)[2 * nreq_blocks]
+ * @param nreq_blocks Pointer to integer that will contain the
+ *          number of block ranges
+ *
+ * @author Jayesh Krishna
+ */
+
+int get_file_req_blocks(file_desc_t *file,
+      int **preqs,
+      int *nreqs,
+      int *nvars_with_reqs,
+      int *last_var_with_req,
+      int **preq_block_ranges,
+      int *nreq_blocks)
+{
+    int mpierr = MPI_SUCCESS;
+
+    assert(file &&
+            preqs && nreqs && last_var_with_req &&
+            preq_block_ranges && nreq_blocks);
+    assert(file->iotype == PIO_IOTYPE_PNETCDF);
+    assert(file->iosystem && (file->iosystem->num_iotasks > 0));
+
+    *nreqs = 0;
+    *nvars_with_reqs = 0;
+    *last_var_with_req = 0;
+    *nreq_blocks = 0;
+
+    int file_nreqs = 0;
+    int vdesc_with_reqs_start = 0;
+    int vdesc_with_reqs_end = 0;
+    /* FIXME: Update file->nreqs with vdesc->nreqs to avoid computing
+     * everytime
+     */
+    for(int i = 0; i < PIO_MAX_VARS; i++){
+      var_desc_t *vdesc = file->varlist + i;
+      if(vdesc->nreqs > 0){
+        file_nreqs += vdesc->nreqs;
+        /* Once the range starts, vdesc_with_reqs_end >= 1 */
+        if(vdesc_with_reqs_end == 0){
+          vdesc_with_reqs_start = i;
+        }
+        vdesc_with_reqs_end = i + 1;
+        (*nvars_with_reqs)++;
+        *last_var_with_req = i;
+      }
+    }
+
+#ifdef PIO_ENABLE_SANITY_CHECKS
+    /* Sanity check : All io ranks have the same number of reqs per file */
+    int file_nreqs_root = file_nreqs;
+    mpierr = MPI_Bcast(&file_nreqs_root, 1, MPI_INT,
+              file->iosystem->ioroot, file->iosystem->io_comm);
+    assert(mpierr == MPI_SUCCESS);
+    assert(file_nreqs_root == file_nreqs);
+#endif
+
+    /* No requests pending on this file */
+    if(file_nreqs == 0){
+      *nreqs = 0;
+      *nreq_blocks = 0;
+
+      return PIO_NOERR;
+    }
+
+    /* preqs : pointer to consolidated list of pending requests on this file */
+    *preqs = (int *) calloc(file_nreqs, sizeof(int));
+    if(!(*preqs)){
+      return pio_err(file->iosystem, file, PIO_ENOMEM, __FILE__, __LINE__,
+                      "Unable to allocate memory (%llu bytes) for consolidating pending requests on a file (%s, ncid=%d, num pending requests = %d)", (unsigned long long) (file_nreqs * sizeof(int)), pio_get_fname_from_file(file), file->pio_ncid, file_nreqs);
+    }
+    *nreqs = file_nreqs;
+
+    /* preq_block_ranges : Contains the ranges for the blocks,
+     * each block of size <= file_req_block_sz_limit, which includes
+     * start indices in the first half and end indices in the second half.
+     * The number of block ranges should be less than the number of
+     * pending requests (max number of blocks => 1 request per block)
+     * => 2 * file_nreqs
+     * This buffer is also used to store the size of block ranges at
+     * index 2 * file_nreqs => 1 int (for communicating with non-root procs)
+     * => size of 2 * file_nreqs + 1
+     */
+    *preq_block_ranges = (int *) calloc(2 * file_nreqs + 1, sizeof(int));
+    if(!(*preq_block_ranges)){
+      return pio_err(file->iosystem, file, PIO_ENOMEM, __FILE__, __LINE__,
+                      "Unable to allocate memory (%llu bytes) for storing pending request ranges in a file (%s, ncid=%d, num pending requests = %d)", (unsigned long long) ((2 * file_nreqs + 1)* sizeof(int)), pio_get_fname_from_file(file), file->pio_ncid, file_nreqs);
+    }
+    int *preq_block_ranges_sz = (*preq_block_ranges) + 2 * file_nreqs;
+    *nreq_blocks = 0;
+
+    int *req_block_starts = *preq_block_ranges;
+    int *req_block_ends = *preq_block_ranges + file_nreqs;
+
+    /* One pending request on this file */
+    if(file_nreqs == 1){
+      int req = file->varlist[vdesc_with_reqs_start].request[0];
+      (*preqs)[0] = (req != PIO_REQ_NULL) ? req : NC_REQ_NULL;
+      req_block_starts[0] = 0;
+      req_block_ends[0] = 0;
+      *nreq_blocks = 1;
+
+      return PIO_NOERR;
+    }
+
+    /* local file pending request sizes */
+    int *file_lrequest = *preqs;
+    PIO_Offset file_lrequest_sz[file_nreqs];
+    PIO_Offset file_grequest_sz[file_nreqs * file->iosystem->num_iotasks];
+
+    for(int i = vdesc_with_reqs_start, j = 0;
+          (i < vdesc_with_reqs_end) && (j < file_nreqs); i++){
+      var_desc_t *vdesc = file->varlist + i;
+      for(int k = 0; k < vdesc->nreqs; k++, j++){
+        file_lrequest[j] = (vdesc->request[k] != PIO_REQ_NULL) ?
+                            (vdesc->request[k]) : NC_REQ_NULL;
+        file_lrequest_sz[j] = vdesc->request_sz[k];
+      }
+    }
+
+#ifdef FLUSH_EVERY_VAR
+    /* Its easier to handle this corner case, used infrequently, separately */
+    /* Each request block consists of requests pending on a single variable */
+    *nreq_blocks = 0;
+    for(int i = vdesc_with_reqs_start, j = 0;
+        (i < vdesc_with_reqs_end) && (j < file_nreqs); i++){
+      var_desc_t *vdesc = file->varlist + i;
+      if(vdesc->nreqs > 0){
+        req_block_starts[*nreq_blocks] = j;
+        req_block_ends[*nreq_blocks] = j + vdesc->nreqs - 1;
+        (*nreq_blocks)++;
+        j += vdesc->nreqs;
+      }
+    }
+
+    /* Copy the starts and ends to a contiguous section */
+    if(file_nreqs != *nreq_blocks){
+      for(int i = *nreq_blocks, j = 0;
+          (i < 2 * file_nreqs) && (j < *nreq_blocks); i++, j++){
+        req_block_starts[i] = req_block_ends[j];
+      }
+    }
+
+    return PIO_NOERR;
+#endif /* #ifdef FLUSH_EVERY_VAR */
+
+    /* Gather file pending request sizes from all I/O processes */
+    mpierr = MPI_Gather(file_lrequest_sz, file_nreqs, MPI_OFFSET,
+                        file_grequest_sz, file_nreqs, MPI_OFFSET,
+                        file->iosystem->ioroot, file->iosystem->io_comm);
+    if(mpierr != MPI_SUCCESS){
+      return check_mpi(file->iosystem, file, mpierr, __FILE__, __LINE__);
+    }
+
+    /* Find the request blocks in the root I/O process */
+    bool is_ioroot =
+      (file->iosystem->io_rank == file->iosystem->ioroot) ? true : false;
+    if(is_ioroot){
+      PIO_Offset file_cur_block_grequest_sz[file->iosystem->num_iotasks];
+
+      /* file_grequest_sz[] = {
+       * rank_0_req0_sz, rank_0_req1_sz, ..., rank_0_reqi_sz, ...
+       * rank_1_req0_sz, rank_1_req1_sz, ..., rank_1_reqi_sz, ...
+       * rank_j_req0_sz, rank_j_req1_sz, ..., rank_j_reqi_sz,...}
+       * In the loop below we calculate block size by calculating
+       * partial sums of requests, one request at a time
+       */
+
+      /* Initialize cur block grequest size with size of the first
+       * request for each I/O rank
+       * Note:
+       *  Number of pending requests on this file, file_nreqs > 1
+       */
+      for(int j = 0; j < file->iosystem->num_iotasks; j++){
+        PIO_Offset cur_idx = j * file_nreqs;
+        file_cur_block_grequest_sz[j] = file_grequest_sz[cur_idx];
+      }
+      int k = 0;
+      for(int i = 1; i < file_nreqs; i++){
+        req_block_ends[k] = i;
+        for(int j = 0; j < file->iosystem->num_iotasks; j++){
+          /* Get idx for reqi on rank j */
+          PIO_Offset cur_idx = i + j * file_nreqs;
+          file_cur_block_grequest_sz[j] += file_grequest_sz[cur_idx];
+          if(file_cur_block_grequest_sz[j] > file_req_block_sz_limit){
+            PIO_Offset nreqs_in_cur_block =
+                        req_block_ends[k] - req_block_starts[k] + 1;
+            assert(nreqs_in_cur_block >= 1);
+            if(nreqs_in_cur_block == 1){
+              /* We cannot have 0 requests in a block but the size
+               * of ith request is > file_req_block_sz_limit.
+               * So include this ith request in a single block with
+               * a warning to the user
+               */
+              printf("PIO: WARNING: Found a single user request (size=%lld bytes) that exceeds the maximum limit (%lld bytes) for user request %d on I/O process %d when processing pending requests on file (%s, ncid=%d, number of pending requests=%d). Waiting on this request might fail during a future wait, consider writing out data < %lld bytes from a single process\n", file_cur_block_grequest_sz[j], file_req_block_sz_limit, i, j, pio_get_fname_from_file(file), file->pio_ncid, file_nreqs, file_req_block_sz_limit);
+            }
+            /* Finish the prev block - indicate that the prev
+             * block cannot include this request
+             */
+            req_block_ends[k] = i - 1;
+            /* We need to start a new block */
+            k++;
+            req_block_starts[k] = i;
+            req_block_ends[k] = i;
+            /* Reset the current size of block for all iotasks */
+            for(int l = 0; l < file->iosystem->num_iotasks; l++){
+              /* Get idx for reqi on rank l */
+              PIO_Offset idx = i + l * file_nreqs;
+              file_cur_block_grequest_sz[l] = file_grequest_sz[idx];
+            }
+            break;
+          }
+        }
+      }
+
+      /* Note: We are guarantreed to have at least 1 block here */
+      *nreq_blocks = ++k;
+
+      /* Copy the starts and ends to a contiguous section */
+      if(file_nreqs != *nreq_blocks){
+        for(int i = *nreq_blocks, j = 0;
+            (i < 2 * file_nreqs) && (j < *nreq_blocks); i++, j++){
+          req_block_starts[i] = req_block_ends[j];
+        }
+      }
+    } /* if(is_ioroot) */
+
+    /* Bcast the request blocks
+     * Note that the last int in the buffer is the number of the blocks
+     */
+    *preq_block_ranges_sz = *nreq_blocks;
+    mpierr = MPI_Bcast(*preq_block_ranges, 2 * file_nreqs + 1, MPI_INT,
+              file->iosystem->ioroot, file->iosystem->io_comm);
+    if(mpierr != MPI_SUCCESS){
+      return check_mpi(file->iosystem, file, mpierr, __FILE__, __LINE__);
+    }
+    *nreq_blocks = *preq_block_ranges_sz;
+    assert(*nreq_blocks > 0);
+
+    return PIO_NOERR;
+}
+
 /**
  * Flush the output buffer. This is only relevant for files opened
  * with pnetcdf.
@@ -1435,7 +1759,7 @@ int pio_read_darray_nc_serial(file_desc_t *file, int fndims, io_desc_t *iodesc, 
  * @param addsize additional size to add to buffer (in bytes)
  * @return 0 for success, error code otherwise.
  * @ingroup PIO_write_darray
- * @author Jim Edwards, Ed Hartnett
+ * @author Jim Edwards, Jayesh Krishna, Ed Hartnett
  */
 int flush_output_buffer(file_desc_t *file, bool force, PIO_Offset addsize)
 {
@@ -1481,23 +1805,24 @@ int flush_output_buffer(file_desc_t *file, bool force, PIO_Offset addsize)
     {
         int rcnt;
         int  maxreq; /* Index of the last vdesc with pending requests */
-        int reqcnt;
         int nvars_with_reqs = 0;
         maxreq = -1;
-        reqcnt = 0;
         rcnt = 0;
-        for (int i = 0; i < PIO_MAX_VARS; i++)
+
+        int *reqs = NULL;
+        int nreqs = 0;
+        int *req_block_ranges = NULL;
+        int nreq_blocks = 0;
+
+        ierr = get_file_req_blocks(file, 
+                &reqs, &nreqs, &nvars_with_reqs, &maxreq,
+                &req_block_ranges, &nreq_blocks);
+        if(ierr != PIO_NOERR)
         {
-            vdesc = file->varlist + i;
-            reqcnt += vdesc->nreqs;
-            if (vdesc->nreqs > 0)
-            {
-                maxreq = i;
-                nvars_with_reqs++;
-            }
+            return pio_err(file->iosystem, file, ierr, __FILE__, __LINE__,
+                            "Unable to consolidate pending requests on file (%s, ncid=%d) to blocks (The function returned : Number of pending requests on file = %d, Number of variables with pending requests = %d, Number of request blocks = %d).", pio_get_fname_from_file(file), file->pio_ncid, nreqs, nvars_with_reqs, nreq_blocks); 
         }
-        int request[reqcnt];
-        int status[reqcnt];
+
 #ifdef PIO_MICRO_TIMING
         bool var_has_pend_reqs[maxreq + 1];
         bool var_timer_was_running[maxreq + 1];
@@ -1518,12 +1843,10 @@ int flush_output_buffer(file_desc_t *file, bool force, PIO_Offset addsize)
             LOG((1, "Unable to start the temp wait timer"));
             return ierr;
         }
-#endif
 
         for (int i = 0; i <= maxreq; i++)
         {
             vdesc = file->varlist + i;
-#ifdef PIO_MICRO_TIMING
             /* Pause all timers, the temp wait timer is used to keep
              * track of wait time
              */
@@ -1538,33 +1861,51 @@ int flush_output_buffer(file_desc_t *file, bool force, PIO_Offset addsize)
                     return ierr;
                 }
             }
+        }
 #endif
+
 #ifdef MPIO_ONESIDED
-            /*onesided optimization requires that all of the requests in a wait_all call represent
-              a contiguous block of data in the file */
+        int *request = reqs;
+        int status[nreqs];
+        rcnt = 0;
+        for (int i = 0; i <= maxreq; i++)
+        {
+            vdesc = file->varlist + i;
+            /* Onesided optimization requires that all of the requests
+             * in a wait_all call represent a contiguous block of data
+             * in the file
+             */
             if (rcnt > 0 && (prev_record != vdesc->record || vdesc->nreqs==0))
             {
                 ierr = ncmpi_wait_all(file->fh, rcnt, request, status);
+                request += rcnt;
                 rcnt = 0;
             }
+            rcnt += vdesc->nreqs;
             prev_record = vdesc->record;
-#endif
-            for (reqcnt = 0; reqcnt < vdesc->nreqs; reqcnt++)
-                request[rcnt++] = max(vdesc->request[reqcnt], NC_REQ_NULL);
-
-            if (vdesc->request != NULL)
-                free(vdesc->request);
-            vdesc->request = NULL;
-            vdesc->nreqs = 0;
-
-#ifdef FLUSH_EVERY_VAR
-            ierr = ncmpi_wait_all(file->fh, rcnt, request, status);
-            rcnt = 0;
-#endif
         }
-
         if (rcnt > 0)
+        {
             ierr = ncmpi_wait_all(file->fh, rcnt, request, status);
+        }
+#else /* MPIO_ONESIDED */
+        int *request = reqs;
+        int status[nreqs];
+        rcnt = 0;
+        int *req_block_starts = req_block_ranges;
+        int *req_block_ends = req_block_ranges + nreq_blocks;
+        for(int k = 0; k < nreq_blocks; k++)
+        {
+            assert(req_block_ends[k] >= req_block_starts[k]);
+            rcnt = req_block_ends[k] - req_block_starts[k] + 1;
+
+            LOG((1, "ncmpi_wait_all(file=%s, ncid=%d, request range = [%d, %d], num pending requests = %d)", pio_get_fname_from_file(file), file->pio_ncid, req_block_starts[k], req_block_ends[k], nreqs));
+            ierr = ncmpi_wait_all(file->fh, rcnt, request, status);
+            request += rcnt;
+        }
+#endif /* MPIO_ONESIDED */
+        free(reqs);
+        free(req_block_ranges);
 
 #ifdef PIO_MICRO_TIMING
         ierr = mtimer_pause(tmp_mt, NULL);
@@ -1653,6 +1994,17 @@ int flush_output_buffer(file_desc_t *file, bool force, PIO_Offset addsize)
         {
             vdesc = file->varlist + i;
             vdesc->wb_pend = 0;
+            if (vdesc->nreqs > 0)
+            {
+                assert(vdesc->request && vdesc->request_sz);
+                free(vdesc->request);
+                free(vdesc->request_sz);
+
+                vdesc->request = NULL;
+                vdesc->request_sz = NULL;
+                vdesc->nreqs = 0;
+            }
+  
             if (vdesc->fillbuf)
             {
                 brel(vdesc->fillbuf);

--- a/src/clib/pio_internal.h
+++ b/src/clib/pio_internal.h
@@ -399,6 +399,17 @@ extern "C" {
     /* Create a unique PIO string */
     int pio_create_uniq_str(iosystem_desc_t *ios, io_desc_t *iodesc, char *str, int len, const char *prefix, const char *suffix);
 
+    /* Set the size limit for each block of requests to wait */
+    int set_file_req_block_size_limit(file_desc_t *file, PIO_Offset sz);
+    /* Get request block ranges for pending requests in a file */
+    int get_file_req_blocks(file_desc_t *file,
+          int **preqs,
+          int *nreqs,
+          int *nvars_with_reqs,
+          int *last_var_with_req,
+          int **preq_block_ranges,
+          int *nreq_blocks);
+
 #if defined(__cplusplus)
 }
 #endif

--- a/tests/cunit/CMakeLists.txt
+++ b/tests/cunit/CMakeLists.txt
@@ -97,7 +97,11 @@ add_executable (test_spmd EXCLUDE_FROM_ALL test_spmd.c test_common.c)
 target_link_libraries (test_spmd pioc)
 add_executable (test_sdecomp_regex EXCLUDE_FROM_ALL test_sdecomp_regex.cpp test_common.c)
 target_link_libraries (test_sdecomp_regex pioc)
+add_executable(test_req_block_wait EXCLUDE_FROM_ALL test_req_block_wait.c test_common.c)
+target_link_libraries (test_req_block_wait pioc)
+
 add_dependencies (tests test_sdecomp_regex)
+add_dependencies (tests test_req_block_wait)
 add_dependencies (tests test_spmd)
 add_dependencies (tests test_rearr)
 add_dependencies (tests test_pioc)
@@ -138,6 +142,22 @@ if (PIO_USE_MPISERIAL)
   add_test(NAME test_pioc
     COMMAND test_pioc)
 else ()
+  add_mpi_test(test_req_block_wait1
+    EXECUTABLE ${CMAKE_CURRENT_BINARY_DIR}/test_req_block_wait
+    NUMPROCS 1
+    TIMEOUT ${DEFAULT_TEST_TIMEOUT})
+  add_mpi_test(test_req_block_wait2
+    EXECUTABLE ${CMAKE_CURRENT_BINARY_DIR}/test_req_block_wait
+    NUMPROCS 2
+    TIMEOUT ${DEFAULT_TEST_TIMEOUT})
+  add_mpi_test(test_req_block_wait3
+    EXECUTABLE ${CMAKE_CURRENT_BINARY_DIR}/test_req_block_wait
+    NUMPROCS 3
+    TIMEOUT ${DEFAULT_TEST_TIMEOUT})
+  add_mpi_test(test_req_block_wait4
+    EXECUTABLE ${CMAKE_CURRENT_BINARY_DIR}/test_req_block_wait
+    NUMPROCS 4
+    TIMEOUT ${DEFAULT_TEST_TIMEOUT})
   add_mpi_test(test_spmd
     EXECUTABLE ${CMAKE_CURRENT_BINARY_DIR}/test_spmd
     NUMPROCS ${AT_LEAST_FOUR_TASKS}

--- a/tests/cunit/test_req_block_wait.c
+++ b/tests/cunit/test_req_block_wait.c
@@ -1,0 +1,928 @@
+#include "mpi.h"
+#include "pio.h"
+#include "pio_internal.h"
+#include "pio_tests.h"
+
+
+#define LOG_RANK0(rank, ...)                     \
+            do{                                   \
+                if(rank == 0)                     \
+                {                                 \
+                    fprintf(stderr, __VA_ARGS__); \
+                }                                 \
+            }while(0);
+
+static const int FAIL = -1;
+
+/* Update vars in file with dummy reqs
+ * file : pointer to file descriptor struct associated with file
+ * nvars : Number of vars to update
+ * disp : Number of vars to skip (displacement from the 1st var)
+ * stride : The stride to use to decide which vars to update
+ * nreqs : Number of requests to add to each variable
+ * request_sizes : Array of request sizes
+ * nrequest_sizes : Size of array of request sizes
+ */
+int update_file_varlist(file_desc_t *file,
+                      int nvars, int disp, int stride,
+                      int nreqs,
+                      PIO_Offset *request_sizes, int nrequest_sizes)
+{
+  int ret = PIO_NOERR;
+  const int DUMMY_REQ_START = 101;
+  assert(file &&
+    (nvars > 0) && (disp >= 0) && (stride > 0) &&
+    (nreqs > 0) && (request_sizes) && (nrequest_sizes > 0));
+
+  for(int v = 0, i = disp;
+      (v < nvars) && (i < PIO_MAX_VARS); v++, i += stride){
+    file->varlist[i].varid = i;
+    snprintf(file->varlist[i].vname, PIO_MAX_NAME, "test_var_%d", i);
+    if(file->varlist[i].request){
+      assert(file->varlist[i].nreqs > 0);
+      free(file->varlist[i].request);
+      assert(file->varlist[i].request_sz != NULL);
+      free(file->varlist[i].request_sz);
+    }
+    file->varlist[i].request = (int *)malloc(nreqs * sizeof(int));
+    file->varlist[i].request_sz =
+      (PIO_Offset *)malloc(nreqs * sizeof(PIO_Offset));
+    assert(file->varlist[i].request && file->varlist[i].request_sz);
+
+    for(int j = 0, reqid = DUMMY_REQ_START, k = 0;
+        j < nreqs; j++, reqid++, k++){
+      if(k == nrequest_sizes){
+        k = 0;
+      }
+      file->varlist[i].request[j] = reqid;
+      file->varlist[i].request_sz[j] = request_sizes[k];
+    }
+    file->varlist[i].nreqs = nreqs;
+  }
+
+  return ret;
+}
+
+/* Init file->varlist */
+int init_file_varlist(file_desc_t *file)
+{
+  int ret = PIO_NOERR;
+  assert(file);
+
+  for(int i = 0; i < PIO_MAX_VARS; i++){
+    file->varlist[i].varid = 0;
+    file->varlist[i].vname[0] = '\0';
+    file->varlist[i].vdesc[0] = '\0';
+    file->varlist[i].rec_var = 0;
+    file->varlist[i].record = 0;
+    file->varlist[i].request = NULL;
+    file->varlist[i].request_sz = NULL;
+    file->varlist[i].nreqs = 0;
+    file->varlist[i].fillvalue = NULL;
+    file->varlist[i].pio_type = PIO_INT;
+    file->varlist[i].type_size = sizeof(int);
+    file->varlist[i].vrsize = 0;
+    file->varlist[i].rb_pend = 0;
+    file->varlist[i].wb_pend = 0;
+    file->varlist[i].use_fill = 0;
+    file->varlist[i].fillbuf = NULL;
+  }
+  return ret;
+}
+
+/* Free file->varlist, file is not freed */
+void free_file_varlist(file_desc_t *file)
+{
+  assert(file);
+  for(int i = 0; i < PIO_MAX_VARS; i++){
+    if(file->varlist[i].nreqs > 0){
+      free(file->varlist[i].request);
+      free(file->varlist[i].request_sz);
+    }
+  }
+}
+
+/* Re-initialize file->varlist : free current varlist and init */
+int reinit_file_varlist(file_desc_t *file)
+{
+  int ret = PIO_NOERR;
+  free_file_varlist(file);
+
+  ret = init_file_varlist(file);
+
+  return ret;
+}
+
+/* Set up iosystem and file structs for a test */
+int test_setup(MPI_Comm comm, int rank, int sz,
+      iosystem_desc_t *ios, file_desc_t *file)
+{
+  int ret = PIO_NOERR;
+  const int TEST_IOSYSID = 101;
+  const int ROOT_RANK = 0;
+
+  assert((comm != MPI_COMM_NULL) && (rank >= 0) && (sz > 0) && ios && file);
+  
+  /* Initialize I/O system
+   * - All tasks are I/O tasks
+   * - I/O root is rank 0
+   */
+  ios->iosysid = TEST_IOSYSID;
+  ios->union_comm = comm;
+  ios->io_comm = comm;
+  ios->comp_comm = comm;
+  ios->intercomm = MPI_COMM_NULL;
+  ios->my_comm = comm;
+  ios->compgroup = MPI_GROUP_NULL;
+  ios->iogroup = MPI_GROUP_NULL;
+  ios->num_iotasks = sz;
+  ios->num_comptasks = sz;
+  ios->num_uniontasks = sz;
+  ios->union_rank = rank;
+  ios->comp_rank = rank;
+  ios->io_rank = rank;
+  ios->iomaster = (rank == ROOT_RANK) ? MPI_ROOT : 0;
+  ios->compmaster = (rank == ROOT_RANK) ? MPI_ROOT : 0;
+  ios->ioroot = ROOT_RANK;
+  ios->comproot = ROOT_RANK;
+  /* We don't need the I/O / compute process ranks for this test */
+  ios->ioranks = NULL;
+  ios->compranks = NULL;
+  ios->error_handler = PIO_RETURN_ERROR;
+  ios->default_rearranger = PIO_REARR_BOX;
+  ios->async = false;
+  ios->ioproc = true;
+  ios->compproc = true;
+  ios->info = MPI_INFO_NULL;
+  ios->async_ios_msg_info.seq_num = 0;
+  ios->async_ios_msg_info.prev_msg = 0;
+  ios->comp_idx = 0;
+  /* We don't need the rearranger options set for this test */
+  ios->next = NULL;
+
+
+  /* Initialize file structure with some dummy requests */
+  file->iosystem = ios;
+  file->fh = 0;
+  strncpy(file->fname, "test_file_req_blocks.nc", PIO_MAX_NAME);
+  file->pio_ncid = 0;
+  file->iotype = PIO_IOTYPE_PNETCDF;
+
+  ret = init_file_varlist(file);
+  assert(ret == PIO_NOERR);
+
+  file->num_unlim_dimids = 0;
+  file->unlim_dimids= NULL;
+  file->mode = PIO_WRITE;
+
+  /* Write multibuffer is not used by this test */
+  file->rb_pend = 0;
+  file->wb_pend = 0;
+  for(int i = 0; i < PIO_IODESC_MAX_IDS; i++){
+    file->iobuf[i] = NULL;
+  }
+  file->next = NULL;
+  file->do_io = true;
+
+  return ret;
+}
+
+/* Teardown/finalize iosystem and file structs */
+int test_teardown(iosystem_desc_t *ios, file_desc_t *file)
+{
+  int ret = PIO_NOERR;
+  assert(ios && file);
+
+  free_file_varlist(file);
+  return ret;
+}
+
+/* Unit tests with simple pending requests in a file */
+int test_simple_file_req_blocks(MPI_Comm comm, int rank, int sz)
+{
+  int ret = PIO_NOERR;
+  iosystem_desc_t iosys;
+  file_desc_t file;
+
+  ret = test_setup(comm, rank, sz, &iosys, &file);
+  if(ret != PIO_NOERR){
+    LOG_RANK0(rank, "Initializing/setup of test failed for test_simple_file_req_blocks, ret = %d\n", ret);
+    return ret;
+  }
+
+  const PIO_Offset MAX_REQ_SZ = 10;
+
+  PIO_Offset one_req_sz[1];
+  PIO_Offset three_req_sz[3];
+  int *reqs = NULL;
+  int nreqs = 0;
+  int nvars_with_reqs = 0;
+  int last_var_with_req = 0;
+  int *req_block_ranges = NULL;
+  int ereq_one_block_ranges[1 * 2];
+  int ereq_two_block_ranges[2 * 2];
+  int nreq_blocks = 0;
+  int enreq_blocks = 0;
+  /*******************  Test 1 *************************/
+  /* A single variable with 1 request within req limit */
+  one_req_sz[0] = MAX_REQ_SZ - 1;
+  ret = update_file_varlist(&file, 1, 0, 1, 1, one_req_sz, 1);
+  if(ret != PIO_NOERR){
+    LOG_RANK0(rank, "Updating file varlist failed for test_simple_file_req_blocks, 1 var with 1 req within req limit, ret = %d\n", ret);
+    return ret;
+  }
+
+  ret = set_file_req_block_size_limit(&file, MAX_REQ_SZ);
+  if(ret != PIO_NOERR){
+    LOG_RANK0(rank, "Setting file request block size limit (to %llu bytes) failed : 1 var with 1 req : test_simple_file_req_blocks, ret = %d\n", (unsigned long long) MAX_REQ_SZ, ret);
+    return ret;
+  }
+
+  reqs = NULL;
+  nreqs = 0;
+  nvars_with_reqs = 0;
+  last_var_with_req = 0;
+  req_block_ranges = NULL;
+  nreq_blocks = 0;
+  enreq_blocks = 1;
+  ereq_one_block_ranges[0] = 0;
+  ereq_one_block_ranges[1] = 0;
+  ret = get_file_req_blocks(&file,
+                            &reqs, &nreqs,
+                            &nvars_with_reqs, &last_var_with_req,
+                            &req_block_ranges, &nreq_blocks);
+  if(ret != PIO_NOERR){
+    LOG_RANK0(rank, "Getting file request block ranges failed : 1 var with 1 req : test_simple_file_req_blocks, ret = %d\n", ret);
+    return ret;
+  }
+
+  if(nreq_blocks != enreq_blocks){
+    LOG_RANK0(rank, "Error while calculating block ranges (expected = %d, returned=%d) : 1 var with 1 req : test_simple_file_req_blocks, ret = %d\n", enreq_blocks, nreq_blocks, ret);
+    free(reqs);
+    free(req_block_ranges);
+    test_teardown(&iosys, &file);
+    return PIO_EINTERNAL;
+  }
+
+  assert(nreq_blocks == 1);
+  for(int i = 0; i < 2 * nreq_blocks; i++){
+    if(req_block_ranges[i] != ereq_one_block_ranges[i]){
+      LOG_RANK0(rank, "Error: Incorrect block range returned, block range index %d = %d (expected %d)\n", i, req_block_ranges[i], ereq_one_block_ranges[i]);
+      LOG_RANK0(rank, "Block ranges returned : \n");
+      for(int j = 0; j < nreq_blocks; j++){
+        LOG_RANK0(rank, "[%d, %d], ",
+          req_block_ranges[j], req_block_ranges[j + nreq_blocks]);
+      }
+      LOG_RANK0(rank, "\n");
+      LOG_RANK0(rank, "Block ranges expected : \n");
+      for(int j = 0; j < nreq_blocks; j++){
+        LOG_RANK0(rank, "[%d, %d], ",
+          ereq_one_block_ranges[j], ereq_one_block_ranges[j + nreq_blocks]);
+      }
+      LOG_RANK0(rank, "\n");
+
+      free(reqs);
+      free(req_block_ranges);
+      test_teardown(&iosys, &file);
+      return PIO_EINTERNAL;
+    }
+  }
+
+  free(reqs);
+  free(req_block_ranges);
+
+  /*******************  Test 2 *************************/
+  /* Two variables with 1 request each within req limit */
+  one_req_sz[0] = MAX_REQ_SZ / 2;
+
+  ret = update_file_varlist(&file, 2, 0, 1, 1, one_req_sz, 1);
+  if(ret != PIO_NOERR){
+    LOG_RANK0(rank, "Updating file varlist failed for test_simple_file_req_blocks, 2 vars with 1 req within req limit, ret = %d\n", ret);
+    return ret;
+  }
+
+  ret = set_file_req_block_size_limit(&file, MAX_REQ_SZ);
+  if(ret != PIO_NOERR){
+    LOG_RANK0(rank, "Setting file request block size limit (to %llu bytes) failed : 2 vars with 1 req each : test_simple_file_req_blocks, ret = %d\n", (unsigned long long) MAX_REQ_SZ, ret);
+    return ret;
+  }
+
+  reqs = NULL;
+  nreqs = 0;
+  nvars_with_reqs = 0;
+  last_var_with_req = 0;
+  req_block_ranges = NULL;
+  nreq_blocks = 0;
+  enreq_blocks = 1;
+  ereq_one_block_ranges[0] = 0;
+  ereq_one_block_ranges[1] = 1;
+  ret = get_file_req_blocks(&file,
+                            &reqs, &nreqs,
+                            &nvars_with_reqs, &last_var_with_req,
+                            &req_block_ranges, &nreq_blocks);
+  if(ret != PIO_NOERR){
+    LOG_RANK0(rank, "Getting file request block ranges failed : 2 vars wtih 1 req each : test_simple_file_req_blocks, ret = %d\n", ret);
+    return ret;
+  }
+
+  if(nreq_blocks != enreq_blocks){
+    LOG_RANK0(rank, "Error while calculating block ranges (expected = %d, returned=%d) : 2 vars with 1 req each : test_simple_file_req_blocks, ret = %d\n", enreq_blocks, nreq_blocks, ret);
+    free(reqs);
+    free(req_block_ranges);
+    test_teardown(&iosys, &file);
+    return PIO_EINTERNAL;
+  }
+
+  assert(nreq_blocks == 1);
+  for(int i = 0; i < 2 * nreq_blocks; i++){
+    if(req_block_ranges[i] != ereq_one_block_ranges[i]){
+      LOG_RANK0(rank, "Error: Incorrect block range returned, block range index %d = %d (expected %d)\n", i, req_block_ranges[i], ereq_one_block_ranges[i]);
+      LOG_RANK0(rank, "Block ranges returned : \n");
+      for(int j = 0; j < nreq_blocks; j++){
+        LOG_RANK0(rank, "[%d, %d], ",
+          req_block_ranges[j], req_block_ranges[j + nreq_blocks]);
+      }
+      LOG_RANK0(rank, "\n");
+      LOG_RANK0(rank, "Block ranges expected : \n");
+      for(int j = 0; j < nreq_blocks; j++){
+        LOG_RANK0(rank, "[%d, %d], ",
+          ereq_one_block_ranges[j], ereq_one_block_ranges[j + nreq_blocks]);
+      }
+      LOG_RANK0(rank, "\n");
+
+      free(reqs);
+      free(req_block_ranges);
+      test_teardown(&iosys, &file);
+      return PIO_EINTERNAL;
+    }
+  }
+
+  free(reqs);
+  free(req_block_ranges);
+
+  /*******************  Test 3 *************************/
+  /* Two variables with 3 requests each within req limit */
+  three_req_sz[0] = MAX_REQ_SZ / 3;
+  three_req_sz[1] = MAX_REQ_SZ / 3;
+  three_req_sz[2] = MAX_REQ_SZ / 3;
+
+  ret = update_file_varlist(&file, 2, 0, 1, 3, three_req_sz, 3);
+  if(ret != PIO_NOERR){
+    LOG_RANK0(rank, "Updating file varlist failed for test_simple_file_req_blocks, 2 vars with 3 reqs each, within req limit, ret = %d\n", ret);
+    return ret;
+  }
+
+  ret = set_file_req_block_size_limit(&file, MAX_REQ_SZ);
+  if(ret != PIO_NOERR){
+    LOG_RANK0(rank, "Setting file request block size limit (to %llu bytes) failed : 2 vars with 3 reqs each : test_simple_file_req_blocks, ret = %d\n", (unsigned long long) MAX_REQ_SZ, ret);
+    return ret;
+  }
+
+  reqs = NULL;
+  nreqs = 0;
+  nvars_with_reqs = 0;
+  last_var_with_req = 0;
+  req_block_ranges = NULL;
+  nreq_blocks = 0;
+  enreq_blocks = 2;
+  /* Expected ranges [0,2], [3,5] */
+  ereq_two_block_ranges[0] = 0;
+  ereq_two_block_ranges[2] = 2;
+  ereq_two_block_ranges[1] = 3;
+  ereq_two_block_ranges[3] = 5;
+  ret = get_file_req_blocks(&file,
+                            &reqs, &nreqs,
+                            &nvars_with_reqs, &last_var_with_req,
+                            &req_block_ranges, &nreq_blocks);
+  if(ret != PIO_NOERR){
+    LOG_RANK0(rank, "Getting file request block ranges failed : 2 vars with 3 reqs each : test_simple_file_req_blocks, ret = %d\n", ret);
+    return ret;
+  }
+
+  if(nreq_blocks != enreq_blocks){
+    LOG_RANK0(rank, "Error while calculating block ranges (expected = %d, returned=%d) : 2 vars with 3 reqs each : test_simple_file_req_blocks, ret = %d\n", enreq_blocks, nreq_blocks, ret);
+    free(reqs);
+    free(req_block_ranges);
+    test_teardown(&iosys, &file);
+    return PIO_EINTERNAL;
+  }
+
+  assert(nreq_blocks == 2);
+  for(int i = 0; i < 2 * nreq_blocks; i++){
+    if(req_block_ranges[i] != ereq_two_block_ranges[i]){
+      LOG_RANK0(rank, "Error: Incorrect block range returned, block range index %d = %d (expected %d)\n", i, req_block_ranges[i], ereq_two_block_ranges[i]);
+      LOG_RANK0(rank, "Block ranges returned : \n");
+      for(int j = 0; j < nreq_blocks; j++){
+        LOG_RANK0(rank, "[%d, %d], ",
+          req_block_ranges[j], req_block_ranges[j + nreq_blocks]);
+      }
+      LOG_RANK0(rank, "\n");
+      LOG_RANK0(rank, "Block ranges expected : \n");
+      for(int j = 0; j < nreq_blocks; j++){
+        LOG_RANK0(rank, "[%d, %d], ",
+          ereq_two_block_ranges[j], ereq_two_block_ranges[j + nreq_blocks]);
+      }
+      LOG_RANK0(rank, "\n");
+
+      free(reqs);
+      free(req_block_ranges);
+      test_teardown(&iosys, &file);
+      return PIO_EINTERNAL;
+    }
+  }
+
+  free(reqs);
+  free(req_block_ranges);
+
+  ret = test_teardown(&iosys, &file);
+  if(ret != PIO_NOERR){
+    LOG_RANK0(rank, "Finalizing/teardown of test failed for test_simple_file_req_blocks, ret = %d\n", ret);
+    return ret;
+  }
+
+  return ret;
+}
+
+/* Unit test with misc file pending request patterns : This
+ * test includes slightly  more complex pending request patterns
+ */
+int test_misc_file_req_blocks(MPI_Comm comm, int rank, int sz)
+{
+  int ret = PIO_NOERR;
+  iosystem_desc_t iosys;
+  file_desc_t file;
+
+  ret = test_setup(comm, rank, sz, &iosys, &file);
+  if(ret != PIO_NOERR){
+    LOG_RANK0(rank, "Initializing/setup of test failed for test_misc_file_req_blocks, ret = %d\n", ret);
+    return ret;
+  }
+
+  const PIO_Offset MAX_REQ_SZ = 20;
+
+  PIO_Offset two_req_sz[2];
+  PIO_Offset three_req_sz[3];
+  int *reqs = NULL;
+  int nreqs = 0;
+  int nvars_with_reqs = 0;
+  int last_var_with_req = 0;
+  int *req_block_ranges = NULL;
+  int nreq_blocks = 0;
+  int enreq_blocks = 0;
+  int ereq_one_block_ranges[1 * 2];
+  int ereq_two_block_ranges[2 * 2];
+  int ereq_three_block_ranges[3 * 2];
+  int ereq_four_block_ranges[4 * 2];
+
+  /*******************  Test 1 *************************/
+  /* Two variables, with stride 2, with 3 requests each within req limit */
+  three_req_sz[0] = MAX_REQ_SZ / 3;
+  three_req_sz[1] = MAX_REQ_SZ / 3;
+  three_req_sz[2] = MAX_REQ_SZ / 3;
+
+  ret = update_file_varlist(&file, 2, 0, 2, 3, three_req_sz, 3);
+  if(ret != PIO_NOERR){
+    LOG_RANK0(rank, "Updating file varlist failed for test_misc_file_req_blocks, 2 vars stride 2 with 3 reqs each, within req limit, ret = %d\n", ret);
+    return ret;
+  }
+
+  ret = set_file_req_block_size_limit(&file, MAX_REQ_SZ);
+  if(ret != PIO_NOERR){
+    LOG_RANK0(rank, "Setting file request block size limit (to %llu bytes) failed : 2 vars stride 2 with 3 reqs each : test_misc_file_req_blocks, ret = %d\n", (unsigned long long) MAX_REQ_SZ, ret);
+    return ret;
+  }
+
+  reqs = NULL;
+  nreqs = 0;
+  nvars_with_reqs = 0;
+  last_var_with_req = 0;
+  req_block_ranges = NULL;
+  nreq_blocks = 0;
+  enreq_blocks = 2;
+  /* Expected ranges [0, 2], [3, 5] */
+  ereq_two_block_ranges[0] = 0;
+  ereq_two_block_ranges[2] = 2;
+  ereq_two_block_ranges[1] = 3;
+  ereq_two_block_ranges[3] = 5;
+  ret = get_file_req_blocks(&file,
+                            &reqs, &nreqs,
+                            &nvars_with_reqs, &last_var_with_req,
+                            &req_block_ranges, &nreq_blocks);
+  if(ret != PIO_NOERR){
+    LOG_RANK0(rank, "Getting file request block ranges failed : 2 vars stride 2 with 3 reqs each : test_misc_file_req_blocks, ret = %d\n", ret);
+    return ret;
+  }
+
+  if(nreq_blocks != enreq_blocks){
+    LOG_RANK0(rank, "Error while calculating block ranges (expected = %d, returned=%d) : 2 vars stride 2 with 3 reqs each : test_misc_file_req_blocks, ret = %d\n", enreq_blocks, nreq_blocks, ret);
+    free(reqs);
+    free(req_block_ranges);
+    test_teardown(&iosys, &file);
+    return PIO_EINTERNAL;
+  }
+
+  assert(nreq_blocks == 2);
+  for(int i = 0; i < 2 * nreq_blocks; i++){
+    if(req_block_ranges[i] != ereq_two_block_ranges[i]){
+      LOG_RANK0(rank, "Error: Incorrect block range returned, block range index %d = %d (expected %d)\n", i, req_block_ranges[i], ereq_two_block_ranges[i]);
+      LOG_RANK0(rank, "Block ranges returned : \n");
+      for(int j = 0; j < nreq_blocks; j++){
+        LOG_RANK0(rank, "[%d, %d], ",
+          req_block_ranges[j], req_block_ranges[j + nreq_blocks]);
+      }
+      LOG_RANK0(rank, "\n");
+      LOG_RANK0(rank, "Block ranges expected : \n");
+      for(int j = 0; j < nreq_blocks; j++){
+        LOG_RANK0(rank, "[%d, %d], ",
+          ereq_two_block_ranges[j], ereq_two_block_ranges[j + nreq_blocks]);
+      }
+      LOG_RANK0(rank, "\n");
+
+      free(reqs);
+      free(req_block_ranges);
+      test_teardown(&iosys, &file);
+      return PIO_EINTERNAL;
+    }
+  }
+
+  free(reqs);
+  free(req_block_ranges);
+
+  /*******************  Test 2 *************************/
+  /* Three variables, with stride 2, displacement 1 and
+   * with 3 requests each within req limit
+   */
+  three_req_sz[0] = MAX_REQ_SZ / 3;
+  three_req_sz[1] = MAX_REQ_SZ / 3;
+  three_req_sz[2] = MAX_REQ_SZ / 3;
+
+  ret = reinit_file_varlist(&file);
+  if(ret != PIO_NOERR){
+    LOG_RANK0(rank, "Re-initializing file varlist failed for test_misc_file_req_blocks, 2 vars disp 1 stride 2 with 3 reqs each within req limit, ret = %d\n", ret);
+    return ret;
+  }
+
+  ret = update_file_varlist(&file, 3, 1, 2, 3, three_req_sz, 3);
+  if(ret != PIO_NOERR){
+    LOG_RANK0(rank, "Updating file varlist failed for test_misc_file_req_blocks, 3 vars disp 1 stride 2 with 3 reqs each, within req limit, ret = %d\n", ret);
+    return ret;
+  }
+
+  ret = set_file_req_block_size_limit(&file, MAX_REQ_SZ);
+  if(ret != PIO_NOERR){
+    LOG_RANK0(rank, "Setting file request block size limit (to %llu bytes) failed : 3 vars disp 1 stride 2 with 3 reqs each : test_misc_file_req_blocks, ret = %d\n", (unsigned long long) MAX_REQ_SZ, ret);
+    return ret;
+  }
+
+  reqs = NULL;
+  nreqs = 0;
+  nvars_with_reqs = 0;
+  last_var_with_req = 0;
+  req_block_ranges = NULL;
+  nreq_blocks = 0;
+  enreq_blocks = 3;
+  /* Expected ranges [0,2], [3,5], [6,8] */
+  ereq_three_block_ranges[0] = 0;
+  ereq_three_block_ranges[3] = 2;
+  ereq_three_block_ranges[1] = 3;
+  ereq_three_block_ranges[4] = 5;
+  ereq_three_block_ranges[2] = 6;
+  ereq_three_block_ranges[5] = 8;
+  ret = get_file_req_blocks(&file,
+                            &reqs, &nreqs,
+                            &nvars_with_reqs, &last_var_with_req,
+                            &req_block_ranges, &nreq_blocks);
+  if(ret != PIO_NOERR){
+    LOG_RANK0(rank, "Getting file request block ranges failed : 3 vars disp 1 stride 2 with 3 reqs each : test_misc_file_req_blocks, ret = %d\n", ret);
+    return ret;
+  }
+
+  if(nreq_blocks != enreq_blocks){
+    LOG_RANK0(rank, "Error while calculating block ranges (expected = %d, returned=%d) : 3 vars disp 1 stride 2 with 3 reqs each : test_misc_file_req_blocks, ret = %d\n", enreq_blocks, nreq_blocks, ret);
+    free(reqs);
+    free(req_block_ranges);
+    test_teardown(&iosys, &file);
+    return PIO_EINTERNAL;
+  }
+
+  assert(nreq_blocks == 3);
+  for(int i = 0; i < 2 * nreq_blocks; i++){
+    if(req_block_ranges[i] != ereq_three_block_ranges[i]){
+      LOG_RANK0(rank, "Error: Incorrect block range returned, block range index %d = %d (expected %d)\n", i, req_block_ranges[i], ereq_three_block_ranges[i]);
+      LOG_RANK0(rank, "Block ranges returned : \n");
+      for(int j = 0; j < nreq_blocks; j++){
+        LOG_RANK0(rank, "[%d, %d], ",
+          req_block_ranges[j], req_block_ranges[j + nreq_blocks]);
+      }
+      LOG_RANK0(rank, "\n");
+      LOG_RANK0(rank, "Block ranges expected : \n");
+      for(int j = 0; j < nreq_blocks; j++){
+        LOG_RANK0(rank, "[%d, %d], ",
+          ereq_three_block_ranges[j], ereq_three_block_ranges[j + nreq_blocks]);
+      }
+      LOG_RANK0(rank, "\n");
+
+      free(reqs);
+      free(req_block_ranges);
+      test_teardown(&iosys, &file);
+      return PIO_EINTERNAL;
+    }
+  }
+
+  free(reqs);
+  free(req_block_ranges);
+
+  /*******************  Test 3 *************************/
+  /* Three variables, with stride 2, displacement 1 and
+   * with 3 requests each within req limit
+   * MAX_REQ_SZ/2 variables with 2 reqs of size 1 each, stride 2
+   * MAX_REQ_SZ/4 variables with 2 reqs of size 2 each, stride 3
+   * MAX_REQ_SZ/8 variables with 2 reqs of size 4 each, stride 4
+   * MAX_REQ_SZ/16 variables with 2 reqs of size 8 each, stride 5
+   */
+  ret = reinit_file_varlist(&file);
+  if(ret != PIO_NOERR){
+    LOG_RANK0(rank, "Re-initializing file varlist failed for test_misc_file_req_blocks, 2 vars disp 1 stride 2 with 3 reqs each within req limit, ret = %d\n", ret);
+    return ret;
+  }
+
+  PIO_Offset req_sz = 1;
+  int disp = 0;
+  enreq_blocks = 4;
+  for(int nvars = MAX_REQ_SZ/2, stride = 2, ereq_block_idx = 0, enreqs = 0;
+      nvars > 0;
+      nvars /= 2, req_sz *= 2, stride += 1, ereq_block_idx++){
+    two_req_sz[0] = req_sz;
+    two_req_sz[1] = req_sz;
+
+    ret = update_file_varlist(&file, nvars, disp, stride, 2, two_req_sz, 2);
+    if(ret != PIO_NOERR){
+      LOG_RANK0(rank, "Updating file varlist failed for test_misc_file_req_blocks, exp inc vars with 2 reqs each, within req limit, ret = %d\n", ret);
+      return ret;
+    }
+
+    disp += (nvars * stride);
+
+    assert((enreq_blocks == 4) && (ereq_block_idx < 4));
+    int nreqs_in_one_block = min(max(1, MAX_REQ_SZ / req_sz), nvars * 2);
+    
+    ereq_four_block_ranges[ereq_block_idx] = enreqs;
+    ereq_four_block_ranges[ereq_block_idx + enreq_blocks] =
+      enreqs + nreqs_in_one_block - 1;
+    enreqs += nreqs_in_one_block;
+  }
+
+  ret = set_file_req_block_size_limit(&file, MAX_REQ_SZ);
+  if(ret != PIO_NOERR){
+    LOG_RANK0(rank, "Setting file request block size limit (to %llu bytes) failed : exp inc vars with 2 reqs each : test_misc_file_req_blocks, ret = %d\n", (unsigned long long) MAX_REQ_SZ, ret);
+    return ret;
+  }
+
+  reqs = NULL;
+  nreqs = 0;
+  nvars_with_reqs = 0;
+  last_var_with_req = 0;
+  req_block_ranges = NULL;
+  nreq_blocks = 0;
+  ret = get_file_req_blocks(&file,
+                            &reqs, &nreqs,
+                            &nvars_with_reqs, &last_var_with_req,
+                            &req_block_ranges, &nreq_blocks);
+  if(ret != PIO_NOERR){
+    LOG_RANK0(rank, "Getting file request block ranges failed : exp inc vars with 2 reqs each : test_misc_file_req_blocks, ret = %d\n", ret);
+    return ret;
+  }
+
+  if(nreq_blocks != enreq_blocks){
+    LOG_RANK0(rank, "Error while calculating block ranges (expected = %d, returned=%d) : exp inc vars with 2 reqs each : test_misc_file_req_blocks, ret = %d\n", enreq_blocks, nreq_blocks, ret);
+    free(reqs);
+    free(req_block_ranges);
+    test_teardown(&iosys, &file);
+    return PIO_EINTERNAL;
+  }
+
+  assert(nreq_blocks == 4);
+  for(int i = 0; i < 2 * nreq_blocks; i++){
+    if(req_block_ranges[i] != ereq_four_block_ranges[i]){
+      LOG_RANK0(rank, "Error: Incorrect block range returned, block range index %d = %d (expected %d)\n", i, req_block_ranges[i], ereq_four_block_ranges[i]);
+      LOG_RANK0(rank, "Block ranges returned : \n");
+      for(int j = 0; j < nreq_blocks; j++){
+        LOG_RANK0(rank, "[%d, %d], ",
+          req_block_ranges[j], req_block_ranges[j + nreq_blocks]);
+      }
+      LOG_RANK0(rank, "\n");
+      LOG_RANK0(rank, "Block ranges expected : \n");
+      for(int j = 0; j < nreq_blocks; j++){
+        LOG_RANK0(rank, "[%d, %d], ",
+          ereq_four_block_ranges[j], ereq_four_block_ranges[j + nreq_blocks]);
+      }
+      LOG_RANK0(rank, "\n");
+
+      free(reqs);
+      free(req_block_ranges);
+      test_teardown(&iosys, &file);
+      return PIO_EINTERNAL;
+    }
+  }
+
+  free(reqs);
+  free(req_block_ranges);
+
+  /*******************  Test 4 *************************/
+  /* N variables, with rank based stride, displacement 1 and
+   * with 3 requests each within req limit
+   * MAX_REQ_SZ/2 variables with 2 reqs of size rank each, stride 2
+   * MAX_REQ_SZ/4 variables with 2 reqs of size rank each, stride 3
+   * MAX_REQ_SZ/8 variables with 2 reqs of size rank each, stride 4
+   * MAX_REQ_SZ/16 variables with 2 reqs of size rank each, stride 5
+   */
+  ret = reinit_file_varlist(&file);
+  if(ret != PIO_NOERR){
+    LOG_RANK0(rank, "Re-initializing file varlist failed for test_misc_file_req_blocks, 2 vars disp 1 stride 2 with 3 reqs each within req limit, ret = %d\n", ret);
+    return ret;
+  }
+
+  PIO_Offset rank_req_sz = (rank+1 <= MAX_REQ_SZ/2) ? rank+1 : MAX_REQ_SZ/2;
+  PIO_Offset max_rank_req_sz = 0;
+  for(int i = 0; i < sz; i++){
+    int irank_req_sz = (i+1 <= MAX_REQ_SZ/2) ? i+1 : MAX_REQ_SZ/2;
+    if(irank_req_sz > max_rank_req_sz){
+      max_rank_req_sz = irank_req_sz;
+    }
+  }
+  disp = 0;
+  enreq_blocks = 1;
+  PIO_Offset req_sum = 0;
+  for(int nvars = MAX_REQ_SZ/2, stride = 2; nvars > 0;
+      nvars /= 2, rank_req_sz *= 2, max_rank_req_sz *= 2, stride += 1){
+    two_req_sz[0] = rank_req_sz;
+    two_req_sz[1] = rank_req_sz;
+
+    for(int j = 0; j < nvars * 2; j++){
+      req_sum += max_rank_req_sz;
+      if(req_sum > MAX_REQ_SZ){
+        req_sum = max_rank_req_sz;
+        enreq_blocks++;
+      }
+    }
+
+    ret = update_file_varlist(&file, nvars, disp, stride, 2, two_req_sz, 2);
+    if(ret != PIO_NOERR){
+      LOG_RANK0(rank, "Updating file varlist failed for test_misc_file_req_blocks, exp inc vars with 2 reqs with size based on rank, within req limit, ret = %d\n", ret);
+      return ret;
+    }
+
+    disp += (nvars * stride);
+  }
+
+  ret = set_file_req_block_size_limit(&file, MAX_REQ_SZ);
+  if(ret != PIO_NOERR){
+    LOG_RANK0(rank, "Setting file request block size limit (to %llu bytes) failed : exp inc vars with 2 reqs with size based on rank : test_misc_file_req_blocks, ret = %d\n", (unsigned long long) MAX_REQ_SZ, ret);
+    return ret;
+  }
+
+  reqs = NULL;
+  nreqs = 0;
+  nvars_with_reqs = 0;
+  last_var_with_req = 0;
+  req_block_ranges = NULL;
+  nreq_blocks = 0;
+  ret = get_file_req_blocks(&file,
+                            &reqs, &nreqs,
+                            &nvars_with_reqs, &last_var_with_req,
+                            &req_block_ranges, &nreq_blocks);
+  if(ret != PIO_NOERR){
+    LOG_RANK0(rank, "Getting file request block ranges failed : exp inc vars with 2 reqs with size based on rank : test_misc_file_req_blocks, ret = %d\n", ret);
+    return ret;
+  }
+
+  if(nreq_blocks != enreq_blocks){
+    LOG_RANK0(rank, "Error while calculating block ranges (expected = %d, returned=%d) : exp inc vars with 2 reqs with size based on rank : test_misc_file_req_blocks, ret = %d\n", enreq_blocks, nreq_blocks, ret);
+    free(reqs);
+    free(req_block_ranges);
+    test_teardown(&iosys, &file);
+    return PIO_EINTERNAL;
+  }
+
+  /* FIXME: Check the value of the block ranges */
+
+  /*
+  LOG_RANK0(rank, "Block ranges returned : \n");
+  for(int i = 0; i < nreq_blocks; i++){
+    LOG_RANK0(rank, "[%d, %d], ",
+      req_block_ranges[i], req_block_ranges[i + nreq_blocks]);
+  }
+  LOG_RANK0(rank, "\n");
+  */
+
+  free(reqs);
+  free(req_block_ranges);
+
+  ret = test_teardown(&iosys, &file);
+  if(ret != PIO_NOERR){
+    LOG_RANK0(rank, "Finalizing/teardown of test failed for test_misc_file_req_blocks, ret = %d\n", ret);
+    return ret;
+  }
+
+  return ret;
+}
+
+int test_invalid_file_req_blocks(MPI_Comm comm, int rank, int sz)
+{
+  int ret = PIO_NOERR;
+
+  return ret;
+}
+
+int test_driver(MPI_Comm comm, int wrank, int wsz, int *num_errors)
+{
+    int nerrs = 0, ret = PIO_NOERR, tmp_ret = PIO_NOERR, mpierr = MPI_SUCCESS;
+    assert((comm != MPI_COMM_NULL) && (wrank >= 0) && (wsz > 0) && num_errors);
+    
+    /* Test simple file request blocks */
+    tmp_ret = test_simple_file_req_blocks(comm, wrank, wsz);
+    mpierr = MPI_Reduce(&tmp_ret, &ret, 1, MPI_INT, MPI_MIN, 0, comm);
+    assert(mpierr == MPI_SUCCESS);
+    if(ret != PIO_NOERR){
+        LOG_RANK0(wrank, "test_simple_file_req_blocks() FAILED, ret = %d\n", ret);
+        nerrs++;
+    }
+    else{
+        LOG_RANK0(wrank, "test_simple_file_req_blocks() PASSED\n");
+    }
+
+    tmp_ret = test_misc_file_req_blocks(comm, wrank, wsz);
+    mpierr = MPI_Reduce(&tmp_ret, &ret, 1, MPI_INT, MPI_MIN, 0, comm);
+    assert(mpierr == MPI_SUCCESS);
+    if(ret != PIO_NOERR){
+        LOG_RANK0(wrank, "test_misc_file_req_blocks() FAILED, ret = %d\n", ret);
+        nerrs++;
+    }
+    else{
+        LOG_RANK0(wrank, "test_misc_file_req_blocks() PASSED\n");
+    }
+
+    *num_errors += nerrs;
+    return nerrs;
+}
+
+int main(int argc, char *argv[])
+{
+    int ret;
+    int wrank, wsz;
+    int num_errors;
+#ifdef TIMING
+#ifndef TIMING_INTERNAL
+    ret = GPTLinitialize();
+    if(ret != 0){
+        LOG_RANK0(wrank, "GPTLinitialize() FAILED, ret = %d\n", ret);
+        return ret;
+    }
+#endif /* TIMING_INTERNAL */
+#endif /* TIMING */
+
+    ret = MPI_Init(&argc, &argv);
+    if(ret != MPI_SUCCESS){
+        LOG_RANK0(wrank, "MPI_Init() FAILED, ret = %d\n", ret);
+        return ret;
+    }
+
+    ret = MPI_Comm_rank(MPI_COMM_WORLD, &wrank);
+    if(ret != MPI_SUCCESS){
+        LOG_RANK0(wrank, "MPI_Comm_rank() FAILED, ret = %d\n", ret);
+        return ret;
+    }
+    ret = MPI_Comm_size(MPI_COMM_WORLD, &wsz);
+    if(ret != MPI_SUCCESS){
+        LOG_RANK0(wrank, "MPI_Comm_rank() FAILED, ret = %d\n", ret);
+        return ret;
+    }
+
+    num_errors = 0;
+    ret = test_driver(MPI_COMM_WORLD, wrank, wsz, &num_errors);
+    if(ret != 0){
+        LOG_RANK0(wrank, "Test driver FAILED\n");
+        return FAIL;
+    }
+    else{
+        LOG_RANK0(wrank, "All tests PASSED\n");
+    }
+
+    MPI_Finalize();
+
+#ifdef TIMING
+#ifndef TIMING_INTERNAL
+    ret = GPTLfinalize();
+    if(ret != 0){
+        LOG_RANK0(wrank, "GPTLinitialize() FAILED, ret = %d\n", ret);
+        return ret;
+    }
+#endif /* TIMING_INTERNAL */
+#endif /* TIMING */
+
+    if(num_errors != 0){
+        LOG_RANK0(wrank, "Total errors = %d\n", num_errors);
+        return FAIL;
+    }
+    return 0;
+}


### PR DESCRIPTION
Adding support for block waiting on PnetCDF requests. This change
allows us to work around per process limits on the amount of data
processed/written_out using PnetCDF.

This change also refactors existing code that implements waiting on
PnetCDF requests and improves the error checking in the code.

This support is required for E3SM ultra high resolution simulations
(e.g. ne1024 + F case).