### PR TITLE
Increase DEFAULT_TEST_TIMEOUT for Fortran tests

### DIFF
--- a/tests/general/CMakeLists.txt
+++ b/tests/general/CMakeLists.txt
@@ -74,8 +74,8 @@ endif()
 #  DEFINE THE TARGETS AND TESTS
 #==============================================================================
 
-# Test Timeout (8 min = 480 sec)
-set (DEFAULT_TEST_TIMEOUT 480)
+# Test Timeout (16 min = 960 sec)
+set (DEFAULT_TEST_TIMEOUT 960)
 set (DEFAULT_TEST_MAXNUMPROCS 4)
 
 # Use environment variable PIO_TF_MAXNUMPROCS to set the maximum number


### PR DESCRIPTION
pio_rearr_opts_np16_nio2_st2 has timed out several times recently
on anlworkstation. Increasing DEFAULT_TEST_TIMEOUT might work.