### PR TITLE
Expose preprocessor definitions required by pio.h via pio_config.h

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,13 +155,6 @@ endif ()
 set (CMAKE_Fortran_COMPILER_DIRECTIVE "CPR${CMAKE_Fortran_COMPILER_NAME}"
   CACHE STRING "Fortran compiler name preprocessor directive")
 
-# configure a header file to pass some of the CMake settings
-# to the source code
-configure_file (
-  "${PROJECT_SOURCE_DIR}/src/clib/config.h.in"
-  "${PROJECT_BINARY_DIR}/src/clib/config.h"
-  )
-
 #==============================================================================
 #  CHECK MIN VERSION OF COMPILERS REQD
 #==============================================================================

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,14 +32,14 @@ option (WITH_NETCDF          "Require the use of NetCDF"                    ON)
 option (WITH_ADIOS           "Require the use of ADIOS"                     OFF)
 option (ADIOS_BP2NC_TEST     "Enable testing of BP to NetCDF conversion"    OFF)
 
-# Set a variable that appears in the config.h.in file.
+# Set a variable that appears in the pio_config.h.in file.
 if(PIO_USE_MALLOC)
   set(USE_MALLOC 1)
 else()
   set(USE_MALLOC 0)
 endif()
 
-# Set a variable that appears in the config.h.in file.
+# Set a variable that appears in the pio_config.h.in file.
 if(PIO_ENABLE_LOGGING)
   set(ENABLE_LOGGING 1)
 else()

--- a/src/clib/CMakeLists.txt
+++ b/src/clib/CMakeLists.txt
@@ -170,12 +170,12 @@ endif ()
 # configure a header file to pass some of the CMake settings
 # to the source code
 configure_file (
-  "${PROJECT_SOURCE_DIR}/config.h.in"
-  "${PROJECT_BINARY_DIR}/config.h"
+  "${PROJECT_SOURCE_DIR}/pio_config.h.in"
+  "${PROJECT_BINARY_DIR}/pio_config.h"
   )
 
 # Install PIO config Include/Header File
-install (FILES ${PROJECT_BINARY_DIR}/config.h DESTINATION include)
+install (FILES ${PROJECT_BINARY_DIR}/pio_config.h DESTINATION include)
 
 if (ADIOS_BP2NC_TEST)
   target_compile_definitions (pioc

--- a/src/clib/CMakeLists.txt
+++ b/src/clib/CMakeLists.txt
@@ -17,9 +17,11 @@ include_directories(
   "${PROJECT_SOURCE_DIR}"   # to find foo/foo.h
   "${PROJECT_BINARY_DIR}")  # to find foo/config.h
 
-# Include the clib source directory
+# Include the clib source and binary directory
 target_include_directories (pioc
   PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_include_directories (pioc
+  PUBLIC ${CMAKE_CURRENT_BINARY_DIR})
 
 # System and compiler CPP directives
 target_compile_definitions (pioc
@@ -96,7 +98,9 @@ endif ()
 
 #====== PIO_MICRO_TIMING ======
 if (PIO_MICRO_TIMING)
-  target_compile_definitions(pioc PUBLIC PIO_MICRO_TIMING)
+  set(USE_MICRO_TIMING 1)
+else ()
+  set(USE_MICRO_TIMING 0)
 endif ()
 
 #===== NetCDF-C =====
@@ -104,15 +108,15 @@ if (WITH_NETCDF)
   find_package (NetCDF ${NETCDF_C_MIN_VER_REQD} COMPONENTS C)
 endif ()
 if (NetCDF_FOUND)
+  set(PIO_USE_NETCDF 1)
   target_include_directories (pioc
     PUBLIC ${NetCDF_C_INCLUDE_DIRS})
-  target_compile_definitions (pioc
-    PUBLIC _NETCDF)
   target_link_libraries (pioc
     PUBLIC ${NetCDF_C_LIBRARIES})
   if (${NetCDF_C_HAS_PARALLEL})
-    target_compile_definitions (pioc
-      PUBLIC _NETCDF4)
+    set(PIO_USE_NETCDF4 1)
+  else ()
+    set(PIO_USE_NETCDF4 0)
   endif ()
   if (${NetCDF_C_LOGGING_ENABLED})
     target_compile_definitions (pioc
@@ -122,8 +126,8 @@ if (NetCDF_FOUND)
       PUBLIC LOGGING)
   endif()
 else ()
-  target_compile_definitions (pioc
-    PUBLIC _NONETCDF)
+  set(PIO_USE_NETCDF 0)
+  set(PIO_USE_NETCDF4 0)
 endif ()
 
 #===== PnetCDF-C =====
@@ -131,10 +135,9 @@ if (WITH_PNETCDF)
   find_package (PnetCDF ${PNETCDF_MIN_VER_REQD} COMPONENTS C)
 endif ()
 if (PnetCDF_FOUND)
+  set(PIO_USE_PNETCDF 1)
   target_include_directories (pioc
     PUBLIC ${PnetCDF_C_INCLUDE_DIRS})
-  target_compile_definitions (pioc
-    PUBLIC _PNETCDF)
   target_link_libraries (pioc
     PUBLIC ${PnetCDF_C_LIBRARIES})
 
@@ -147,8 +150,7 @@ if (PnetCDF_FOUND)
       PUBLIC USE_PNETCDF_VARN_ON_READ)
   endif()
 else ()
-  target_compile_definitions (pioc
-    PUBLIC _NOPNETCDF)
+  set(PIO_USE_PNETCDF 0)
 endif ()
 
 #===== ADIOS-C =====
@@ -156,16 +158,24 @@ if (WITH_ADIOS)
   find_package (ADIOS ${ADIOS_MIN_VER_REQD})
 endif ()
 if (ADIOS_FOUND)
+  set(PIO_USE_ADIOS 1)
   target_include_directories (pioc
     PUBLIC ${ADIOS_INCLUDE_DIRS})
-  target_compile_definitions (pioc
-    PUBLIC _ADIOS)
   target_link_libraries (pioc
     PUBLIC ${ADIOS_LIBRARIES} adios2pio-nm-lib)
 else ()
-  target_compile_definitions (pioc
-    PUBLIC _NOADIOS)
+  set(PIO_USE_ADIOS 0)
 endif ()
+
+# configure a header file to pass some of the CMake settings
+# to the source code
+configure_file (
+  "${PROJECT_SOURCE_DIR}/config.h.in"
+  "${PROJECT_BINARY_DIR}/config.h"
+  )
+
+# Install PIO config Include/Header File
+install (FILES ${PROJECT_BINARY_DIR}/config.h DESTINATION include)
 
 if (ADIOS_BP2NC_TEST)
   target_compile_definitions (pioc

--- a/src/clib/bget.c
+++ b/src/clib/bget.c
@@ -397,7 +397,7 @@
   BGET CONFIGURATION
   ==================
 */
-#include <config.h>
+#include <pio_config.h>
 #include <pio.h>
 #include <pio_internal.h>
 #if PIO_USE_MALLOC

--- a/src/clib/config.h.in
+++ b/src/clib/config.h.in
@@ -34,4 +34,24 @@
 /** Maximum number of non-contiguous regions cached in a single IO process. */
 #define PIO_MAX_CACHED_IO_REGIONS @PIO_MAX_CACHED_IO_REGIONS@
 
+/** Set to 1 if the library is configured to use the PnetCDF library,
+ *  0 otherwise */
+#define PIO_USE_PNETCDF @PIO_USE_PNETCDF@
+
+/** Set to 1 if the library is configured to use the NetCDF library,
+ *  0 otherwise */
+#define PIO_USE_NETCDF @PIO_USE_NETCDF@
+
+/** Set to 1 if the library is configured to use the NetCDF4 features,
+ *  in the NetCDF library, 0 otherwise */
+#define PIO_USE_NETCDF4 @PIO_USE_NETCDF4@
+
+/** Set to 1 if the library is configured to use the ADIOS library,
+ *  0 otherwise */
+#define PIO_USE_ADIOS @PIO_USE_ADIOS@
+
+/** Set to 1 if the library is configured to use Micro timing,
+ *  0 otherwise */
+#define PIO_USE_MICRO_TIMING @USE_MICRO_TIMING@
+
 #endif /* _PIO_CONFIG_ */

--- a/src/clib/pio.h
+++ b/src/clib/pio.h
@@ -15,7 +15,7 @@
 #include <string.h> /* memcpy */
 #include <mpi.h>
 
-#include "config.h"
+#include "pio_config.h"
 #if PIO_USE_PNETCDF
   #define _PNETCDF 1
 #endif

--- a/src/clib/pio.h
+++ b/src/clib/pio.h
@@ -15,6 +15,23 @@
 #include <string.h> /* memcpy */
 #include <mpi.h>
 
+#include "config.h"
+#if PIO_USE_PNETCDF
+  #define _PNETCDF 1
+#endif
+#if PIO_USE_NETCDF
+  #define _NETCDF 1
+  #if PIO_USE_NETCDF4
+    #define _NETCDF4 1
+  #endif
+#endif
+#if PIO_USE_ADIOS
+  #define _ADIOS 1
+#endif
+#if PIO_USE_MICRO_TIMING
+  #define PIO_MICRO_TIMING 1
+#endif
+
 #ifdef _NETCDF
 #include <netcdf.h>
 #ifdef _NETCDF4

--- a/src/clib/pio_config.h.in
+++ b/src/clib/pio_config.h.in
@@ -1,6 +1,6 @@
 /** @file 
  *
- * This is the template for the config.h file, which is created at
+ * This is the template for the pio_config.h file, which is created at
  * build-time by cmake.
  */
 #ifndef _PIO_CONFIG_

--- a/src/clib/pio_darray.c
+++ b/src/clib/pio_darray.c
@@ -8,7 +8,7 @@
  *
  * @author Jim Edwards
  */
-#include <config.h>
+#include <pio_config.h>
 #include <pio.h>
 #include <pio_internal.h>
 #ifdef PIO_MICRO_TIMING

--- a/src/clib/pio_darray_int.c
+++ b/src/clib/pio_darray_int.c
@@ -10,7 +10,7 @@
  */
 
 #include <limits.h>
-#include <config.h>
+#include <pio_config.h>
 #include <pio.h>
 #include <pio_internal.h>
 #ifdef PIO_MICRO_TIMING

--- a/src/clib/pio_file.c
+++ b/src/clib/pio_file.c
@@ -2,7 +2,7 @@
  * @file
  * PIO File Handling
  */
-#include <config.h>
+#include <pio_config.h>
 #include <pio.h>
 #include <pio_internal.h>
 #include "../../tools/adios2pio-nm/adios2pio-nm-lib-c.h"

--- a/src/clib/pio_get_nc.c
+++ b/src/clib/pio_get_nc.c
@@ -8,7 +8,7 @@
  * @see http://code.google.com/p/parallelio/
  */
 
-#include <config.h>
+#include <pio_config.h>
 #include <pio.h>
 #include <pio_internal.h>
 

--- a/src/clib/pio_getput_int.c
+++ b/src/clib/pio_getput_int.c
@@ -9,7 +9,7 @@
  * @see http://code.google.com/p/parallelio/
  */
 
-#include <config.h>
+#include <pio_config.h>
 #include <pio.h>
 #include <pio_internal.h>
 

--- a/src/clib/pio_lists.c
+++ b/src/clib/pio_lists.c
@@ -2,7 +2,7 @@
  * @file
  * PIO list functions.
  */
-#include <config.h>
+#include <pio_config.h>
 #include <pio.h>
 #include <pio_internal.h>
 #ifdef PIO_MICRO_TIMING

--- a/src/clib/pio_mpi_timer.c
+++ b/src/clib/pio_mpi_timer.c
@@ -1,4 +1,4 @@
-#include "config.h"
+#include "pio_config.h"
 #include "mpi.h"
 #include "pio_timer.h"
 #include "pio_internal.h"

--- a/src/clib/pio_msg.c
+++ b/src/clib/pio_msg.c
@@ -8,7 +8,7 @@
  * @author Ed Hartnett
  */
 
-#include <config.h>
+#include <pio_config.h>
 #include <stdarg.h>
 #include <pio.h>
 #include <pio_internal.h>

--- a/src/clib/pio_nc.c
+++ b/src/clib/pio_nc.c
@@ -14,7 +14,7 @@
  * @author Jim Edwards (jedwards@ucar.edu), Ed Hartnett
  * @date     Feburary 2014, April 2016
  */
-#include <config.h>
+#include <pio_config.h>
 #include <pio.h>
 #include <pio_internal.h>
 #ifdef PIO_MICRO_TIMING

--- a/src/clib/pio_nc4.c
+++ b/src/clib/pio_nc4.c
@@ -4,7 +4,7 @@
  *
  * @author Ed Hartnett
  */
-#include <config.h>
+#include <pio_config.h>
 #include <pio.h>
 #include <pio_internal.h>
 

--- a/src/clib/pio_print.c
+++ b/src/clib/pio_print.c
@@ -1,4 +1,4 @@
-#include "config.h"
+#include "pio_config.h"
 #include "pio.h"
 #include "pio_internal.h"
 

--- a/src/clib/pio_put_nc.c
+++ b/src/clib/pio_put_nc.c
@@ -7,7 +7,7 @@
  * @see http://code.google.com/p/parallelio/
  */
 
-#include <config.h>
+#include <pio_config.h>
 #include <pio.h>
 #include <pio_internal.h>
 

--- a/src/clib/pio_rearrange.c
+++ b/src/clib/pio_rearrange.c
@@ -3,7 +3,7 @@
  *
  * @author Jim Edwards
  */
-#include <config.h>
+#include <pio_config.h>
 #include <pio.h>
 #include <pio_internal.h>
 

--- a/src/clib/pio_sdecomps_regex.cpp
+++ b/src/clib/pio_sdecomps_regex.cpp
@@ -16,7 +16,7 @@
 #endif
 
 extern "C"{
-#include "config.h"
+#include "pio_config.h"
 #include "pio.h"
 #include "pio_internal.h"
 #include "pio_sdecomps_regex.h"

--- a/src/clib/pio_sdecomps_regex.hpp
+++ b/src/clib/pio_sdecomps_regex.hpp
@@ -11,7 +11,7 @@
 #include <algorithm>
 #include <stack>
 extern "C"{
-#include "config.h"
+#include "pio_config.h"
 #include "pio.h"
 #include "pio_internal.h"
 #include "pio_sdecomps_regex.h"

--- a/src/clib/pio_spmd.c
+++ b/src/clib/pio_spmd.c
@@ -7,7 +7,7 @@
  * @author Jim Edwards
  * @date 2014
  */
-#include <config.h>
+#include <pio_config.h>
 #include <pio.h>
 #include <pio_internal.h>
 

--- a/src/clib/pio_timer.c
+++ b/src/clib/pio_timer.c
@@ -1,4 +1,4 @@
-#include "config.h"
+#include "pio_config.h"
 #include "pio_timer.h"
 #include "pio_internal.h"
 

--- a/src/clib/pio_timer.h
+++ b/src/clib/pio_timer.h
@@ -1,7 +1,7 @@
 #ifndef _PIO_TIMER_H_
 #define _PIO_TIMER_H_
 
-#include "config.h"
+#include "pio_config.h"
 #include <stdbool.h>
 #include "mpi.h"
 #include "pio_internal.h"

--- a/src/clib/pio_varm.c
+++ b/src/clib/pio_varm.c
@@ -1,4 +1,4 @@
-#include <config.h>
+#include <pio_config.h>
 #include <pio.h>
 #include <pio_internal.h>
 

--- a/src/clib/pioc.c
+++ b/src/clib/pioc.c
@@ -7,7 +7,7 @@
  * @see http://code.google.com/p/parallelio/
  */
 
-#include <config.h>
+#include <pio_config.h>
 #include <pio.h>
 #include <pio_internal.h>
 #ifdef PIO_MICRO_TIMING

--- a/src/clib/pioc_sc.c
+++ b/src/clib/pioc_sc.c
@@ -5,7 +5,7 @@
  * @author Jim Edwards
  * @date  2014
  */
-#include <config.h>
+#include <pio_config.h>
 #include <pio.h>
 #include <pio_internal.h>
 

--- a/src/clib/pioc_support.c
+++ b/src/clib/pioc_support.c
@@ -1,7 +1,7 @@
 /** @file
  * Support functions for the PIO library.
  */
-#include <config.h>
+#include <pio_config.h>
 #include <stdio.h>
 #include <stdbool.h>
 #include <stdarg.h>


### PR DESCRIPTION
Moving the preprocessor definitions required by pio.h from
compiler flags to the Scorpio configuration header file

Fixes #270 