### PR TITLE
Fix a build error for tools/adios2pio-nm

### DIFF
--- a/tools/adios2pio-nm/CMakeLists.txt
+++ b/tools/adios2pio-nm/CMakeLists.txt
@@ -25,7 +25,7 @@ include_directories(
   "${PROJECT_BINARY_DIR}")  # to find foo/config.h
 
 target_include_directories(adios2pio-nm-lib PUBLIC 
-  ${CMAKE_SOURCE_DIR}/src/clib ${ADIOS_INCLUDE_DIRS} 
+  ${CMAKE_SOURCE_DIR}/src/clib ${CMAKE_BINARY_DIR}/src/clib ${ADIOS_INCLUDE_DIRS} 
   ${NETCDF_C_INCLUDE_DIRS} 
   ${PnetCDF_C_INCLUDE_DIRS} 
   ${PIO_C_EXTRA_INCLUDE_DIRS})


### PR DESCRIPTION
The include directory of pio_config.h is not set for
tools/adios2pio-nm. As a result, scorpio fails to build
adios2pio-nm-lib.cxx which indirectly includes pio_config.h.