### PR TITLE
Fix fortran NetCDF lib detection

### DIFF
--- a/src/flib/CMakeLists.txt
+++ b/src/flib/CMakeLists.txt
@@ -194,7 +194,7 @@ endif ()
 if (WITH_NETCDF)
   find_package (NetCDF ${NETCDF_FORTRAN_MIN_VER_REQD} COMPONENTS Fortran)
 endif ()
-if (NetCDF_FOUND)
+if (NetCDF_Fortran_FOUND)
   target_include_directories (piof
     PUBLIC ${NetCDF_Fortran_INCLUDE_DIRS})
   target_compile_definitions (piof


### PR DESCRIPTION
Fix Fortran NetCDF library detection in CMake by
using the correct CMake variable that indicates 
that the Fortran library was found/detected.

Note: This change explicitly indicates that we are
currently ignoring checking for the minimum version
of the NetCDF Fortran library required by Scorpio

Fixes #274 