### PR TITLE
Adding a CTest environment variable for anlworkstation

### DIFF
--- a/ctest/CTestEnvironment-anlworkstation.cmake
+++ b/ctest/CTestEnvironment-anlworkstation.cmake
@@ -77,3 +77,8 @@ endif ()
 if (DEFINED ENV{ENABLE_ADIOS_BP2NC_TEST})
     set (CTEST_CONFIGURE_OPTIONS "${CTEST_CONFIGURE_OPTIONS} -DADIOS_BP2NC_TEST=ON")
 endif ()
+
+# If ENABLE_TESTS environment variable is set, then enable the testing builds
+if (DEFINED ENV{ENABLE_TESTS})
+    set (CTEST_CONFIGURE_OPTIONS "${CTEST_CONFIGURE_OPTIONS} -DPIO_ENABLE_TESTS=ON")
+endif ()


### PR DESCRIPTION
This change is for SCORPIO CDash builds on anlworkstation to
explicitly turn on PIO_ENABLE_TESTS.

Note that PIO_ENABLE_TESTS is set to OFF by default in PR #278.