### PR TITLE
Skip OpenMPI C++ headers

### DIFF
--- a/src/clib/CMakeLists.txt
+++ b/src/clib/CMakeLists.txt
@@ -30,6 +30,8 @@ target_compile_definitions (pioc
   PUBLIC ${CMAKE_C_COMPILER_DIRECTIVE})
 target_compile_definitions (pioc
   PUBLIC MPICH_SKIP_MPICXX)
+target_compile_definitions (pioc
+  PUBLIC OMPI_SKIP_MPICXX)
 
 # Compiler-specific compiler options
 string (TOUPPER "${CMAKE_C_COMPILER_ID}" CMAKE_C_COMPILER_NAME)


### PR DESCRIPTION
We already skip the MPI C++ headers for MPICH. Ensure that we
do the same for OpenMPI