### PR TITLE
Fix potential integer overflow inside PIOc_write_darray_multi()

### DIFF
--- a/src/clib/pio.h
+++ b/src/clib/pio.h
@@ -541,7 +541,7 @@ typedef struct io_desc_t
     PIO_Offset llen;
 
     /** Maximum llen participating. */
-    int maxiobuflen;
+    PIO_Offset maxiobuflen;
 
     /** Array (length nrecvs) of computation tasks received from. */
     int *rfrom;


### PR DESCRIPTION
This PR updates the data type of maxiobuflen in struct io_desc_t,
to be consistent with llen in the same struct.

It also updates the data type of a local variable (rlen) inside
PIOc_write_darray_multi() to store the multiplication of nvars
and maxiobuflen, which might be larger than INT_MAX.

The data type of a loop counter is also updated to compare
with maxiobuflen that has a new type.

Fixes #289