### PR TITLE
Exclude MPI C++ headers

### DIFF
--- a/src/clib/pio_sdecomps_regex.cpp
+++ b/src/clib/pio_sdecomps_regex.cpp
@@ -8,13 +8,6 @@
 #include <algorithm>
 #include <stack>
 
-#ifdef _ADIOS2
-/* mpi.h has to be included to compile this code. Some mpi.h header files   */
-/* include mpicxx.h when __cplusplus is defined. It causes "error: template */
-/* with C linkage" errors.                                                  */
-#include <mpi.h>
-#endif
-
 extern "C"{
 #include "pio_config.h"
 #include "pio.h"

--- a/tests/cunit/test_sdecomp_regex.cpp
+++ b/tests/cunit/test_sdecomp_regex.cpp
@@ -4,13 +4,6 @@
 #include <algorithm>
 #include <cassert>
 
-#ifdef _ADIOS2
-/* mpi.h has to be included to compile this code. Some mpi.h header files   */
-/* include mpicxx.h when __cplusplus is defined. It causes "error: template */
-/* with C linkage" errors.                                                  */
-#include <mpi.h>
-#endif
-
 #include "pio_sdecomps_regex.hpp"
 extern "C"{
 #include <pio_tests.h>

--- a/tools/adios2pio-nm/CMakeLists.txt
+++ b/tools/adios2pio-nm/CMakeLists.txt
@@ -39,6 +39,10 @@ target_compile_definitions (adios2pio-nm-lib
   PRIVATE ${CMAKE_SYSTEM_DIRECTIVE})
 target_compile_definitions (adios2pio-nm-lib
   PUBLIC ${CMAKE_C_COMPILER_DIRECTIVE})
+target_compile_definitions (adios2pio-nm-lib
+  PUBLIC MPICH_SKIP_MPICXX)
+target_compile_definitions (adios2pio-nm-lib
+  PUBLIC OMPI_SKIP_MPICXX)
 
 ADD_EXECUTABLE(adios2pio-nm.exe ${SRC})
 TARGET_LINK_LIBRARIES(adios2pio-nm.exe adios2pio-nm-lib pioc)

--- a/tools/spio_finfo/CMakeLists.txt
+++ b/tools/spio_finfo/CMakeLists.txt
@@ -36,6 +36,11 @@ target_include_directories(spio_finfo.exe PRIVATE
 target_link_libraries(spio_finfo.exe
                       PRIVATE pioc)
 
+target_compile_definitions (spio_finfo.exe
+  PUBLIC MPICH_SKIP_MPICXX)
+target_compile_definitions (spio_finfo.exe
+  PUBLIC OMPI_SKIP_MPICXX)
+
 # Binary utilities
 install (TARGETS spio_finfo.exe DESTINATION bin)
 


### PR DESCRIPTION
Handle errors due to including MPI headers in C++ source files.
Also removing source code hacks required for including MPI
header files in C++ sources.