### PR TITLE
Turn off compression for scalar variables

### DIFF
--- a/src/clib/pio_nc.c
+++ b/src/clib/pio_nc.c
@@ -2461,6 +2461,7 @@ int PIOc_def_var(int ncid, const char *name, nc_type xtype, int ndims,
     int invalid_unlim_dim = 0; /* True invalid dims are used. */
     int mpierr = MPI_SUCCESS;  /* Return code from MPI function codes. */
     int ierr = PIO_NOERR;                  /* Return code from function calls. */
+    int ierr2 = PIO_NOERR;    /* Return code from function calls. */
 #ifdef PIO_MICRO_TIMING
     char timer_log_fname[PIO_MAX_NAME];
 #endif
@@ -2636,23 +2637,60 @@ int PIOc_def_var(int ncid, const char *name, nc_type xtype, int ndims,
     {
 #ifdef _PNETCDF
         if (file->iotype == PIO_IOTYPE_PNETCDF)
+        {
             ierr = ncmpi_def_var(file->fh, name, xtype, ndims, dimidsp, varidp);
+            if (ierr != PIO_NOERR)
+            {
+                char errmsg[PIO_MAX_NAME];
+                ierr2 = PIOc_strerror(ierr, errmsg);
+                ierr = pio_err(ios, file, ierr, __FILE__, __LINE__,
+                                "Defining variable %s (ndims = %d) in file %s (ncid=%d, iotype=%s) failed. %s", name, ndims, pio_get_fname_from_file(file), ncid, pio_iotype_to_string(file->iotype), ((ierr2 == PIO_NOERR) ? errmsg : ""));
+            }
+        }
 #endif /* _PNETCDF */
 
 #ifdef _NETCDF
         if (file->iotype != PIO_IOTYPE_PNETCDF && file->iotype != PIO_IOTYPE_ADIOS && file->do_io)
+        {
             ierr = nc_def_var(file->fh, name, xtype, ndims, dimidsp, varidp);
+            if (ierr != PIO_NOERR)
+            {
+                char errmsg[PIO_MAX_NAME];
+                ierr2 = PIOc_strerror(ierr, errmsg);
+                ierr = pio_err(ios, file, ierr, __FILE__, __LINE__,
+                                "Defining variable %s (ndims = %d) in file %s (ncid=%d, iotype=%s) failed. %s", name, ndims, pio_get_fname_from_file(file), ncid, pio_iotype_to_string(file->iotype), ((ierr2 == PIO_NOERR) ? errmsg : ""));
+            }
+        }
 #endif /* _NETCDF */
 
 #ifdef _NETCDF4
         /* For netCDF-4 serial files, turn on compression for this variable. */
         if (!ierr && file->iotype == PIO_IOTYPE_NETCDF4C && file->do_io)
+        {
             ierr = nc_def_var_deflate(file->fh, *varidp, 0, 1, 1);
+            if (ierr != PIO_NOERR)
+            {
+                char errmsg[PIO_MAX_NAME];
+                ierr2 = PIOc_strerror(ierr, errmsg);
+                ierr = pio_err(ios, file, ierr, __FILE__, __LINE__,
+                                "Defining variable %s (varid = %d, ndims = %d) in file %s (ncid=%d, iotype=%s) failed. Turning on compression on the variable failed. %s", name, *varidp, ndims, pio_get_fname_from_file(file), ncid, pio_iotype_to_string(file->iotype), ((ierr2 == PIO_NOERR) ? errmsg : ""));
+            }
+        }
 
         /* For netCDF-4 parallel files, set parallel access to collective. */
         if (!ierr && file->iotype == PIO_IOTYPE_NETCDF4P && file->do_io)
+        {
             ierr = nc_var_par_access(file->fh, *varidp, NC_COLLECTIVE);
+            if (ierr != PIO_NOERR)
+            {
+                char errmsg[PIO_MAX_NAME];
+                ierr2 = PIOc_strerror(ierr, errmsg);
+                ierr = pio_err(ios, file, ierr, __FILE__, __LINE__,
+                                "Defining variable %s (varid = %d, ndims = %d) in file %s (ncid=%d, iotype=%s) failed. Setting parallel access for the variable failed. %s", name, *varidp, ndims, pio_get_fname_from_file(file), ncid, pio_iotype_to_string(file->iotype), ((ierr2 == PIO_NOERR) ? errmsg : ""));
+            }
+        }
 #endif /* _NETCDF4 */
+
     }
 
     ierr = check_netcdf(NULL, file, ierr, __FILE__, __LINE__);

--- a/src/clib/pio_nc.c
+++ b/src/clib/pio_nc.c
@@ -2664,8 +2664,10 @@ int PIOc_def_var(int ncid, const char *name, nc_type xtype, int ndims,
 #endif /* _NETCDF */
 
 #ifdef _NETCDF4
-        /* For netCDF-4 serial files, turn on compression for this variable. */
-        if (!ierr && file->iotype == PIO_IOTYPE_NETCDF4C && file->do_io)
+        /* For netCDF-4 serial files, turn on compression for this
+           variable (non-scalar). */
+        if (!ierr && file->iotype == PIO_IOTYPE_NETCDF4C
+            && (ndims > 0) && file->do_io)
         {
             ierr = nc_def_var_deflate(file->fh, *varidp, 0, 1, 1);
             if (ierr != PIO_NOERR)

--- a/src/clib/pioc_support.c
+++ b/src/clib/pioc_support.c
@@ -2717,6 +2717,7 @@ int PIOc_openfile_retry(int iosysid, int *ncidp, int *iotype, const char *filena
     int imode;                 /* Internal mode val for netcdf4 file open. */
     int mpierr = MPI_SUCCESS;  /** Return code from MPI function codes. */
     int ierr = PIO_NOERR;      /* Return code from function calls. */
+    int ierr2 = PIO_NOERR;      /* Return code from function calls. */
 
     /* Get the IO system info from the iosysid. */
     if (!(ios = pio_get_iosystem_from_id(iosysid)))
@@ -2889,9 +2890,6 @@ int PIOc_openfile_retry(int iosysid, int *ncidp, int *iotype, const char *filena
             }
             if ((ierr != NC_NOERR) && (file->iotype != PIO_IOTYPE_NETCDF))
             {
-                /* reset ierr on all tasks */
-                ierr = PIO_NOERR;
-
                 /* reset file markers for NETCDF on all tasks */
                 file->iotype = PIO_IOTYPE_NETCDF;
 
@@ -2910,7 +2908,10 @@ int PIOc_openfile_retry(int iosysid, int *ncidp, int *iotype, const char *filena
                 /* open netcdf file serially on main task */
                 if (ios->io_rank == 0)
                 {
-                    printf("PIO: WARNING: Opening file (%s) with iotype=%d (%s) failed. Retrying with iotype=PIO_IOTYPE_NETCDF\n", filename, *iotype, pio_iotype_to_string(*iotype));
+                    char errmsg[PIO_MAX_NAME];
+
+                    ierr2 = PIOc_strerror(ierr, errmsg);
+                    printf("PIO: WARNING: Opening file (%s) with iotype=%d (%s) failed (ierr=%d, %s). Retrying with iotype=PIO_IOTYPE_NETCDF\n", filename, *iotype, pio_iotype_to_string(*iotype), ierr, ((ierr2 == PIO_NOERR) ? errmsg : ""));
                     ierr = nc_open(filename, file->mode, &file->fh);
                     if(ierr == NC_NOERR)
                     {
@@ -2918,7 +2919,12 @@ int PIOc_openfile_retry(int iosysid, int *ncidp, int *iotype, const char *filena
                     }
                 }
                 else
+                {
+                    /* reset ierr */
+                    ierr = PIO_NOERR;
+
                     file->do_io = 0;
+                }
             }
             LOG((2, "retry nc_open(%s) : fd = %d, iotype = %d, do_io = %d, ierr = %d",
                  filename, file->fh, file->iotype, file->do_io, ierr));


### PR DESCRIPTION
The newer versions of the NetCDF library (e.g. NetCDF C 4.7.4)
explicitly disallow (the netcdf API returns an error now) enabling
compression of scalar variables. So disabling compression for
scalar variables.

Also adding some extra information in the error messages for
some APIs.
