### PR TITLE
Replace deprecated MPI routine MPI_Errhandler_set

### DIFF
--- a/examples/adios/timesteps.c
+++ b/examples/adios/timesteps.c
@@ -209,7 +209,7 @@ int main(int argc, char **argv)
     if ((ret = MPI_Init(&argc, &argv)))
         MPIERR(ret);
 
-    if ((ret = MPI_Errhandler_set(MPI_COMM_WORLD, MPI_ERRORS_RETURN)))
+    if ((ret = MPI_Comm_set_errhandler(MPI_COMM_WORLD, MPI_ERRORS_RETURN)))
         MPIERR(ret);
 
     /* Learn my rank and the total number of processors. */

--- a/examples/adios/timesteps_double.c
+++ b/examples/adios/timesteps_double.c
@@ -209,7 +209,7 @@ int main(int argc, char **argv)
     if ((ret = MPI_Init(&argc, &argv)))
         MPIERR(ret);
 
-    if ((ret = MPI_Errhandler_set(MPI_COMM_WORLD, MPI_ERRORS_RETURN)))
+    if ((ret = MPI_Comm_set_errhandler(MPI_COMM_WORLD, MPI_ERRORS_RETURN)))
         MPIERR(ret);
 
     /* Learn my rank and the total number of processors. */

--- a/examples/c/example2.c
+++ b/examples/c/example2.c
@@ -462,7 +462,7 @@ int main(int argc, char* argv[])
     /* Initialize MPI. */
     if ((ret = MPI_Init(&argc, &argv)))
 	MPIERR(ret);
-    if ((ret = MPI_Errhandler_set(MPI_COMM_WORLD, MPI_ERRORS_RETURN)))
+    if ((ret = MPI_Comm_set_errhandler(MPI_COMM_WORLD, MPI_ERRORS_RETURN)))
 	MPIERR(ret);
 
     /* Learn my rank and the total number of processors. */

--- a/tests/general/test_memleak.c
+++ b/tests/general/test_memleak.c
@@ -191,7 +191,7 @@ main(int argc, char **argv)
     /* Initialize MPI. */
     if ((ret = MPI_Init(&argc, &argv)))
 	MPIERR(ret);
-    if ((ret = MPI_Errhandler_set(MPI_COMM_WORLD, MPI_ERRORS_RETURN)))
+    if ((ret = MPI_Comm_set_errhandler(MPI_COMM_WORLD, MPI_ERRORS_RETURN)))
 	MPIERR(ret);
 
     /* Learn my rank and the total number of processors. */


### PR DESCRIPTION
This PR fixes some compiler warnings on deprecated declarations
from OpenMPI build.

MPI_Errhandler_set is superseded by MPI_Comm_set_errhandler in
MPI-2.0.


