### PR TITLE
Update PIOc_def_var_deflate to support NetCDF 4.7.4

### DIFF
--- a/src/clib/pio_nc4.c
+++ b/src/clib/pio_nc4.c
@@ -72,8 +72,16 @@ int PIOc_def_var_deflate(int ncid, int varid, int shuffle, int deflate,
         if (file->iotype == PIO_IOTYPE_NETCDF4P)
             ierr = NC_EINVAL;
         else
+        {
             if (file->do_io)
-                ierr = nc_def_var_deflate(file->fh, varid, shuffle, deflate, deflate_level);
+            {
+                /* In NetCDF 4.7.4 and later releases, to set a new deflate level, deflation
+                   needs to be turned off first to unset existing deflate level */
+                ierr = nc_def_var_deflate(file->fh, varid, 0, 0, 1);
+                if (ierr == PIO_NOERR)
+                    ierr = nc_def_var_deflate(file->fh, varid, shuffle, deflate, deflate_level);
+            }
+        }
 #endif
     }
 


### PR DESCRIPTION
In NetCDF 4.7.4 and later releases, nc_def_var_deflate keeps
existing deflate level unless deflation is turned off. Without this
change, PIOc_def_var_deflate fails to set a new deflate level for
a variable.

This PR also fixes failed pio_unit_test for OpenMPI CDash build
which uses NetCDF 4.7.4c-4.3.1cxx-4.4.4f.