### PR TITLE
Improve the load balancing for default SUBSET partition

### DIFF
--- a/tests/cunit/test_rearr.c
+++ b/tests/cunit/test_rearr.c
@@ -892,7 +892,11 @@ int test_default_subset_partition(MPI_Comm test_comm, int my_rank)
 
     ios->ioproc = 1;
     ios->io_rank = my_rank;
+    ios->comp_rank = my_rank;
+    ios->num_iotasks = TARGET_NTASKS;
+    ios->num_comptasks = TARGET_NTASKS;
     ios->comp_comm = test_comm;
+    ios->union_comm = test_comm;
 
     /* Run the function to test. */
     if ((ret = default_subset_partition(ios, iodesc)))


### PR DESCRIPTION
When the number of compute tasks is not divisible by the number of
IO tasks, the existing algorithm assigns most or all of the extra
compute tasks to the last IO task. This might cause performance
issues for SUBSET rearranger.

The new algorithm assigns the extra compute tasks evenly to some
IO tasks with lower ranks to achieve a better load balancing.

Fixes #311