### PR TITLE
Check whether the number of ioids exceeds the limit and also set a higher limit

### DIFF
--- a/src/clib/pio.h
+++ b/src/clib/pio.h
@@ -66,7 +66,7 @@ unsigned long get_adios2_io_cnt();
 
 /** The start ID and maximum number of IDs for IO decompositions. */
 #define PIO_IODESC_START_ID 512
-#define PIO_IODESC_MAX_IDS 4096
+#define PIO_IODESC_MAX_IDS 65536
 
 /** The maximum number of variables allowed in a netCDF file. */
 #define PIO_MAX_VARS_UB 8192

--- a/src/clib/pioc.c
+++ b/src/clib/pioc.c
@@ -718,6 +718,17 @@ int PIOc_InitDecomp(int iosysid, int pio_type, int ndims, const int *gdimlen, in
     }
     *ioidp = pio_add_to_iodesc_list(iodesc, comm);
 
+    /* Check whether we have exceeded the maximum number of ioids (PIO_IODESC_MAX_IDS).
+     * This limit is necessary since each file uses a sparse pointer array (with a fixed
+     * size of PIO_IODESC_MAX_IDS) to look up a data buffer per ioid.
+     * FIXME: Replace the sparse array with a map or hash map to get rid of this limit
+     */
+    if (*ioidp - PIO_IODESC_START_ID + 1 > PIO_IODESC_MAX_IDS)
+    {
+        return pio_err(ios, NULL, PIO_EINTERNAL, __FILE__, __LINE__,
+                       "Initializing the PIO decomposition failed. Maximum number of ioids (limit = %d) has been reached", PIO_IODESC_MAX_IDS);
+    }
+
 #if PIO_SAVE_DECOMPS
     if(pio_save_decomps_regex_match(*ioidp, NULL, NULL))
     {


### PR DESCRIPTION
Make sure that the user gets an error when the number of ioids
exceeds the limit.

Also increase that limit from 4K to 64K to get some E3SM cases
running.

In addition to this short-term fix, a planned long-term fix would
completely get rid of this limit with some code refactoring.

Fixes #315