### PR TITLE
Fix and simplify CalcStartandCount() for BOX rearranger

### DIFF
--- a/src/clib/pioc_sc.c
+++ b/src/clib/pioc_sc.c
@@ -465,6 +465,7 @@ int CalcStartandCount(int pio_type, int ndims, const int *gdims, int num_io_proc
                     {
                         piodie(__FILE__, __LINE__, "Start (%lld) plus count (%lld) exceeds dimension bound, (gdims[%d] = %d) + 1", (long long int)start, (long long int) count, i, gdims[i]);
                     }
+                    break; /* Terminate on this dimension */
                 }
                 else if(gdims[i] > 1)
                 {
@@ -507,6 +508,8 @@ int CalcStartandCount(int pio_type, int ndims, const int *gdims, int num_io_proc
         {
             tpsize = 0;
             use_io_procs--;
+            /* maxbytes needs to be updated for a smaller use_io_procs */
+            maxbytes = max(blocksize, pgdims * basesize / use_io_procs) + 256;
         }
     }
 


### PR DESCRIPTION
For test_CalcStartandCount(), update expected result of an
existing test case, and add more test cases (some are from
actual E3SM production runs).

The existing CalcStartandCount() function fails on the updated
test cases, generating correct but suboptimal partitions.

Fix two bugs found in CalcStartandCount() so that it can pass all
updated test cases with expected partitions.

Rewrite CalcStartandCount() as part of code refactoring. The
new version uses less temporary variables and removes an
inefficient while loop for convergence.

Fixes #318