### PR TITLE
Fix a memory corruption issue for compute_counts() used by BOX rearranger

### DIFF
--- a/src/clib/pio_rearrange.c
+++ b/src/clib/pio_rearrange.c
@@ -823,7 +823,6 @@ int compute_counts(iosystem_desc_t *ios, io_desc_t *iodesc,
         LOG((3, "totalrecv = %d", totalrecv));
         if (totalrecv > 0)
         {
-            totalrecv = iodesc->llen;  /* can reduce memory usage here */
             if (!(iodesc->rindex = calloc(totalrecv, sizeof(PIO_Offset))))
             {
                 return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__,

--- a/src/clib/pio_rearrange.c
+++ b/src/clib/pio_rearrange.c
@@ -1519,6 +1519,11 @@ int box_rearrange_create(iosystem_desc_t *ios, int maplen, const PIO_Offset *com
                 if (dest_ioproc[k] >= 0)
                     continue;
 
+                /* compmap is a 1 based array of offsets into the global space.
+                 * A 0 in this array indicates a value which should not be transfered. */
+                if (compmap[k] < 1)
+                    continue;
+
                 PIO_Offset lcoord[ndims];
                 bool found = true;
 
@@ -1822,6 +1827,11 @@ int box_rearrange_create_with_holes(iosystem_desc_t *ios, int maplen, const PIO_
             {
                 /* An IO task has already been found for this element */
                 if (dest_ioproc[k] >= 0)
+                    continue;
+
+                /* compmap is a 1 based array of offsets into the global space.
+                 * A 0 in this array indicates a value which should not be transfered. */
+                if (compmap[k] < 1)
                     continue;
 
                 PIO_Offset lcoord[ndims];

--- a/src/clib/pioc.c
+++ b/src/clib/pioc.c
@@ -752,8 +752,23 @@ int PIOc_InitDecomp(int iosysid, int pio_type, int ndims, const int *gdimlen, in
          iodesc->ioid, iodesc->nrecvs, iodesc->ndof, iodesc->ndims, iodesc->num_aiotasks,
          iodesc->rearranger, iodesc->maxregions, iodesc->needsfill, iodesc->llen,
          iodesc->maxiobuflen));
-    for (int j = 0; j < iodesc->llen; j++)
-        LOG((3, "rindex[%d] = %lld", j, iodesc->rindex[j]));
+    if (ios->ioproc)
+    {
+        if (iodesc->rearranger == PIO_REARR_SUBSET)
+        {
+            for (int j = 0; j < iodesc->llen; j++)
+                LOG((3, "rindex[%d] = %lld", j, iodesc->rindex[j]));
+        }
+        else
+        {
+            int totalrecv = 0;
+            for (int j = 0; j < iodesc->nrecvs; j++)
+                totalrecv += iodesc->rcount[j];
+
+            for (int j = 0; j < totalrecv; j++)
+                LOG((3, "rindex[%d] = %lld", j, iodesc->rindex[j]));
+        }
+    }
 #endif /* PIO_ENABLE_LOGGING */            
 
     /* This function only does something if pre-processor macro


### PR DESCRIPTION
Add a C unit test for box_rearrange_create() to reproduce a memory
corruption issue found in a standalone HOMME test.

Remove a line that improperly resets totalrecv in compute_counts(),
which is the cause of the memory corruption on iodesc->rindex.

Also, for zero elements in compmap, there is no need to find a
destination IO task for them. This optimization can reduce the
value of totalrecv to reduce the memory usage.

For BOX rearranger, when logging iodesc->rindex, the buffer
length is no longer iodesc->llen and it needs to be calculated.

Fixes #323, #324