### PR TITLE
Adjust CMAKE_CXX_FLAGS for Cray compiler

### DIFF
--- a/tools/spio_finfo/CMakeLists.txt
+++ b/tools/spio_finfo/CMakeLists.txt
@@ -10,7 +10,12 @@ add_definitions(${PIO_DEFINITIONS})
 #link_directories(${PIO_LIB_DIR})
 
 # Enable C++11 support
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+string (TOUPPER "${CMAKE_CXX_COMPILER_ID}" CMAKE_CXX_COMPILER_NAME)
+if (CMAKE_CXX_COMPILER_NAME STREQUAL "CRAY")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -h std=c++11")
+else ()
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+endif ()
 
 set(SRC ${CMAKE_SOURCE_DIR}/tools/util/argparser.cxx
     ${CMAKE_SOURCE_DIR}/tools/util/spio_misc_tool_utils.cxx


### PR DESCRIPTION
Adjust CMAKE_CXX_FLAGS for Cray compiler to enable C++11

Without this change builds with the Cray compiler will fail. This
compiler specific flags is already present for the main library
builds.