### PR TITLE
Consistent use of the user provided NetCDF_<LANG>_PATHS variable

### DIFF
--- a/cmake/FindNetCDF.cmake
+++ b/cmake/FindNetCDF.cmake
@@ -47,11 +47,9 @@ foreach (NCDFcomp IN LISTS NetCDF_FIND_VALID_COMPONENTS)
             initialize_paths (NetCDF_${NCDFcomp}_PATHS
                               INCLUDE_DIRECTORIES ${MPI_${NCDFcomp}_INCLUDE_PATH}
                               LIBRARIES ${MPI_${NCDFcomp}_LIBRARIES})
-            find_package_component(NetCDF COMPONENT ${NCDFcomp}
-                                   PATHS ${NetCDF_${NCDFcomp}_PATHS})
-        else ()
-            find_package_component(NetCDF COMPONENT ${NCDFcomp})
         endif ()
+        find_package_component(NetCDF COMPONENT ${NCDFcomp}
+                               PATHS ${NetCDF_${NCDFcomp}_PATHS})
 
         # Continue only if component found
         if (NetCDF_${NCDFcomp}_FOUND)


### PR DESCRIPTION
In FindNetCDF.cmake, we were only using the user-provided paths for the case where `MPI_<LANG>_FOUND=TRUE`. This commit makes the module use `NetCDF_<LANG>_PATHS` regardless of the value of `MPI_<LANG>_FOUND`.

Fixes #334.