### PR TITLE
Explicit conversion of C strings to Fortran strings during gets

### DIFF
--- a/src/flib/pionfget_mod.F90.in
+++ b/src/flib/pionfget_mod.F90.in
@@ -521,10 +521,8 @@ CONTAINS
 
 #if {DIMS} != 0
     integer :: fstr_dim_sz({DIMS})
-#else
-    integer :: fstr_dim_sz
 #endif
-    integer :: max_nstrs, max_flen, clen
+    integer :: max_nstrs, max_flen
     integer :: cstr_idx
     logical :: cstr_copied
     integer :: i, j, k, m, n, q
@@ -550,17 +548,14 @@ CONTAINS
                   " (space available to copy only 1 string)"
       call piodie(__PIO_FILE__, __LINE__, "Insufficient user buffer space")
     end if
-    fstr_dim_sz = len(fstr)
 #endif
     fstr = F_SPACE_CHAR
     cstr_idx = 0
 #if {DIMS} == 0
     max_flen= len(fstr)
-    clen = 0
     cstr_copied = .false.
     do i=1,min(max_clen, max_flen)
       fstr(i:i) = cstr(i)
-      clen = clen + 1
       if(fstr(i:i) == C_NULL_CHAR) then
         fstr(i:i) = F_SPACE_CHAR
         cstr_copied = .true.
@@ -579,11 +574,9 @@ CONTAINS
 #if {DIMS} == 1
     max_flen= len(fstr(1))
     do j=1,fstr_dim_sz(1)
-      clen = 0
       cstr_copied = .false.
       do i=1,min(max_clen, max_flen)
         fstr(j)(i:i) = cstr(cstr_idx * max_clen + i)
-        clen = clen + 1
         if(fstr(j)(i:i) == C_NULL_CHAR) then
           fstr(j)(i:i) = F_SPACE_CHAR
           cstr_copied = .true.
@@ -605,11 +598,9 @@ CONTAINS
     max_flen= len(fstr(1,1))
     do k=1,fstr_dim_sz(2)
       do j=1,fstr_dim_sz(1)
-        clen = 0
         cstr_copied = .false.
         do i=1,min(max_clen, max_flen)
           fstr(j,k)(i:i) = cstr(cstr_idx * max_clen + i)
-          clen = clen + 1
           if(fstr(j,k)(i:i) == C_NULL_CHAR) then
             fstr(j,k)(i:i) = F_SPACE_CHAR
             cstr_copied = .true.
@@ -633,11 +624,9 @@ CONTAINS
     do m=1,fstr_dim_sz(3)
       do k=1,fstr_dim_sz(2)
         do j=1,fstr_dim_sz(1)
-          clen = 0
           cstr_copied = .false.
           do i=1,min(max_clen, max_flen)
             fstr(j,k,m)(i:i) = cstr(cstr_idx * max_clen + i)
-            clen = clen + 1
             if(fstr(j,k,m)(i:i) == C_NULL_CHAR) then
               fstr(j,k,m)(i:i) = F_SPACE_CHAR
               cstr_copied = .true.
@@ -663,11 +652,9 @@ CONTAINS
       do m=1,fstr_dim_sz(3)
         do k=1,fstr_dim_sz(2)
           do j=1,fstr_dim_sz(1)
-            clen = 0
             cstr_copied = .false.
             do i=1,min(max_clen, max_flen)
               fstr(j,k,m,n)(i:i) = cstr(cstr_idx * max_clen + i)
-              clen = clen + 1
               if(fstr(j,k,m,n)(i:i) == C_NULL_CHAR) then
                 fstr(j,k,m,n)(i:i) = F_SPACE_CHAR
                 cstr_copied = .true.
@@ -695,11 +682,9 @@ CONTAINS
         do m=1,fstr_dim_sz(3)
           do k=1,fstr_dim_sz(2)
             do j=1,fstr_dim_sz(1)
-              clen = 0
               cstr_copied = .false.
               do i=1,min(max_clen, max_flen)
                 fstr(j,k,m,n,q)(i:i) = cstr(cstr_idx * max_clen + i)
-                clen = clen + 1
                 if(fstr(j,k,m,n,q)(i:i) == C_NULL_CHAR) then
                   fstr(j,k,m,n,q)(i:i) = F_SPACE_CHAR
                   cstr_copied = .true.

--- a/src/flib/pionfget_mod.F90.in
+++ b/src/flib/pionfget_mod.F90.in
@@ -302,8 +302,15 @@ CONTAINS
     type (File_desc_t), intent(in) :: File
     integer, intent(in) :: varid, start(:), count(:)
     character(len=*), intent(out) :: ival{DIMSTR}
+
+    character(C_CHAR), allocatable :: cval(:)
+
     ival = ' '
-    ierr = get_vara_text_internal (File%fh, varid, start, count, size(ival), ival)
+    allocate(cval(size(ival) * len(ival)))
+    ierr = get_vara_text_internal (File%fh, varid, start, count, size(cval), cval)
+
+    call Cstring2Fstring_{DIMS}d (cval, len(ival), ival)
+    deallocate(cval)
 
   end function get_vara_{DIMS}d_text
 
@@ -391,24 +398,31 @@ CONTAINS
     type (File_desc_t), intent(in) :: File
     integer, intent(in) :: varid
     character(len=*), intent(out) :: ival{DIMSTR}
+
+    character(C_CHAR), allocatable :: cval(:)
+
     ival = ' '
-    ierr = get_var_text_internal(File%fh, varid, size(ival), ival)
+    allocate(cval(size(ival) * len(ival)))
+!    ierr = get_var_text_internal(File%fh, varid, size(ival), ival)
+    ierr = PIOc_get_var_text(File%fh, varid-1, cval)
+    call Cstring2Fstring_{DIMS}d (cval, len(ival), ival)
+    deallocate(cval)
 
   end function get_var_{DIMS}d_text
 
-  integer function get_var_text_internal (ncid,varid, nstrs, ival) result(ierr)
-    integer, intent(in) :: ncid
-    integer, intent(in) :: varid
-    integer, intent(in) :: nstrs
-    character(len=*), intent(out) :: ival(*)
-    integer :: j
-
-    ierr = PIOc_get_var_text(ncid, varid-1, ival)
-    do j=1,nstrs
-       call replace_c_null(ival(j))
-    end do
-
-  end function get_var_text_internal
+!  integer function get_var_text_internal (ncid,varid, nstrs, ival) result(ierr)
+!    integer, intent(in) :: ncid
+!    integer, intent(in) :: varid
+!    integer, intent(in) :: nstrs
+!    character(len=*), intent(out) :: ival(*)
+!    integer :: j
+!
+!    ierr = PIOc_get_var_text(ncid, varid-1, ival)
+!    do j=1,nstrs
+!       call replace_c_null(ival(j))
+!    end do
+!
+!  end function get_var_text_internal
 
 ! TYPE int,real,double
   integer function get_var_{TYPE}_internal  (ncid,varid, ival) result(ierr)
@@ -443,14 +457,15 @@ CONTAINS
 
   end function get_vara_{TYPE}_internal
 
-  integer function get_vara_text_internal  (ncid,varid, start, count, nstrs, ival) result(ierr)
+  integer function get_vara_text_internal  (ncid,varid, start, count, nstrs, cval) result(ierr)
     use pio_nf, only : pio_inq_varndims
     integer, intent(in) :: ncid
     integer, intent(in) :: varid
     integer, intent(in) :: start(:)
     integer, intent(in) :: count(:)
     integer, intent(in) :: nstrs
-    character(len=*), intent(out) :: ival(*)
+    !character(len=*), intent(out) :: ival(*)
+    character(C_CHAR), intent(out) :: cval(:)
     integer :: j
     integer(C_SIZE_T), allocatable :: cstart(:), ccount(:)
     integer :: i, ndims
@@ -462,10 +477,10 @@ CONTAINS
        ccount(i) = count(ndims-i+1)
     enddo
 
-    ierr = PIOc_get_vara_text (ncid, varid-1, cstart, ccount, ival)
-    do j=1,nstrs
-       call replace_c_null(ival(j),ccount(ndims))
-    end do
+    ierr = PIOc_get_vara_text (ncid, varid-1, cstart, ccount, cval)
+    !do j=1,nstrs
+    !   call replace_c_null(ival(j),ccount(ndims))
+    !end do
     deallocate(ccount, cstart)
   end function get_vara_text_internal
 
@@ -499,4 +514,172 @@ CONTAINS
     ierr = get_var_{DIMS}d_{TYPE} (File, vardesc%varid, ival)
 
   end function get_var_vdesc_{DIMS}d_{TYPE}
+
+! DIMS 1,2,3,4,5
+  subroutine Cstring2Fstring_{DIMS}d(cstr, max_clen, fstr)
+    character(C_CHAR), intent(in) :: cstr(:)
+    integer, intent(in) :: max_clen
+    character(len=*), intent(out) :: fstr{DIMSTR}
+
+    integer :: fstr_dim_sz({DIMS})
+    integer :: max_flen, clen
+    integer :: cstr_idx
+    logical :: cstr_copied
+    integer :: i, j, k, m, n, q
+
+    character, parameter :: F_SPACE_CHAR = ' '
+
+    fstr = F_SPACE_CHAR
+    do i=1,{DIMS}
+      fstr_dim_sz(i) = size(fstr,i)
+    enddo
+    cstr_idx = 0
+#if {DIMS} == 1
+    max_flen= len(fstr(1))
+    do j=1,fstr_dim_sz(1)
+      clen = 0
+      cstr_copied = .false.
+      do i=1,min(max_clen, max_flen)
+        fstr(j)(i:i) = cstr(cstr_idx * max_clen + i)
+        clen = clen + 1
+        if(fstr(j)(i:i) == C_NULL_CHAR) then
+          fstr(j)(i:i) = F_SPACE_CHAR
+          cstr_copied = .true.
+          exit
+        end if
+      end do
+      if(.not. cstr_copied) then
+        ! We have exhausted the Fortran write buffer
+        ! Warn the user of the truncation
+        print *, "WARNING: The user buffer provided had insufficient space (",&
+                  max_flen, " chars to read strings with ", max_clen, " chars).",&
+                  "The contents will be truncated to : ", trim(fstr(j))
+        fstr(j)(max_flen:max_flen) = F_SPACE_CHAR
+      end if
+      cstr_idx = cstr_idx + 1
+    enddo
+#endif
+#if {DIMS} == 2
+    max_flen= len(fstr(1,1))
+    do k=1,fstr_dim_sz(2)
+      do j=1,fstr_dim_sz(1)
+        clen = 0
+        cstr_copied = .false.
+        do i=1,min(max_clen, max_flen)
+          fstr(j,k)(i:i) = cstr(cstr_idx * max_clen + i)
+          clen = clen + 1
+          if(fstr(j,k)(i:i) == C_NULL_CHAR) then
+            fstr(j,k)(i:i) = F_SPACE_CHAR
+            cstr_copied = .true.
+            exit
+          end if
+        end do
+        if(.not. cstr_copied) then
+          ! We have exhausted the Fortran write buffer
+          ! Warn the user of the truncation
+          print *, "WARNING: The user buffer provided had insufficient space (",&
+                    max_flen, " chars to read strings with ", max_clen, " chars).",&
+                    "The contents will be truncated to : ", trim(fstr(j,k))
+          fstr(j,k)(max_flen:max_flen) = F_SPACE_CHAR
+        end if
+        cstr_idx = cstr_idx + 1
+      enddo ! do j=1,fstr_dim_sz(1)
+    enddo ! do k=1,fstr_dim_sz(2)
+#endif
+#if {DIMS} == 3
+    max_flen= len(fstr(1,1,1))
+    do m=1,fstr_dim_sz(3)
+      do k=1,fstr_dim_sz(2)
+        do j=1,fstr_dim_sz(1)
+          clen = 0
+          cstr_copied = .false.
+          do i=1,min(max_clen, max_flen)
+            fstr(j,k,m)(i:i) = cstr(cstr_idx * max_clen + i)
+            clen = clen + 1
+            if(fstr(j,k,m)(i:i) == C_NULL_CHAR) then
+              fstr(j,k,m)(i:i) = F_SPACE_CHAR
+              cstr_copied = .true.
+              exit
+            end if
+          end do
+          if(.not. cstr_copied) then
+            ! We have exhausted the Fortran write buffer
+            ! Warn the user of the truncation
+            print *, "WARNING: The user buffer provided had insufficient space (",&
+                      max_flen, " chars to read strings with ", max_clen, " chars).",&
+                      "The contents will be truncated to : ", trim(fstr(j,k,m))
+            fstr(j,k,m)(max_flen:max_flen) = F_SPACE_CHAR
+          end if
+          cstr_idx = cstr_idx + 1
+        enddo ! do j=1,fstr_dim_sz(1)
+      enddo ! do k=1,fstr_dim_sz(2)
+    enddo ! do m=1,fstr_dim_sz(3)
+#endif
+#if {DIMS} == 4
+    max_flen= len(fstr(1,1,1,1))
+    do n=1,fstr_dim_sz(4)
+      do m=1,fstr_dim_sz(3)
+        do k=1,fstr_dim_sz(2)
+          do j=1,fstr_dim_sz(1)
+            clen = 0
+            cstr_copied = .false.
+            do i=1,min(max_clen, max_flen)
+              fstr(j,k,m,n)(i:i) = cstr(cstr_idx * max_clen + i)
+              clen = clen + 1
+              if(fstr(j,k,m,n)(i:i) == C_NULL_CHAR) then
+                fstr(j,k,m,n)(i:i) = F_SPACE_CHAR
+                cstr_copied = .true.
+                exit
+              end if
+            end do
+            if(.not. cstr_copied) then
+              ! We have exhausted the Fortran write buffer
+              ! Warn the user of the truncation
+              print *, "WARNING: The user buffer provided had insufficient space (",&
+                        max_flen, " chars to read strings with ", max_clen, " chars).",&
+                        "The contents will be truncated to : ", trim(fstr(j,k,m,n))
+              fstr(j,k,m,n)(max_flen:max_flen) = F_SPACE_CHAR
+            end if
+            cstr_idx = cstr_idx + 1
+          enddo ! do j=1,fstr_dim_sz(1)
+        enddo ! do k=1,fstr_dim_sz(2)
+      enddo ! do m=1,fstr_dim_sz(3)
+    enddo ! do n=1,fstr_dim_sz(4)
+#endif
+#if {DIMS} == 5
+    max_flen= len(fstr(1,1,1,1,1))
+    do q=1,fstr_dim_sz(5)
+      do n=1,fstr_dim_sz(4)
+        do m=1,fstr_dim_sz(3)
+          do k=1,fstr_dim_sz(2)
+            do j=1,fstr_dim_sz(1)
+              clen = 0
+              cstr_copied = .false.
+              do i=1,min(max_clen, max_flen)
+                fstr(j,k,m,n,q)(i:i) = cstr(cstr_idx * max_clen + i)
+                clen = clen + 1
+                if(fstr(j,k,m,n,q)(i:i) == C_NULL_CHAR) then
+                  fstr(j,k,m,n,q)(i:i) = F_SPACE_CHAR
+                  cstr_copied = .true.
+                  exit
+                end if
+              end do
+              if(.not. cstr_copied) then
+                ! We have exhausted the Fortran write buffer
+                ! Warn the user of the truncation
+                print *, "WARNING: The user buffer provided had insufficient space (",&
+                          max_flen, " chars to read strings with ", max_clen, " chars).",&
+                          "The contents will be truncated to : ", trim(fstr(j,k,m,n,q))
+                fstr(j,k,m,n,q)(max_flen:max_flen) = F_SPACE_CHAR
+              end if
+              cstr_idx = cstr_idx + 1
+            enddo ! do j=1,fstr_dim_sz(1)
+          enddo ! do k=1,fstr_dim_sz(2)
+        enddo ! do m=1,fstr_dim_sz(3)
+      enddo ! do n=1,fstr_dim_sz(4)
+    enddo ! do q=1,fstr_dim_sz(5)
+#endif
+
+  end subroutine Cstring2Fstring_{DIMS}d
+
 end module pionfget_mod

--- a/src/flib/pionfget_mod.F90.in
+++ b/src/flib/pionfget_mod.F90.in
@@ -304,12 +304,14 @@ CONTAINS
     character(len=*), intent(out) :: ival{DIMSTR}
 
     character(C_CHAR), allocatable :: cval(:)
+    integer :: cval_sz
 
     ival = ' '
-    allocate(cval(size(ival) * len(ival)))
+    cval_sz = size(ival) * len(ival)
+    allocate(cval(cval_sz))
     ierr = get_vara_text_internal (File%fh, varid, start, count, size(cval), cval)
 
-    call Cstring2Fstring_{DIMS}d (cval, len(ival), ival)
+    call Cstring2Fstring_{DIMS}d (cval, cval_sz, len(ival), ival)
     deallocate(cval)
 
   end function get_vara_{DIMS}d_text
@@ -400,7 +402,7 @@ CONTAINS
     character(len=*), intent(out) :: ival{DIMSTR}
 
     character(C_CHAR), allocatable :: cval(:)
-    integer :: clen, nstrs
+    integer :: cval_sz, clen, nstrs
 
     ival = ' '
     ierr = get_text_var_sz(File, varid, clen, var_nstrs=nstrs)
@@ -408,10 +410,11 @@ CONTAINS
       call piodie(__PIO_FILE__, __LINE__, "Unable to query the text variable size")
     end if
 
-    allocate(cval(clen * nstrs))
+    cval_sz = clen * nstrs
+    allocate(cval(cval_sz))
 !    ierr = get_var_text_internal(File%fh, varid, size(ival), ival)
     ierr = PIOc_get_var_text(File%fh, varid-1, cval)
-    call Cstring2Fstring_{DIMS}d (cval, clen, ival)
+    call Cstring2Fstring_{DIMS}d (cval, cval_sz, clen, ival)
     deallocate(cval)
 
   end function get_var_{DIMS}d_text
@@ -522,18 +525,29 @@ CONTAINS
   end function get_var_vdesc_{DIMS}d_{TYPE}
 
 ! DIMS 1,2,3,4,5
-  subroutine Cstring2Fstring_{DIMS}d(cstr, max_clen, fstr)
+  subroutine Cstring2Fstring_{DIMS}d(cstr, cstr_sz, max_clen, fstr)
     character(C_CHAR), intent(in) :: cstr(:)
+    ! The total size of cstr, the total number of chars in cstr
+    integer, intent(in) :: cstr_sz
+    ! The length of each string in cstr
     integer, intent(in) :: max_clen
     character(len=*), intent(out) :: fstr{DIMSTR}
 
     integer :: fstr_dim_sz({DIMS})
-    integer :: max_flen, clen
+    integer :: max_nstrs, max_flen, clen
     integer :: cstr_idx
     logical :: cstr_copied
     integer :: i, j, k, m, n, q
 
     character, parameter :: F_SPACE_CHAR = ' '
+
+    max_nstrs = cstr_sz / max_clen
+    if(max_nstrs > size(fstr)) then
+      print *, "ERROR: The provided user buffer",&
+                  " does not have space for copying ", max_nstrs, "strings",&
+                  " (space available to copy only ", size(fstr), " strings)"
+      call piodie(__PIO_FILE__, __LINE__, "Insufficient user buffer space")
+    end if
 
     fstr = F_SPACE_CHAR
     do i=1,{DIMS}

--- a/src/flib/pionfget_mod.F90.in
+++ b/src/flib/pionfget_mod.F90.in
@@ -304,14 +304,18 @@ CONTAINS
     character(len=*), intent(out) :: ival{DIMSTR}
 
     character(C_CHAR), allocatable :: cval(:)
-    integer :: cval_sz
+    integer :: cval_sz, clen
 
     ival = ' '
-    cval_sz = size(ival) * len(ival)
+    ierr = get_text_var_sz(File, varid, clen)
+    if(ierr /= PIO_NOERR) then
+      call piodie(__PIO_FILE__, __LINE__, "Unable to query text var size")
+    end if
+    cval_sz = size(ival) * clen
     allocate(cval(cval_sz))
     ierr = get_vara_text_internal (File%fh, varid, start, count, size(cval), cval)
 
-    call Cstring2Fstring_{DIMS}d (cval, cval_sz, len(ival), ival)
+    call Cstring2Fstring_{DIMS}d (cval, cval_sz, clen, ival)
     deallocate(cval)
 
   end function get_vara_{DIMS}d_text

--- a/src/flib/pionfget_mod.F90.in
+++ b/src/flib/pionfget_mod.F90.in
@@ -548,7 +548,7 @@ CONTAINS
           exit
         end if
       end do
-      if(.not. cstr_copied) then
+      if((.not. cstr_copied) .and. (max_flen < max_clen)) then
         ! We have exhausted the Fortran write buffer
         ! Warn the user of the truncation
         print *, "WARNING: The user buffer provided had insufficient space (",&
@@ -574,7 +574,7 @@ CONTAINS
             exit
           end if
         end do
-        if(.not. cstr_copied) then
+        if((.not. cstr_copied) .and. (max_flen < max_clen)) then
           ! We have exhausted the Fortran write buffer
           ! Warn the user of the truncation
           print *, "WARNING: The user buffer provided had insufficient space (",&
@@ -602,7 +602,7 @@ CONTAINS
               exit
             end if
           end do
-          if(.not. cstr_copied) then
+          if((.not. cstr_copied) .and. (max_flen < max_clen)) then
             ! We have exhausted the Fortran write buffer
             ! Warn the user of the truncation
             print *, "WARNING: The user buffer provided had insufficient space (",&
@@ -632,7 +632,7 @@ CONTAINS
                 exit
               end if
             end do
-            if(.not. cstr_copied) then
+            if((.not. cstr_copied) .and. (max_flen < max_clen)) then
               ! We have exhausted the Fortran write buffer
               ! Warn the user of the truncation
               print *, "WARNING: The user buffer provided had insufficient space (",&
@@ -664,7 +664,7 @@ CONTAINS
                   exit
                 end if
               end do
-              if(.not. cstr_copied) then
+              if((.not. cstr_copied) .and. (max_flen < max_clen)) then
                 ! We have exhausted the Fortran write buffer
                 ! Warn the user of the truncation
                 print *, "WARNING: The user buffer provided had insufficient space (",&

--- a/src/flib/pionfget_mod.F90.in
+++ b/src/flib/pionfget_mod.F90.in
@@ -9,8 +9,8 @@ module pionfget_mod
   use perf_mod, only : t_startf, t_stopf      ! _EXTERNAL
 #endif
   use pio_kinds, only: i4,r4,r8
-  use pio_types, only : file_desc_t, var_desc_t
-  use pio_support, only : replace_c_null
+  use pio_types, only : file_desc_t, var_desc_t, pio_noerr
+  use pio_support, only : replace_c_null, get_text_var_sz, piodie
   implicit none
   private
 !>
@@ -400,12 +400,18 @@ CONTAINS
     character(len=*), intent(out) :: ival{DIMSTR}
 
     character(C_CHAR), allocatable :: cval(:)
+    integer :: clen, nstrs
 
     ival = ' '
-    allocate(cval(size(ival) * len(ival)))
+    ierr = get_text_var_sz(File, varid, clen, var_nstrs=nstrs)
+    if(ierr /= PIO_NOERR) then
+      call piodie(__PIO_FILE__, __LINE__, "Unable to query the text variable size")
+    end if
+
+    allocate(cval(clen * nstrs))
 !    ierr = get_var_text_internal(File%fh, varid, size(ival), ival)
     ierr = PIOc_get_var_text(File%fh, varid-1, cval)
-    call Cstring2Fstring_{DIMS}d (cval, len(ival), ival)
+    call Cstring2Fstring_{DIMS}d (cval, clen, ival)
     deallocate(cval)
 
   end function get_var_{DIMS}d_text

--- a/src/flib/pionfget_mod.F90.in
+++ b/src/flib/pionfget_mod.F90.in
@@ -361,29 +361,6 @@ CONTAINS
 
   end function get_vara_vdesc_{DIMS}d_{TYPE}
 
-!>
-!! @public
-!! @ingroup PIO_get_var
-!! @brief Writes an netcdf attribute to a file
-!! @details
-!! @param File @ref file_desc_t
-!! @param varid : The netcdf variable identifier
-!! @param ival : The value for the netcdf metadata
-!! @retval ierr @ref error_return
-!<
-  integer function get_var_0d_text (File,varid, ival) result(ierr)
-    type (File_desc_t), intent(in) :: File
-    integer, intent(in) :: varid
-    character(len=*), intent(out) :: ival
-
-
-    ival =C_NULL_CHAR
-    ierr = PIOc_get_var_text(File%fh, varid-1, ival)
-    call replace_c_null(ival)
-!    print *,__FILE__,__LINE__,trim(ival)
-  end function Get_var_0d_text
-
-
 ! TYPE int,real,double
 ! DIMS 0
   integer function get_var_0d_{TYPE} (File,varid, ival) result(ierr)
@@ -399,7 +376,7 @@ CONTAINS
 
   end function Get_var_0d_{TYPE}
 
-! DIMS 1,2,3,4,5
+! DIMS 0,1,2,3,4,5
   integer function get_var_{DIMS}d_text (File,varid, ival) result(ierr)
     type (File_desc_t), intent(in) :: File
     integer, intent(in) :: varid
@@ -414,7 +391,12 @@ CONTAINS
       call piodie(__PIO_FILE__, __LINE__, "Unable to query the text variable size")
     end if
 
-    cval_sz = clen * nstrs
+    if(nstrs > 0) then
+      cval_sz = clen * nstrs
+    else
+      cval_sz = clen
+    end if
+
     allocate(cval(cval_sz))
 !    ierr = get_var_text_internal(File%fh, varid, size(ival), ival)
     ierr = PIOc_get_var_text(File%fh, varid-1, cval)
@@ -528,7 +510,7 @@ CONTAINS
 
   end function get_var_vdesc_{DIMS}d_{TYPE}
 
-! DIMS 1,2,3,4,5
+! DIMS 0,1,2,3,4,5
   subroutine Cstring2Fstring_{DIMS}d(cstr, cstr_sz, max_clen, fstr)
     character(C_CHAR), intent(in) :: cstr(:)
     ! The total size of cstr, the total number of chars in cstr
@@ -537,7 +519,11 @@ CONTAINS
     integer, intent(in) :: max_clen
     character(len=*), intent(out) :: fstr{DIMSTR}
 
+#if {DIMS} != 0
     integer :: fstr_dim_sz({DIMS})
+#else
+    integer :: fstr_dim_sz
+#endif
     integer :: max_nstrs, max_flen, clen
     integer :: cstr_idx
     logical :: cstr_copied
@@ -546,6 +532,7 @@ CONTAINS
     character, parameter :: F_SPACE_CHAR = ' '
 
     max_nstrs = cstr_sz / max_clen
+#if {DIMS} != 0
     if(max_nstrs > size(fstr)) then
       print *, "ERROR: The provided user buffer",&
                   " does not have space for copying ", max_nstrs, "strings",&
@@ -553,11 +540,42 @@ CONTAINS
       call piodie(__PIO_FILE__, __LINE__, "Insufficient user buffer space")
     end if
 
-    fstr = F_SPACE_CHAR
     do i=1,{DIMS}
       fstr_dim_sz(i) = size(fstr,i)
     enddo
+#else
+    if(max_nstrs > 1) then
+      print *, "ERROR: The provided user buffer",&
+                  " does not have space for copying ", max_nstrs, "strings",&
+                  " (space available to copy only 1 string)"
+      call piodie(__PIO_FILE__, __LINE__, "Insufficient user buffer space")
+    end if
+    fstr_dim_sz = len(fstr)
+#endif
+    fstr = F_SPACE_CHAR
     cstr_idx = 0
+#if {DIMS} == 0
+    max_flen= len(fstr)
+    clen = 0
+    cstr_copied = .false.
+    do i=1,min(max_clen, max_flen)
+      fstr(i:i) = cstr(i)
+      clen = clen + 1
+      if(fstr(i:i) == C_NULL_CHAR) then
+        fstr(i:i) = F_SPACE_CHAR
+        cstr_copied = .true.
+        exit
+      end if
+    end do
+    if((.not. cstr_copied) .and. (max_flen < max_clen)) then
+      ! We have exhausted the Fortran write buffer
+      ! Warn the user of the truncation
+      print *, "WARNING: The user buffer provided had insufficient space (",&
+                max_flen, " chars to read string with ", max_clen, " chars).",&
+                "The contents will be truncated to : ", trim(fstr)
+      fstr(max_flen:max_flen) = F_SPACE_CHAR
+    end if
+#endif
 #if {DIMS} == 1
     max_flen= len(fstr(1))
     do j=1,fstr_dim_sz(1)

--- a/src/flib/pionfget_mod.F90.in
+++ b/src/flib/pionfget_mod.F90.in
@@ -398,26 +398,11 @@ CONTAINS
     end if
 
     allocate(cval(cval_sz))
-!    ierr = get_var_text_internal(File%fh, varid, size(ival), ival)
     ierr = PIOc_get_var_text(File%fh, varid-1, cval)
     call Cstring2Fstring_{DIMS}d (cval, cval_sz, clen, ival)
     deallocate(cval)
 
   end function get_var_{DIMS}d_text
-
-!  integer function get_var_text_internal (ncid,varid, nstrs, ival) result(ierr)
-!    integer, intent(in) :: ncid
-!    integer, intent(in) :: varid
-!    integer, intent(in) :: nstrs
-!    character(len=*), intent(out) :: ival(*)
-!    integer :: j
-!
-!    ierr = PIOc_get_var_text(ncid, varid-1, ival)
-!    do j=1,nstrs
-!       call replace_c_null(ival(j))
-!    end do
-!
-!  end function get_var_text_internal
 
 ! TYPE int,real,double
   integer function get_var_{TYPE}_internal  (ncid,varid, ival) result(ierr)
@@ -459,7 +444,6 @@ CONTAINS
     integer, intent(in) :: start(:)
     integer, intent(in) :: count(:)
     integer, intent(in) :: nstrs
-    !character(len=*), intent(out) :: ival(*)
     character(C_CHAR), intent(out) :: cval(:)
     integer :: j
     integer(C_SIZE_T), allocatable :: cstart(:), ccount(:)
@@ -473,9 +457,6 @@ CONTAINS
     enddo
 
     ierr = PIOc_get_vara_text (ncid, varid-1, cstart, ccount, cval)
-    !do j=1,nstrs
-    !   call replace_c_null(ival(j),ccount(ndims))
-    !end do
     deallocate(ccount, cstart)
   end function get_vara_text_internal
 

--- a/src/flib/pionfput_mod.F90.in
+++ b/src/flib/pionfput_mod.F90.in
@@ -169,7 +169,9 @@ contains
         ierr = PIOc_put_var1_{NCTYPE} (file%fh, varid-1, cindex, ival)
         deallocate(cindex)
     else
-        print *, 'PIO: WARNING: Empty index array passed to PIO_put_var function put_var1_{TYPE}, a collective C API call will be skipped on this process. ', __PIO_FILE__, __LINE__
+        print *, "PIO: WARNING: Empty index array passed to PIO_put_var"&
+                  " function put_var1_{TYPE}, a collective C API call will"&
+                  " be skipped on this process. ", __PIO_FILE__, __LINE__
     end if
 #ifdef TIMING
     call t_stopf("PIO:put_var1_{TYPE}")
@@ -307,7 +309,9 @@ contains
         ierr = put_var_internal_{TYPE} (File%fh, varid, cval)
         deallocate(cval)
     else
-        print *, 'PIO: WARNING: Empty {DIMS}d {TYPE} data passed to PIO_put_var function put_var_{DIMS}d_{TYPE}, a collective C API call will be skipped on this process. ', __PIO_FILE__, __LINE__
+        print *, "PIO: WARNING: Empty {DIMS}d {TYPE} data passed to PIO_put_var"&
+                  " function put_var_{DIMS}d_{TYPE}, a collective C API call will"&
+                  " be skipped on this process. ", __PIO_FILE__, __LINE__
     end if
 
   end function put_var_{DIMS}d_{TYPE}
@@ -460,7 +464,9 @@ contains
         ierr = PIOc_put_vara_text(file%fh, varid-1,  cstart, ccount, cval)
         deallocate(cval)
     else
-        print *, 'PIO: WARNING: Empty {DIMS}d text data passed to PIO_put_var function put_vara_{DIMS}d_text, a collective C API call will be skipped on this process. ', __PIO_FILE__, __LINE__
+        print *, "PIO: WARNING: Empty {DIMS}d text data passed to PIO_put_var"&
+                  " function put_vara_{DIMS}d_text, a collective C API call will"&
+                  " be skipped on this process. ", __PIO_FILE__, __LINE__
     end if
     deallocate(cstart, ccount)
 

--- a/src/flib/pionfput_mod.F90.in
+++ b/src/flib/pionfput_mod.F90.in
@@ -10,6 +10,7 @@ module pionfput_mod
   use iso_c_binding
   use pio_kinds, only: i4,r4,r8
   use pio_types, only : file_desc_t, var_desc_t, pio_noerr
+  use pio_support, only : piodie, get_text_var_sz
 
   implicit none
   private
@@ -218,7 +219,17 @@ contains
 !   This manipulation is required to convert the fortran string to
 !   a c character array with all trailing space set to null
 !
-    clen = len(ival)
+    ierr = get_text_var_sz(File, varid, clen)
+    if(ierr /= PIO_NOERR) then
+      call piodie(__PIO_FILE__, __LINE__, "Getting text variable size failed")
+    end if
+    if(clen < len_trim(ival)) then
+      print *, "WARNING: The length of the string in the user buffer ,",&
+                len_trim(ival),&
+                " chars, is greater than the size of the variable",&
+                " being written to, ", clen, " chars. The string, '",&
+                trim(ival), "', will be truncated"
+    end if
     if (clen > 0) then
         allocate(cval(clen))
         cval = C_NULL_CHAR
@@ -251,17 +262,26 @@ contains
     integer, intent(in) :: varid
     character(len=*), intent(in) :: ival{DIMSTR}
     character, allocatable :: cval(:)
-    integer :: clen,  sd
+    integer :: clen, nstrs
 
 !   This manipulation is required to convert the fortran string to
 !   a c character array with all trailing space set to null
 !
     ierr = PIO_NOERR
-    clen = len(ival)
-    sd = size(ival)
-    if (clen*sd > 0) then
-        allocate(cval(clen*sd))
-        call Fstring2Cstring_{DIMS}d (ival, cval)
+    ierr = get_text_var_sz(File, varid, clen, var_nstrs=nstrs)
+    if(ierr /= PIO_NOERR) then
+      call piodie(__PIO_FILE__, __LINE__, "Getting text variable size failed")
+    end if
+    if(clen < len(ival)) then
+      print *, "WARNING: The length of the string in the user buffer ,",&
+                len(ival),&
+                " chars, is greater than the size of the variable",&
+                " being written to, ", clen, " chars. The strings",&
+                " may be truncated"
+    end if
+    if (clen * nstrs > 0) then
+        allocate(cval(clen * nstrs))
+        call Fstring2Cstring_{DIMS}d (ival, cval, clen)
         ierr = PIOc_put_var_text(file%fh, varid-1,  cval)
         deallocate(cval)
     else
@@ -455,103 +475,152 @@ contains
 !   This manipulation is required to convert the fortran string to
 !   a c character array with all trailing space set to null
 !
-    clen = len(ival)
+    ierr = get_text_var_sz(File, varid, clen)
+    if(ierr /= PIO_NOERR) then
+      call piodie(__PIO_FILE__, __LINE__, "Unable to get text var size")
+    end if
     sd = size(ival)
     if (clen*sd > 0) then
         allocate(cval(clen*sd))
-        call Fstring2Cstring_{DIMS}d (ival, cval)
+        call Fstring2Cstring_{DIMS}d (ival, cval, clen)
 
         ierr = PIOc_put_vara_text(file%fh, varid-1,  cstart, ccount, cval)
-        deallocate(cval, cstart, ccount)
+        deallocate(cval)
     else
         print *, 'PIO: WARNING: Empty {DIMS}d text data passed to PIO_put_var function put_vara_{DIMS}d_text, a collective C API call will be skipped on this process. ', __PIO_FILE__, __LINE__
     end if
+    deallocate(cstart, ccount)
 
   end function put_vara_{DIMS}d_text
 
 ! DIMS 1,2,3,4,5
-  subroutine Fstring2Cstring_{DIMS}d(fstr, cstr)
+  subroutine Fstring2Cstring_{DIMS}d(fstr, cstr, max_clen)
     character(len=*), intent(in) :: fstr{DIMSTR}
     character(C_CHAR), intent(out) :: cstr(:)
-    integer :: clen, sd({DIMS})
-    integer :: cinc
+    integer, intent(in) :: max_clen
+
+    integer :: fstr_dim_sz({DIMS})
+    integer :: max_flen
+    integer :: cstr_idx
     integer :: i, j, k, m, n, q
 
     cstr = C_NULL_CHAR
     do i=1,{DIMS}
-       sd(i) = size(fstr,i)
+      fstr_dim_sz(i) = size(fstr,i)
     enddo
-    cinc = 0
+    cstr_idx = 0
 #if {DIMS} == 1
-    clen= len(fstr(1))
-    do j=1,sd(1)
-       do i=1,max(1,len_trim(fstr(j)))
-          cstr(i+cinc*clen) = fstr(j)(i:i)
-       end do
-       cinc = cinc+1
+    do j=1,fstr_dim_sz(1)
+      max_flen = len_trim(fstr(j))
+      do i=1,min(max_clen, max_flen)
+        cstr(cstr_idx * max_clen + i) = fstr(j)(i:i)
+      end do
+      if(max_clen < max_flen + 1) then
+        ! We have exhausted the C write buffer
+        ! C string = Fortran string chars + C_NULL_CHAR
+        ! Warn the user of the truncation
+        cstr(cstr_idx * max_clen + max_clen) = C_NULL_CHAR
+        print *, "WARNING: The user buffer provided had insufficient space (",&
+                  max_clen, " chars to write strings with ", max_flen, " chars).",&
+                  "The contents will be truncated to : ", trim(fstr(j)(1:max_clen-1))
+      end if
+      cstr_idx = cstr_idx + 1
     enddo
 #endif
 #if {DIMS} == 2
-    clen= len(fstr(1,1))
-    do k=1,sd(2)
-       do j=1,sd(1)
-          do i=1,max(1,len_trim(fstr(j,k)))
-             cstr(i+cinc*clen) = fstr(j,k)(i:i)
-          end do
-          cinc = cinc+1
-       enddo
-    enddo
+    do k=1,fstr_dim_sz(2)
+      do j=1,fstr_dim_sz(1)
+        max_flen = len_trim(fstr(j,k))
+        do i=1,min(max_clen, max_flen)
+          cstr(cstr_idx * max_clen + i) = fstr(j,k)(i:i)
+        end do
+        if(max_clen < max_flen + 1) then
+          ! We have exhausted the C write buffer
+          ! C string = Fortran string chars + C_NULL_CHAR
+          ! Warn the user of the truncation
+          cstr(cstr_idx * max_clen + max_clen) = C_NULL_CHAR
+          print *, "WARNING: The user buffer provided had insufficient space (",&
+                    max_clen, " chars to write strings with ", max_flen, " chars).",&
+                    "The contents will be truncated to : ", trim(fstr(j,k)(1:max_clen-1))
+        end if
+        cstr_idx = cstr_idx + 1
+      enddo ! do j=1,fstr_dim_sz(1)
+    enddo ! do k=1,fstr_dim_sz(2)
 #endif
 #if {DIMS} == 3
-    clen= len(fstr(1,1,1))
-    do m=1,sd(3)
-       do k=1,sd(2)
-          do j=1,sd(1)
-             do i=1,max(1,len_trim(fstr(j,k,m)))
-                cstr(i+cinc*clen) = fstr(j,k,m)(i:i)
-             end do
-             cinc = cinc+1
-          enddo
-       enddo
-    enddo
+    do m=1,fstr_dim_sz(3)
+      do k=1,fstr_dim_sz(2)
+        do j=1,fstr_dim_sz(1)
+          max_flen = len_trim(fstr(j,k,m))
+          do i=1,min(max_clen, max_flen)
+            cstr(cstr_idx * max_clen + i) = fstr(j,k,m)(i:i)
+          end do
+          if(max_clen < max_flen + 1) then
+            ! We have exhausted the C write buffer
+            ! C string = Fortran string chars + C_NULL_CHAR
+            ! Warn the user of the truncation
+            cstr(cstr_idx * max_clen + max_clen) = C_NULL_CHAR
+            print *, "WARNING: The user buffer provided had insufficient space (",&
+                      max_clen, " chars to write strings with ", max_flen, " chars).",&
+                      "The contents will be truncated to : ", trim(fstr(j,k,m)(1:max_clen-1))
+          end if
+          cstr_idx = cstr_idx + 1
+        enddo ! do j=1,fstr_dim_sz(1)
+      enddo ! do k=1,fstr_dim_sz(2)
+    enddo ! do m=1,fstr_dim_sz(3)
 #endif
 #if {DIMS} == 4
-    clen= len(fstr(1,1,1,1))
-    do n=1,sd(4)
-       do m=1,sd(3)
-          do k=1,sd(2)
-             do j=1,sd(1)
-                do i=1,max(1,len_trim(fstr(j,k,m,n)))
-                   cstr(i+cinc*clen) = fstr(j,k,m,n)(i:i)
-                end do
-                cinc = cinc+1
-             enddo
-          enddo
-       enddo
-    enddo
+    do n=1,fstr_dim_sz(4)
+      do m=1,fstr_dim_sz(3)
+        do k=1,fstr_dim_sz(2)
+          do j=1,fstr_dim_sz(1)
+            max_flen = len_trim(fstr(j,k,m,n))
+            do i=1,min(max_clen, max_flen)
+              cstr(cstr_idx * max_clen + i) = fstr(j,k,m,n)(i:i)
+            end do
+            if(max_clen < max_flen + 1) then
+              ! We have exhausted the C write buffer
+              ! C string = Fortran string chars + C_NULL_CHAR
+              ! Warn the user of the truncation
+              cstr(cstr_idx * max_clen + max_clen) = C_NULL_CHAR
+              print *, "WARNING: The user buffer provided had insufficient space (",&
+                        max_clen, " chars to write strings with ", max_flen, " chars).",&
+                        "The contents will be truncated to : ", trim(fstr(j,k,m,n)(1:max_clen-1))
+            end if
+            cstr_idx = cstr_idx + 1
+          enddo ! do j=1,fstr_dim_sz(1)
+        enddo ! do k=1,fstr_dim_sz(2)
+      enddo ! do m=1,fstr_dim_sz(3)
+    enddo ! do n=1,fstr_dim_sz(4)
 #endif
 #if {DIMS} == 5
-    clen= len(fstr(1,1,1,1,1))
-    do q=1,sd(5)
-       do n=1,sd(4)
-          do m=1,sd(3)
-             do k=1,sd(2)
-                do j=1,sd(1)
-                   do i=1,max(1,len_trim(fstr(j,k,m,n,q)))
-                      cstr(i+cinc*clen) = fstr(j,k,m,n,q)(i:i)
-                   end do
-                   cinc = cinc+1
-                enddo
-             enddo
-          enddo
-       enddo
-    enddo
+    do q=1,fstr_dim_sz(5)
+      do n=1,fstr_dim_sz(4)
+        do m=1,fstr_dim_sz(3)
+          do k=1,fstr_dim_sz(2)
+            do j=1,fstr_dim_sz(1)
+              max_flen = len_trim(fstr(j,k,m,n,q))
+              do i=1,min(max_clen, max_flen)
+                cstr(cstr_idx * max_clen + i) = fstr(j,k,m,n,q)(i:i)
+              end do
+              if(max_clen < max_flen + 1) then
+                ! We have exhausted the C write buffer
+                ! C string = Fortran string chars + C_NULL_CHAR
+                ! Warn the user of the truncation
+                cstr(cstr_idx * max_clen + max_clen) = C_NULL_CHAR
+                print *, "WARNING: The user buffer provided had insufficient space (",&
+                          max_clen, " chars to write strings with ", max_flen, " chars).",&
+                          "The contents will be truncated to : ", trim(fstr(j,k,m,n,q)(1:max_clen-1))
+              end if
+              cstr_idx = cstr_idx + 1
+            enddo ! do j=1,fstr_dim_sz(1)
+          enddo ! do k=1,fstr_dim_sz(2)
+        enddo ! do m=1,fstr_dim_sz(3)
+      enddo ! do n=1,fstr_dim_sz(4)
+    enddo ! do q=1,fstr_dim_sz(5)
 #endif
 
-
   end subroutine Fstring2Cstring_{DIMS}d
-
-
 
 ! TYPE int,real,double
 ! DIMS 1,2,3,4,5

--- a/src/flib/pionfput_mod.F90.in
+++ b/src/flib/pionfput_mod.F90.in
@@ -262,7 +262,7 @@ contains
     integer, intent(in) :: varid
     character(len=*), intent(in) :: ival{DIMSTR}
     character, allocatable :: cval(:)
-    integer :: clen, nstrs
+    integer :: cval_sz, clen, nstrs
 
 !   This manipulation is required to convert the fortran string to
 !   a c character array with all trailing space set to null
@@ -279,9 +279,10 @@ contains
                 " being written to, ", clen, " chars. The strings",&
                 " may be truncated"
     end if
-    if (clen * nstrs > 0) then
-        allocate(cval(clen * nstrs))
-        call Fstring2Cstring_{DIMS}d (ival, cval, clen)
+    cval_sz = clen * nstrs
+    if (cval_sz > 0) then
+        allocate(cval(cval_sz))
+        call Fstring2Cstring_{DIMS}d (ival, cval, cval_sz, clen)
         ierr = PIOc_put_var_text(file%fh, varid-1,  cval)
         deallocate(cval)
     else
@@ -451,7 +452,7 @@ contains
     integer, intent(in) :: varid, start(:), count(:)
     character(len=*), intent(in) :: ival{DIMSTR}
     character, allocatable :: cval(:)
-    integer :: clen,  sd
+    integer :: cval_sz, clen,  sd
     integer(C_SIZE_T), allocatable :: cstart(:), ccount(:)
     integer :: i
     integer :: ndims
@@ -480,9 +481,10 @@ contains
       call piodie(__PIO_FILE__, __LINE__, "Unable to get text var size")
     end if
     sd = size(ival)
-    if (clen*sd > 0) then
-        allocate(cval(clen*sd))
-        call Fstring2Cstring_{DIMS}d (ival, cval, clen)
+    cval_sz = clen * sd
+    if (cval_sz > 0) then
+        allocate(cval(cval_sz))
+        call Fstring2Cstring_{DIMS}d (ival, cval, cval_sz, clen)
 
         ierr = PIOc_put_vara_text(file%fh, varid-1,  cstart, ccount, cval)
         deallocate(cval)
@@ -494,15 +496,26 @@ contains
   end function put_vara_{DIMS}d_text
 
 ! DIMS 1,2,3,4,5
-  subroutine Fstring2Cstring_{DIMS}d(fstr, cstr, max_clen)
+  subroutine Fstring2Cstring_{DIMS}d(fstr, cstr, cstr_sz, max_clen)
     character(len=*), intent(in) :: fstr{DIMSTR}
     character(C_CHAR), intent(out) :: cstr(:)
+    ! The total size of cstr, the total number  of chars in cstr
+    integer, intent(in) :: cstr_sz
+    ! The max length of each string in cstr
     integer, intent(in) :: max_clen
 
     integer :: fstr_dim_sz({DIMS})
-    integer :: max_flen
+    integer :: max_nstrs, max_flen
     integer :: cstr_idx
     integer :: i, j, k, m, n, q
+
+    max_nstrs = cstr_sz / max_clen
+    if(size(fstr) > max_nstrs) then
+      print *, "ERROR: The provided user buffer",&
+                  " does not have space for copying ", size(fstr), "strings",&
+                  " (space available to copy only ", max_nstrs, " strings)"
+      call piodie(__PIO_FILE__, __LINE__, "Insufficient user buffer space")
+    end if
 
     cstr = C_NULL_CHAR
     do i=1,{DIMS}

--- a/src/flib/pionfput_mod.F90.in
+++ b/src/flib/pionfput_mod.F90.in
@@ -233,7 +233,7 @@ contains
     if (clen > 0) then
         allocate(cval(clen))
         cval = C_NULL_CHAR
-        do i=1,len_trim(ival)
+        do i=1,min(clen, len_trim(ival))
             cval(i) = ival(i:i)
         end do
 

--- a/src/flib/pionfput_mod.F90.in
+++ b/src/flib/pionfput_mod.F90.in
@@ -196,55 +196,7 @@ contains
     ierr = put_var1_{TYPE} (File, vardesc%varid, index, ival)
   end function put_var1_vdesc_{TYPE}
 
-!>
-!! @public
-!! @ingroup PIO_put_var
-!! @brief Writes a netCDF scalar variable.
-!! @details
-!! @param File @copydoc file_desc_t
-!! @param File : A file handle returne from \ref PIO_openfile or \ref PIO_createfile.
-!! @param varid : The netcdf variable identifier
-!! @param ival : The value for the netcdf variable
-!! @retval ierr @copydoc error_return
-!<
-  integer function put_var_0d_text (File,varid, ival) result(ierr)
-    type (File_desc_t), intent(inout) :: File
-    integer, intent(in) :: varid
-    character(len=*), intent(in) :: ival
-
-    character, allocatable :: cval(:)
-    integer :: clen, i
-
-
-!   This manipulation is required to convert the fortran string to
-!   a c character array with all trailing space set to null
-!
-    ierr = get_text_var_sz(File, varid, clen)
-    if(ierr /= PIO_NOERR) then
-      call piodie(__PIO_FILE__, __LINE__, "Getting text variable size failed")
-    end if
-    if(clen < len_trim(ival)) then
-      print *, "WARNING: The length of the string in the user buffer ,",&
-                len_trim(ival),&
-                " chars, is greater than the size of the variable",&
-                " being written to, ", clen, " chars. The string, '",&
-                trim(ival), "', will be truncated"
-    end if
-    if (clen > 0) then
-        allocate(cval(clen))
-        cval = C_NULL_CHAR
-        do i=1,min(clen, len_trim(ival))
-            cval(i) = ival(i:i)
-        end do
-
-        ierr = PIOc_put_var_text(file%fh, varid-1,  cval)
-
-        deallocate(cval)
-    else
-        print *, 'PIO: WARNING: Empty character array passed to PIO_put_var function put_var_0d_text, a collective C API call will be skipped on this process. ', __PIO_FILE__, __LINE__
-    end if
-  end function put_var_0d_text
-! DIMS 1,2,3,4,5
+! DIMS 0,1,2,3,4,5
 ! TYPE text
 !>
 !! @public
@@ -268,6 +220,11 @@ contains
 !   a c character array with all trailing space set to null
 !
     ierr = PIO_NOERR
+    if(len(ival) == 0) then
+      print *, "PIO: WARNING: Empty {DIMS}d text data passed to PIO_put_var"&
+                " function put_var_{DIMS}d_text, a collective C API call will"&
+                " be skipped on this process. ", __PIO_FILE__, __LINE__
+    end if
     ierr = get_text_var_sz(File, varid, clen, var_nstrs=nstrs)
     if(ierr /= PIO_NOERR) then
       call piodie(__PIO_FILE__, __LINE__, "Getting text variable size failed")
@@ -279,15 +236,15 @@ contains
                 " being written to, ", clen, " chars. The strings",&
                 " may be truncated"
     end if
-    cval_sz = clen * nstrs
-    if (cval_sz > 0) then
-        allocate(cval(cval_sz))
-        call Fstring2Cstring_{DIMS}d (ival, cval, cval_sz, clen)
-        ierr = PIOc_put_var_text(file%fh, varid-1,  cval)
-        deallocate(cval)
+    if(nstrs > 0) then
+      cval_sz = clen * nstrs
     else
-        print *, 'PIO: WARNING: Empty {DIMS}d text data passed to PIO_put_var function put_var_{DIMS}d_text, a collective C API call will be skipped on this process. ', __PIO_FILE__, __LINE__
+      cval_sz = clen
     end if
+    allocate(cval(cval_sz))
+    call Fstring2Cstring_{DIMS}d (ival, cval, cval_sz, clen, cstr_add_null = .false.)
+    ierr = PIOc_put_var_text(file%fh, varid-1,  cval)
+    deallocate(cval)
 
   end function put_var_{DIMS}d_text
 
@@ -509,7 +466,7 @@ contains
 
   end function put_vara_{DIMS}d_text
 
-! DIMS 1,2,3,4,5
+! DIMS 0,1,2,3,4,5
   subroutine Fstring2Cstring_{DIMS}d(fstr, cstr, cstr_sz, max_clen, cstr_add_null)
     character(len=*), intent(in) :: fstr{DIMSTR}
     character(C_CHAR), intent(out) :: cstr(:)
@@ -520,7 +477,11 @@ contains
     logical, intent(in), optional :: cstr_add_null
 
     logical :: add_c_null = .true.
+#if {DIMS} != 0
     integer :: fstr_dim_sz({DIMS})
+#else
+    integer :: fstr_dim_sz
+#endif
     integer :: max_nstrs, max_flen
     integer :: cstr_idx
     integer :: i, j, k, m, n, q
@@ -530,6 +491,7 @@ contains
     end if
 
     max_nstrs = cstr_sz / max_clen
+#if {DIMS} != 0
     if(size(fstr) > max_nstrs) then
       print *, "ERROR: The provided user buffer",&
                   " does not have space for copying ", size(fstr), "strings",&
@@ -537,11 +499,35 @@ contains
       call piodie(__PIO_FILE__, __LINE__, "Insufficient user buffer space")
     end if
 
-    cstr = C_NULL_CHAR
     do i=1,{DIMS}
       fstr_dim_sz(i) = size(fstr,i)
     enddo
+#else
+    if(max_nstrs < 1) then
+      print *, "ERROR: The provided user buffer",&
+                  " does not have space for copying a string",&
+                  " (space available to copy only ", max_nstrs, " strings)"
+      call piodie(__PIO_FILE__, __LINE__, "Insufficient user buffer space")
+    end if
+    fstr_dim_sz = len_trim(fstr)
+#endif
+    cstr = C_NULL_CHAR
     cstr_idx = 0
+#if {DIMS} == 0
+    max_flen = len_trim(fstr)
+    do i=1,min(max_clen, max_flen)
+      cstr(i) = fstr(i:i)
+    end do
+    if(add_c_null .and. (max_clen < max_flen + 1)) then
+      ! We have exhausted the C write buffer
+      ! C string = Fortran string chars + C_NULL_CHAR
+      ! Warn the user of the truncation
+      cstr(max_clen) = C_NULL_CHAR
+      print *, "WARNING: The user buffer provided had insufficient space (",&
+                max_clen, " chars to write strings with ", max_flen, " chars).",&
+                "The contents will be truncated to : ", trim(fstr)
+    end if
+#endif
 #if {DIMS} == 1
     do j=1,fstr_dim_sz(1)
       max_flen = len_trim(fstr(j))

--- a/src/flib/pionfput_mod.F90.in
+++ b/src/flib/pionfput_mod.F90.in
@@ -485,8 +485,6 @@ contains
     logical :: add_c_null = .true.
 #if {DIMS} != 0
     integer :: fstr_dim_sz({DIMS})
-#else
-    integer :: fstr_dim_sz
 #endif
     integer :: max_nstrs, max_flen
     integer :: cstr_idx
@@ -515,7 +513,6 @@ contains
                   " (space available to copy only ", max_nstrs, " strings)"
       call piodie(__PIO_FILE__, __LINE__, "Insufficient user buffer space")
     end if
-    fstr_dim_sz = len_trim(fstr)
 #endif
     cstr = C_NULL_CHAR
     cstr_idx = 0

--- a/src/flib/pionfput_mod.F90.in
+++ b/src/flib/pionfput_mod.F90.in
@@ -261,7 +261,7 @@ contains
     type (File_desc_t), intent(inout) :: File
     integer, intent(in) :: varid
     character(len=*), intent(in) :: ival{DIMSTR}
-    character, allocatable :: cval(:)
+    character(C_CHAR), allocatable :: cval(:)
     integer :: cval_sz, clen, nstrs
 
 !   This manipulation is required to convert the fortran string to
@@ -466,6 +466,9 @@ contains
           ndims=i
        endif
     enddo
+    if(ndims == 0) then
+      call piodie(__PIO_FILE__, __LINE__, "Invalid count array passed to put_vara_*d_text")
+    end if
     allocate(cstart(ndims),ccount(ndims))
 
     do i=1,ndims
@@ -476,15 +479,26 @@ contains
 !   This manipulation is required to convert the fortran string to
 !   a c character array with all trailing space set to null
 !
-    ierr = get_text_var_sz(File, varid, clen)
-    if(ierr /= PIO_NOERR) then
-      call piodie(__PIO_FILE__, __LINE__, "Unable to get text var size")
-    end if
+    clen = len(ival)
     sd = size(ival)
     cval_sz = clen * sd
     if (cval_sz > 0) then
         allocate(cval(cval_sz))
-        call Fstring2Cstring_{DIMS}d (ival, cval, cval_sz, clen)
+        ! Reshape the fortran array of strings to a contiguous 1d character array.
+        ! The 1d character array does not include string delimiters between the
+        ! different strings in the fortran array. The way the characters in the
+        ! C string is written out is determined by the shape specified in the
+        ! start/count arrays provided by the user.
+        ! character(len=3) :: ival[2] = [ "abc",
+        !                                 "def" ]
+        ! is converted to a single 1d character array
+        ! cval[6] = [   'a',
+        !               'b',
+        !               'c',
+        !               'd',
+        !               'e',
+        !               'f' ]
+        call Fstring2Cstring_{DIMS}d (ival, cval, cval_sz, clen, cstr_add_null = .false.)
 
         ierr = PIOc_put_vara_text(file%fh, varid-1,  cstart, ccount, cval)
         deallocate(cval)
@@ -496,18 +510,24 @@ contains
   end function put_vara_{DIMS}d_text
 
 ! DIMS 1,2,3,4,5
-  subroutine Fstring2Cstring_{DIMS}d(fstr, cstr, cstr_sz, max_clen)
+  subroutine Fstring2Cstring_{DIMS}d(fstr, cstr, cstr_sz, max_clen, cstr_add_null)
     character(len=*), intent(in) :: fstr{DIMSTR}
     character(C_CHAR), intent(out) :: cstr(:)
     ! The total size of cstr, the total number  of chars in cstr
     integer, intent(in) :: cstr_sz
     ! The max length of each string in cstr
     integer, intent(in) :: max_clen
+    logical, intent(in), optional :: cstr_add_null
 
+    logical :: add_c_null = .true.
     integer :: fstr_dim_sz({DIMS})
     integer :: max_nstrs, max_flen
     integer :: cstr_idx
     integer :: i, j, k, m, n, q
+
+    if(present(cstr_add_null)) then
+      add_c_null = cstr_add_null
+    end if
 
     max_nstrs = cstr_sz / max_clen
     if(size(fstr) > max_nstrs) then
@@ -528,7 +548,7 @@ contains
       do i=1,min(max_clen, max_flen)
         cstr(cstr_idx * max_clen + i) = fstr(j)(i:i)
       end do
-      if(max_clen < max_flen + 1) then
+      if(add_c_null .and. (max_clen < max_flen + 1)) then
         ! We have exhausted the C write buffer
         ! C string = Fortran string chars + C_NULL_CHAR
         ! Warn the user of the truncation
@@ -547,7 +567,7 @@ contains
         do i=1,min(max_clen, max_flen)
           cstr(cstr_idx * max_clen + i) = fstr(j,k)(i:i)
         end do
-        if(max_clen < max_flen + 1) then
+        if(add_c_null .and. (max_clen < max_flen + 1)) then
           ! We have exhausted the C write buffer
           ! C string = Fortran string chars + C_NULL_CHAR
           ! Warn the user of the truncation
@@ -568,7 +588,7 @@ contains
           do i=1,min(max_clen, max_flen)
             cstr(cstr_idx * max_clen + i) = fstr(j,k,m)(i:i)
           end do
-          if(max_clen < max_flen + 1) then
+          if(add_c_null .and. (max_clen < max_flen + 1)) then
             ! We have exhausted the C write buffer
             ! C string = Fortran string chars + C_NULL_CHAR
             ! Warn the user of the truncation
@@ -591,7 +611,7 @@ contains
             do i=1,min(max_clen, max_flen)
               cstr(cstr_idx * max_clen + i) = fstr(j,k,m,n)(i:i)
             end do
-            if(max_clen < max_flen + 1) then
+            if(add_c_null .and. (max_clen < max_flen + 1)) then
               ! We have exhausted the C write buffer
               ! C string = Fortran string chars + C_NULL_CHAR
               ! Warn the user of the truncation
@@ -616,7 +636,7 @@ contains
               do i=1,min(max_clen, max_flen)
                 cstr(cstr_idx * max_clen + i) = fstr(j,k,m,n,q)(i:i)
               end do
-              if(max_clen < max_flen + 1) then
+              if(add_c_null .and. (max_clen < max_flen + 1)) then
                 ! We have exhausted the C write buffer
                 ! C string = Fortran string chars + C_NULL_CHAR
                 ! Warn the user of the truncation

--- a/tests/general/ncdf_get_put.F90.in
+++ b/tests/general/ncdf_get_put.F90.in
@@ -939,6 +939,10 @@ PIO_TF_AUTO_TEST_SUB_BEGIN test_put_get_2d_str_arr
 
 PIO_TF_AUTO_TEST_SUB_END test_put_get_2d_str_arr
 
+! Miscellaneous tests for pio_put/get_var for text variables
+! 1) Test put/get var for [0:3]d text variables
+! 2) Test puts with strings (and hence user buffers) smaller than the variable
+! 3) Test gets with strings (and hence user buffers) larger than the variable
 PIO_TF_AUTO_TEST_SUB_BEGIN test_put_get_misc_str
   Implicit none
   type(file_desc_t) :: pio_file
@@ -981,6 +985,10 @@ PIO_TF_AUTO_TEST_SUB_BEGIN test_put_get_misc_str
   character(len=PIO_TF_MAX_STR_LEN), dimension(:), allocatable :: iotype_descs
   integer :: num_iotypes
 
+  ! Formats for the data written out in the text variable
+  ! Each string in the variable is of the form
+  ! "VAR_NAME(VAR_IDX,...)"
+  ! e.g. For 2D var, var2d, var2d(j,i) = "var2d(j,i)"
   character(len=*), parameter :: VNAME_WITH_1D_IDX_FMT1 = '(A5,"(",I5,")")'
   character(len=*), parameter :: VNAME_WITH_2D_IDX_FMT1 = '(A5,"(",I5,",",I5,")")'
   character(len=*), parameter :: VNAME_WITH_3D_IDX_FMT1 = '(A5,"(",I5,",",I5,",",I5,")")'
@@ -993,6 +1001,7 @@ PIO_TF_AUTO_TEST_SUB_BEGIN test_put_get_misc_str
   num_iotypes = 0
   call PIO_TF_Get_nc_iotypes(iotypes, iotype_descs, num_iotypes)
   do i=1,num_iotypes
+    ! Initialize the buffers written out to the variable
     exp_str0d = var0d_name
     exp_sstr0d = var0d_name
     do row=1,NUM_ROWS
@@ -1251,6 +1260,7 @@ PIO_TF_AUTO_TEST_SUB_BEGIN test_put_get_misc_str
 
 PIO_TF_AUTO_TEST_SUB_END test_put_get_misc_str
 
+! Test puts of a text variables, one frame at a time
 PIO_TF_AUTO_TEST_SUB_BEGIN test_put_get_str_frames
   Implicit none
   type(file_desc_t) :: pio_file
@@ -1295,6 +1305,10 @@ PIO_TF_AUTO_TEST_SUB_BEGIN test_put_get_str_frames
   character(len=PIO_TF_MAX_STR_LEN), dimension(:), allocatable :: iotype_descs
   integer :: num_iotypes
 
+  ! Formats for the data written out in the text variable
+  ! Each string in the variable is of the form
+  ! "VAR_NAME(VAR_IDX,...)"
+  ! e.g. For 2D var, var2d, var2d(j,i) = "var2d(j,i)"
   character(len=*), parameter :: VNAME_WITH_1D_IDX_FMT1 = '(A5,"(",I5,")")'
   character(len=*), parameter :: VNAME_WITH_2D_IDX_FMT1 = '(A5,"(",I5,",",I5,")")'
   character(len=*), parameter :: VNAME_WITH_3D_IDX_FMT1 = '(A5,"(",I5,",",I5,",",I5,")")'
@@ -1306,6 +1320,7 @@ PIO_TF_AUTO_TEST_SUB_BEGIN test_put_get_str_frames
 
   num_iotypes = 0
   call PIO_TF_Get_nc_iotypes(iotypes, iotype_descs, num_iotypes)
+  ! Init buffers to be written out to the variables
   do i=1,num_iotypes
     do row=1,NUM_ROWS
       write(exp_str1d(row), VNAME_WITH_1D_IDX_FMT1) var2d_name, row
@@ -1347,6 +1362,7 @@ PIO_TF_AUTO_TEST_SUB_BEGIN test_put_get_str_frames
     ret = PIO_enddef(pio_file)
     PIO_TF_CHECK_ERR(ret, "Failed to enddef:" // trim(filename))
 
+    ! Write the 1d text variable, 1 string at a time
     do row=1,NUM_ROWS
       strt = 1
       cnt = 0
@@ -1361,6 +1377,7 @@ PIO_TF_AUTO_TEST_SUB_BEGIN test_put_get_str_frames
       PIO_TF_CHECK_ERR(ret, "Failed to put 1d array of strings in file " // trim(filename))
     end do
 
+    ! Write the 2d text variable, 1 array/row of strings at a time
     do col=1,NUM_COLS
       strt = 1
       cnt = 0
@@ -1377,6 +1394,7 @@ PIO_TF_AUTO_TEST_SUB_BEGIN test_put_get_str_frames
       PIO_TF_CHECK_ERR(ret, "Failed to put 2d array of strings in file " // trim(filename))
     end do
 
+    ! Write the 3d text variable, 1 2d array (row x col) of strings at a time
     do step=1,NUM_STEPS
       strt = 1
       cnt = 0
@@ -1442,6 +1460,14 @@ PIO_TF_AUTO_TEST_SUB_BEGIN test_put_get_str_frames
 
 PIO_TF_AUTO_TEST_SUB_END test_put_get_str_frames
 
+! Testing put/get of hyperslabs of a text variable
+! Each string in the text variable is initialized with the variable name and
+! index
+! e.g. The string in the jth col and ith row of a 2d variable, var2d(j, i),
+! is initialized to "var2d(j,i)"
+! The contents of the variable is then modified/rewritten in two parts,
+! 1) var2d(j,i) = "var2d(j,i)" is modified to "v__2d(j,i)"
+! 2) var2d(j,i) = "v__2d(j,i)" is modified to "v__2_(j,i)"
 PIO_TF_AUTO_TEST_SUB_BEGIN test_put_get_str_hslabs
   Implicit none
   type(file_desc_t) :: pio_file
@@ -1489,6 +1515,10 @@ PIO_TF_AUTO_TEST_SUB_BEGIN test_put_get_str_hslabs
   character(len=PIO_TF_MAX_STR_LEN), dimension(:), allocatable :: iotype_descs
   integer :: num_iotypes
 
+  ! Formats for the data written out in the text variable
+  ! Each string in the variable is of the form
+  ! "VAR_NAME(VAR_IDX,...)"
+  ! e.g. For 2D var, var2d, var2d(j,i) = "var2d(j,i)"
   character(len=*), parameter :: VNAME_WITH_1D_IDX_FMT1 = '(A5,"(",I5,")")'
   character(len=*), parameter :: VNAME_WITH_2D_IDX_FMT1 = '(A5,"(",I5,",",I5,")")'
   character(len=*), parameter :: VNAME_WITH_3D_IDX_FMT1 = '(A5,"(",I5,",",I5,",",I5,")")'
@@ -1506,6 +1536,7 @@ PIO_TF_AUTO_TEST_SUB_BEGIN test_put_get_str_hslabs
   write(var3d_name, VAR_NAME_FMT) VAR_NAME_PREFIX1, VAR3D_ID, VAR_NAME_SUFFIX1
 
   do i=1,num_iotypes
+    ! Init bufs used to write data to variables
     var1d_name_tmp_buf = var1d_name
     var2d_name_tmp_buf = var2d_name
     var3d_name_tmp_buf = var3d_name
@@ -1601,6 +1632,8 @@ PIO_TF_AUTO_TEST_SUB_BEGIN test_put_get_str_hslabs
       end do
     end do
 
+    ! Write a hslab of 1d text variable to modify prefix of each string
+    ! in the variable, 1 string at a time
     do row=1,NUM_ROWS
       strt = 1
       cnt = 0
@@ -1611,7 +1644,6 @@ PIO_TF_AUTO_TEST_SUB_BEGIN test_put_get_str_hslabs
 
       ! Pack the data written out into an array of strings, each of length 1
       ! tmp_str(1) = "v", tmp_str(2) = "_", tmp_str(3) = "_"
-      ! tmp_str(4) = "v", tmp_str(5) = "_", tmp_str(6) = "_"
       ! ...
       allocate(tmp_str(cnt(1) * cnt(2)))
       do j=1, cnt(2)
@@ -1626,6 +1658,8 @@ PIO_TF_AUTO_TEST_SUB_BEGIN test_put_get_str_hslabs
       deallocate(tmp_str)
     end do
 
+    ! Write a hslab of 2d text variable to modify prefix of each string
+    ! in the variable, a 1d array/col of strings at a time
     do col=1,NUM_COLS
       strt = 1
       cnt = 0
@@ -1656,6 +1690,8 @@ PIO_TF_AUTO_TEST_SUB_BEGIN test_put_get_str_hslabs
       deallocate(tmp_str)
     end do
 
+    ! Write a hslab of 3d text variable to modify prefix of each string
+    ! in the variable, 1 2d array of strings at a time
     do step=1,NUM_STEPS
       strt = 1
       cnt = 0
@@ -1746,6 +1782,8 @@ PIO_TF_AUTO_TEST_SUB_BEGIN test_put_get_str_hslabs
       end do
     end do
 
+    ! Write hslab of 1d text variable to modify a part of each string in the variable,
+    ! 1 string at a time
     do row=1,NUM_ROWS
       strt = 1
       cnt = 0
@@ -1772,6 +1810,8 @@ PIO_TF_AUTO_TEST_SUB_BEGIN test_put_get_str_hslabs
       deallocate(tmp_str)
     end do
 
+    ! Write an hslab of data to modify part of the variable, 1 1d array of strings
+    ! at a time
     do col=1,NUM_COLS
       strt = 1
       cnt = 0
@@ -1803,6 +1843,8 @@ PIO_TF_AUTO_TEST_SUB_BEGIN test_put_get_str_hslabs
       deallocate(tmp_str)
     end do
 
+    ! Write an hslab of data to modify part of the variable, 1 2d array of strings
+    ! at a time
     do step=1,NUM_STEPS
       strt = 1
       cnt = 0

--- a/tests/general/ncdf_get_put.F90.in
+++ b/tests/general/ncdf_get_put.F90.in
@@ -1251,3 +1251,194 @@ PIO_TF_AUTO_TEST_SUB_BEGIN test_put_get_misc_str
 
 PIO_TF_AUTO_TEST_SUB_END test_put_get_misc_str
 
+PIO_TF_AUTO_TEST_SUB_BEGIN test_put_get_str_frames
+  Implicit none
+  type(file_desc_t) :: pio_file
+  character(len=*), parameter :: filename = "test_pio_ncdf_get_str_frames.testfile"
+  type(var_desc_t)  :: var1d, var2d, var3d
+  character(len=*), parameter :: var1d_name = "var1d"
+  character(len=*), parameter :: var2d_name = "var2d"
+  character(len=*), parameter :: var3d_name = "var3d"
+
+  integer, parameter :: SHORT_STR_LEN = 32
+  integer, parameter :: LONG_STR_LEN = 128
+  integer, parameter :: STR_LEN = 64
+
+  integer, parameter :: NDIMS = 4
+  integer, dimension(NDIMS) :: pio_dims
+  integer, parameter :: NUM_ROWS = 4
+  integer, parameter :: NUM_COLS = 8
+  integer, parameter :: NUM_STEPS = 6
+  character(len=*), parameter :: dim0_name = "slen"
+  character(len=*), parameter :: dim1_name = "row"
+  character(len=*), parameter :: dim2_name = "col"
+  character(len=*), parameter :: dim3_name = "step"
+
+  character(len=STR_LEN) :: exp_str1d(NUM_ROWS)
+  character(len=STR_LEN) :: exp_str2d(NUM_ROWS, NUM_COLS)
+  character(len=STR_LEN) :: exp_str3d(NUM_ROWS, NUM_COLS, NUM_STEPS)
+  character(len=STR_LEN) :: frame_str1d(1)
+  character(len=STR_LEN) :: frame_str2d(NUM_ROWS, 1)
+  character(len=STR_LEN) :: frame_str3d(NUM_ROWS, NUM_COLS, 1)
+  character(len=STR_LEN) :: gstr1d(NUM_ROWS)
+  character(len=STR_LEN) :: gstr2d(NUM_ROWS, NUM_COLS)
+  character(len=STR_LEN) :: gstr3d(NUM_ROWS, NUM_COLS, NUM_STEPS)
+
+  character(len=SHORT_STR_LEN) :: exp_sstr1d(NUM_ROWS)
+  character(len=SHORT_STR_LEN) :: exp_sstr2d(NUM_ROWS, NUM_COLS)
+  character(len=LONG_STR_LEN) :: glstr1d(NUM_ROWS)
+  character(len=LONG_STR_LEN) :: glstr2d(NUM_ROWS, NUM_COLS)
+
+  integer, dimension(NDIMS) :: strt, cnt
+
+  integer, dimension(:), allocatable :: iotypes
+  character(len=PIO_TF_MAX_STR_LEN), dimension(:), allocatable :: iotype_descs
+  integer :: num_iotypes
+
+  character(len=*), parameter :: VNAME_WITH_1D_IDX_FMT1 = '(A5,"(",I5,")")'
+  character(len=*), parameter :: VNAME_WITH_2D_IDX_FMT1 = '(A5,"(",I5,",",I5,")")'
+  character(len=*), parameter :: VNAME_WITH_3D_IDX_FMT1 = '(A5,"(",I5,",",I5,",",I5,")")'
+  character(len=*), parameter :: VNAME_WITH_1D_IDX_FMT2 = '(A5,"[",I5,"]")'
+  character(len=*), parameter :: VNAME_WITH_2D_IDX_FMT2 = '(A5,"[",I5,",",I5,"]")'
+  character(len=*), parameter :: VNAME_WITH_3D_IDX_FMT2 = '(A5,"[",I5,",",I5,",",I5,"]")'
+
+  integer :: i, row, col, step, ret
+
+  num_iotypes = 0
+  call PIO_TF_Get_nc_iotypes(iotypes, iotype_descs, num_iotypes)
+  do i=1,num_iotypes
+    do row=1,NUM_ROWS
+      write(exp_str1d(row), VNAME_WITH_1D_IDX_FMT1) var2d_name, row
+      write(exp_sstr1d(row), VNAME_WITH_1D_IDX_FMT1) var2d_name, row
+      do col=1,NUM_COLS
+        write(exp_str2d(row,col), VNAME_WITH_2D_IDX_FMT1) var2d_name, row, col
+        write(exp_sstr2d(row,col), VNAME_WITH_2D_IDX_FMT1) var2d_name, row, col
+        do step=1,NUM_STEPS
+          write(exp_str3d(row,col,step), VNAME_WITH_3D_IDX_FMT1) var3d_name, row, col, step
+        end do
+      end do
+    end do
+
+    PIO_TF_LOG(0,*) "Testing type :", iotype_descs(i)
+    ret = PIO_createfile(pio_tf_iosystem_, pio_file, iotypes(i), filename, PIO_CLOBBER)
+    PIO_TF_CHECK_ERR(ret, "Failed to open:" // trim(filename))
+
+    ret = PIO_def_dim(pio_file, dim0_name, STR_LEN, pio_dims(1))
+    PIO_TF_CHECK_ERR(ret, "Failed to define dim 0:" // trim(filename))
+
+    ret = PIO_def_dim(pio_file, dim1_name, NUM_ROWS, pio_dims(2))
+    PIO_TF_CHECK_ERR(ret, "Failed to define dim 1:" // trim(filename))
+
+    ret = PIO_def_dim(pio_file, dim2_name, NUM_COLS, pio_dims(3))
+    PIO_TF_CHECK_ERR(ret, "Failed to define dim 2:" // trim(filename))
+
+    ret = PIO_def_dim(pio_file, dim3_name, NUM_STEPS, pio_dims(4))
+    PIO_TF_CHECK_ERR(ret, "Failed to define dim 3:" // trim(filename))
+
+    ret = PIO_def_var(pio_file, var1d_name, PIO_char, (/pio_dims(1), pio_dims(2)/), var1d)
+    PIO_TF_CHECK_ERR(ret, "Failed to define 1 dim char array or 1d array of strings in file " // trim(filename))
+
+    ret = PIO_def_var(pio_file, var2d_name, PIO_char, (/pio_dims(1), pio_dims(2), pio_dims(3)/), var2d)
+    PIO_TF_CHECK_ERR(ret, "Failed to define 2 dim char array or 2d array of strings in file " // trim(filename))
+
+    ret = PIO_def_var(pio_file, var3d_name, PIO_char, pio_dims, var3d)
+    PIO_TF_CHECK_ERR(ret, "Failed to define 3 dim char array or 3d array of strings in file " // trim(filename))
+
+    ret = PIO_enddef(pio_file)
+    PIO_TF_CHECK_ERR(ret, "Failed to enddef:" // trim(filename))
+
+    do row=1,NUM_ROWS
+      strt = 1
+      cnt = 0
+      strt(1) = 1
+      strt(2) = row
+      cnt(1) = STR_LEN
+      cnt(2) = 1
+
+      frame_str1d(1) = exp_str1d(row)
+      ! This calls put_vara_1d_text()
+      ret = PIO_put_var(pio_file, var1d, strt, cnt, frame_str1d);
+      PIO_TF_CHECK_ERR(ret, "Failed to put 1d array of strings in file " // trim(filename))
+    end do
+
+    do col=1,NUM_COLS
+      strt = 1
+      cnt = 0
+      strt(1) = 1
+      strt(2) = 1
+      strt(3) = col
+      cnt(1) = STR_LEN
+      cnt(2) = NUM_ROWS
+      cnt(3) = 1
+
+      frame_str2d(:,1) = exp_str2d(:,col)
+      ! This calls put_vara_2d_text()
+      ret = PIO_put_var(pio_file, var2d, strt, cnt, frame_str2d);
+      PIO_TF_CHECK_ERR(ret, "Failed to put 2d array of strings in file " // trim(filename))
+    end do
+
+    do step=1,NUM_STEPS
+      strt = 1
+      cnt = 0
+      strt(1) = 1
+      strt(2) = 1
+      strt(3) = 1
+      strt(4) = step
+      cnt(1) = STR_LEN
+      cnt(2) = NUM_ROWS
+      cnt(3) = NUM_COLS
+      cnt(4) = 1
+
+      frame_str3d(:,:,1) = exp_str3d(:,:,step)
+      ! This calls put_vara_3d_text()
+      ret = PIO_put_var(pio_file, var3d, strt, cnt, frame_str3d);
+      PIO_TF_CHECK_ERR(ret, "Failed to put 3d array of strings in file " // trim(filename))
+    end do
+
+    ! Sync data to disk
+#ifdef PIO_TEST_CLOSE_OPEN_FOR_SYNC
+    call PIO_closefile(pio_file)
+
+    ret = PIO_openfile(pio_tf_iosystem_, pio_file, iotypes(i), filename, PIO_nowrite)
+    PIO_TF_CHECK_ERR(ret, "Failed to reopen:" // trim(filename))
+
+    ret = PIO_inq_varid(pio_file, var1d_name, var1d)
+    PIO_TF_CHECK_ERR(ret, "Failed to inquire 1d array of strings var in file " // trim(filename))
+
+    ret = PIO_inq_varid(pio_file, var2d_name, var2d)
+    PIO_TF_CHECK_ERR(ret, "Failed to inquire 2d array of strings var in file " // trim(filename))
+
+    ret = PIO_inq_varid(pio_file, var3d_name, var3d)
+    PIO_TF_CHECK_ERR(ret, "Failed to inquire 3d array of strings var in file " // trim(filename))
+#else
+    call PIO_syncfile(pio_file)
+#endif
+
+    ! This calls get_var_1d_text()
+    ret = PIO_get_var(pio_file, var1d, gstr1d);
+    PIO_TF_CHECK_ERR(ret, "Failed to get 1d char var in file " // trim(filename))
+
+    PIO_TF_CHECK_VAL((gstr1d, exp_str1d), "Got wrong value for 1d char var")
+
+    ! This calls get_var_2d_text()
+    ret = PIO_get_var(pio_file, var2d, gstr2d);
+    PIO_TF_CHECK_ERR(ret, "Failed to get 2d char var in file " // trim(filename))
+
+    PIO_TF_CHECK_VAL((gstr2d, exp_str2d), "Got wrong value for 2d char var")
+
+    ! This calls get_var_3d_text()
+    ret = PIO_get_var(pio_file, var3d, gstr3d);
+    PIO_TF_CHECK_ERR(ret, "Failed to get 3d char var in file " // trim(filename))
+
+    PIO_TF_CHECK_VAL((gstr3d, exp_str3d), "Got wrong value for 3d char var")
+
+    call PIO_closefile(pio_file)
+    call PIO_deletefile(pio_tf_iosystem_, filename);
+  end do
+  if(allocated(iotypes)) then
+    deallocate(iotypes)
+    deallocate(iotype_descs)
+  end if
+
+PIO_TF_AUTO_TEST_SUB_END test_put_get_str_frames
+

--- a/tests/general/ncdf_get_put.F90.in
+++ b/tests/general/ncdf_get_put.F90.in
@@ -939,3 +939,315 @@ PIO_TF_AUTO_TEST_SUB_BEGIN test_put_get_2d_str_arr
 
 PIO_TF_AUTO_TEST_SUB_END test_put_get_2d_str_arr
 
+PIO_TF_AUTO_TEST_SUB_BEGIN test_put_get_misc_str
+  Implicit none
+  type(file_desc_t) :: pio_file
+  character(len=*), parameter :: filename = "test_pio_ncdf_get_put_misc_str.testfile"
+  type(var_desc_t)  :: var0d, var1d, var2d, var3d
+  character(len=*), parameter :: var0d_name = "var0d"
+  character(len=*), parameter :: var1d_name = "var1d"
+  character(len=*), parameter :: var2d_name = "var2d"
+  character(len=*), parameter :: var3d_name = "var3d"
+
+  integer, parameter :: SHORT_STR_LEN = 32
+  integer, parameter :: LONG_STR_LEN = 128
+  integer, parameter :: STR_LEN = 64
+
+  integer, parameter :: NDIMS = 4
+  integer, dimension(NDIMS) :: pio_dims
+  integer, parameter :: NUM_ROWS = 4
+  integer, parameter :: NUM_COLS = 8
+  integer, parameter :: NUM_STEPS = 2
+  character(len=*), parameter :: dim0_name = "slen"
+  character(len=*), parameter :: dim1_name = "row"
+  character(len=*), parameter :: dim2_name = "col"
+  character(len=*), parameter :: dim3_name = "step"
+
+  character(len=STR_LEN) :: exp_str0d, exp_str1d(NUM_ROWS)
+  character(len=STR_LEN) :: exp_str2d(NUM_ROWS, NUM_COLS)
+  character(len=STR_LEN) :: exp_str3d(NUM_ROWS, NUM_COLS, NUM_STEPS)
+  character(len=STR_LEN) :: gstr0d, gstr1d(NUM_ROWS)
+  character(len=STR_LEN) :: gstr2d(NUM_ROWS, NUM_COLS)
+  character(len=STR_LEN) :: gstr3d(NUM_ROWS, NUM_COLS, NUM_STEPS)
+
+  character(len=SHORT_STR_LEN) :: exp_sstr0d, exp_sstr1d(NUM_ROWS)
+  character(len=SHORT_STR_LEN) :: exp_sstr2d(NUM_ROWS, NUM_COLS)
+  character(len=LONG_STR_LEN) :: glstr0d, glstr1d(NUM_ROWS)
+  character(len=LONG_STR_LEN) :: glstr2d(NUM_ROWS, NUM_COLS)
+
+  integer, dimension(NDIMS) :: strt, cnt
+
+  integer, dimension(:), allocatable :: iotypes
+  character(len=PIO_TF_MAX_STR_LEN), dimension(:), allocatable :: iotype_descs
+  integer :: num_iotypes
+
+  character(len=*), parameter :: VNAME_WITH_1D_IDX_FMT1 = '(A5,"(",I5,")")'
+  character(len=*), parameter :: VNAME_WITH_2D_IDX_FMT1 = '(A5,"(",I5,",",I5,")")'
+  character(len=*), parameter :: VNAME_WITH_3D_IDX_FMT1 = '(A5,"(",I5,",",I5,",",I5,")")'
+  character(len=*), parameter :: VNAME_WITH_1D_IDX_FMT2 = '(A5,"[",I5,"]")'
+  character(len=*), parameter :: VNAME_WITH_2D_IDX_FMT2 = '(A5,"[",I5,",",I5,"]")'
+  character(len=*), parameter :: VNAME_WITH_3D_IDX_FMT2 = '(A5,"[",I5,",",I5,",",I5,"]")'
+
+  integer :: i, row, col, step, ret
+
+  num_iotypes = 0
+  call PIO_TF_Get_nc_iotypes(iotypes, iotype_descs, num_iotypes)
+  do i=1,num_iotypes
+    exp_str0d = var0d_name
+    exp_sstr0d = var0d_name
+    do row=1,NUM_ROWS
+      write(exp_str1d(row), VNAME_WITH_1D_IDX_FMT1) var1d_name, row
+      write(exp_sstr1d(row), VNAME_WITH_1D_IDX_FMT1) var1d_name, row
+      do col=1,NUM_COLS
+        write(exp_str2d(row,col), VNAME_WITH_2D_IDX_FMT1) var2d_name, row, col
+        write(exp_sstr2d(row,col), VNAME_WITH_2D_IDX_FMT1) var2d_name, row, col
+        do step=1,NUM_STEPS
+          write(exp_str3d(row,col,step), VNAME_WITH_3D_IDX_FMT1) var2d_name, row, col, step
+        end do
+      end do
+    end do
+
+    PIO_TF_LOG(0,*) "Testing type :", iotype_descs(i)
+    ret = PIO_createfile(pio_tf_iosystem_, pio_file, iotypes(i), filename, PIO_CLOBBER)
+    PIO_TF_CHECK_ERR(ret, "Failed to open:" // trim(filename))
+
+    ret = PIO_def_dim(pio_file, dim0_name, STR_LEN, pio_dims(1))
+    PIO_TF_CHECK_ERR(ret, "Failed to define dim 0:" // trim(filename))
+
+    ret = PIO_def_dim(pio_file, dim1_name, NUM_ROWS, pio_dims(2))
+    PIO_TF_CHECK_ERR(ret, "Failed to define dim 1:" // trim(filename))
+
+    ret = PIO_def_dim(pio_file, dim2_name, NUM_COLS, pio_dims(3))
+    PIO_TF_CHECK_ERR(ret, "Failed to define dim 2:" // trim(filename))
+
+    ret = PIO_def_dim(pio_file, dim3_name, NUM_STEPS, pio_dims(4))
+    PIO_TF_CHECK_ERR(ret, "Failed to define dim 3:" // trim(filename))
+
+    ret = PIO_def_var(pio_file, var0d_name, PIO_char, (/pio_dims(1)/), var0d)
+    PIO_TF_CHECK_ERR(ret, "Failed to define 0 dim char array or string in file " // trim(filename))
+
+    ret = PIO_def_var(pio_file, var1d_name, PIO_char, (/pio_dims(1), pio_dims(2)/), var1d)
+    PIO_TF_CHECK_ERR(ret, "Failed to define 1 dim char array or 1d array of strings in file " // trim(filename))
+
+    ret = PIO_def_var(pio_file, var2d_name, PIO_char, (/pio_dims(1), pio_dims(2), pio_dims(3)/), var2d)
+    PIO_TF_CHECK_ERR(ret, "Failed to define 2 dim char array or 2d array of strings in file " // trim(filename))
+
+    ret = PIO_def_var(pio_file, var3d_name, PIO_char, pio_dims, var3d)
+    PIO_TF_CHECK_ERR(ret, "Failed to define 3 dim char array or 3d array of strings in file " // trim(filename))
+
+    ret = PIO_enddef(pio_file)
+    PIO_TF_CHECK_ERR(ret, "Failed to enddef:" // trim(filename))
+
+    ! This calls put_var_0d_text()
+    ret = PIO_put_var(pio_file, var0d, exp_str0d);
+    PIO_TF_CHECK_ERR(ret, "Failed to put 0 dim char array or string in file " // trim(filename))
+
+    ! This calls put_var_1d_text()
+    ret = PIO_put_var(pio_file, var1d, exp_str1d);
+    PIO_TF_CHECK_ERR(ret, "Failed to put 1d array of strings in file " // trim(filename))
+
+    ! This calls put_var_2d_text()
+    ret = PIO_put_var(pio_file, var2d, exp_str2d);
+    PIO_TF_CHECK_ERR(ret, "Failed to put 2d array of strings in file " // trim(filename))
+
+    ! This calls put_var_3d_text()
+    ret = PIO_put_var(pio_file, var3d, exp_str3d);
+    PIO_TF_CHECK_ERR(ret, "Failed to put 3d array of strings in file " // trim(filename))
+
+    ! Sync data to disk
+#ifdef PIO_TEST_CLOSE_OPEN_FOR_SYNC
+    call PIO_closefile(pio_file)
+
+    ret = PIO_openfile(pio_tf_iosystem_, pio_file, iotypes(i), filename, PIO_nowrite)
+    PIO_TF_CHECK_ERR(ret, "Failed to reopen:" // trim(filename))
+
+    ret = PIO_inq_varid(pio_file, var0d_name, var0d)
+    PIO_TF_CHECK_ERR(ret, "Failed to inquire 0d char or string var in file " // trim(filename))
+
+    ret = PIO_inq_varid(pio_file, var1d_name, var1d)
+    PIO_TF_CHECK_ERR(ret, "Failed to inquire 1d array of strings var in file " // trim(filename))
+
+    ret = PIO_inq_varid(pio_file, var2d_name, var2d)
+    PIO_TF_CHECK_ERR(ret, "Failed to inquire 2d array of strings var in file " // trim(filename))
+
+    ret = PIO_inq_varid(pio_file, var3d_name, var3d)
+    PIO_TF_CHECK_ERR(ret, "Failed to inquire 3d array of strings var in file " // trim(filename))
+#else
+    call PIO_syncfile(pio_file)
+#endif
+
+    ! This calls get_var_0d_text()
+    ret = PIO_get_var(pio_file, var0d, gstr0d);
+    PIO_TF_CHECK_ERR(ret, "Failed to get 0d char var in file " // trim(filename))
+
+    PIO_TF_CHECK_VAL((gstr0d, exp_str0d), "Got wrong value for 0d char var")
+
+    ! This calls get_var_1d_text()
+    ret = PIO_get_var(pio_file, var1d, gstr1d);
+    PIO_TF_CHECK_ERR(ret, "Failed to get 1d char var in file " // trim(filename))
+
+    PIO_TF_CHECK_VAL((gstr1d, exp_str1d), "Got wrong value for 1d char var")
+
+    ! This calls get_var_2d_text()
+    ret = PIO_get_var(pio_file, var2d, gstr2d);
+    PIO_TF_CHECK_ERR(ret, "Failed to get 2d char var in file " // trim(filename))
+
+    PIO_TF_CHECK_VAL((gstr2d, exp_str2d), "Got wrong value for 2d char var")
+
+    ! This calls get_var_3d_text()
+    ret = PIO_get_var(pio_file, var3d, gstr3d);
+    PIO_TF_CHECK_ERR(ret, "Failed to get 3d char var in file " // trim(filename))
+
+    PIO_TF_CHECK_VAL((gstr3d, exp_str3d), "Got wrong value for 3d char var")
+
+    ! Re-write the variables in the file with a smaller (than the variable size)
+    ! buffer
+    exp_sstr0d = var0d_name // "_"
+    do row=1,NUM_ROWS
+      write(exp_sstr1d(row), VNAME_WITH_1D_IDX_FMT2) var1d_name, row
+      do col=1,NUM_COLS
+        write(exp_sstr2d(row,col), VNAME_WITH_2D_IDX_FMT2) var2d_name, row, col
+      end do
+    end do
+
+    ! This calls put_var_0d_text()
+    ret = PIO_put_var(pio_file, var0d, exp_sstr0d);
+    PIO_TF_CHECK_ERR(ret, "Failed to put 0 dim char array or string with small buf in file " // trim(filename))
+
+    ! This calls put_var_1d_text()
+    ret = PIO_put_var(pio_file, var1d, exp_sstr1d);
+    PIO_TF_CHECK_ERR(ret, "Failed to put 1d array of strings with small buf in file " // trim(filename))
+
+    ! This calls put_var_2d_text()
+    ret = PIO_put_var(pio_file, var2d, exp_sstr2d);
+    PIO_TF_CHECK_ERR(ret, "Failed to put 2d array of strings with small buf in file " // trim(filename))
+
+    ! Sync data to disk
+#ifdef PIO_TEST_CLOSE_OPEN_FOR_SYNC
+    call PIO_closefile(pio_file)
+
+    ret = PIO_openfile(pio_tf_iosystem_, pio_file, iotypes(i), filename, PIO_nowrite)
+    PIO_TF_CHECK_ERR(ret, "Failed to reopen:" // trim(filename))
+
+    ret = PIO_inq_varid(pio_file, var0d_name, var0d)
+    PIO_TF_CHECK_ERR(ret, "Failed to inquire 0d char or string var in file " // trim(filename))
+
+    ret = PIO_inq_varid(pio_file, var1d_name, var1d)
+    PIO_TF_CHECK_ERR(ret, "Failed to inquire 1d array of strings var in file " // trim(filename))
+
+    ret = PIO_inq_varid(pio_file, var2d_name, var2d)
+    PIO_TF_CHECK_ERR(ret, "Failed to inquire 2d array of strings var in file " // trim(filename))
+
+#else
+    call PIO_syncfile(pio_file)
+#endif
+
+    ! Read data back with a larger (than the size of the variable) buffer
+    ! This calls get_var_0d_text()
+    ret = PIO_get_var(pio_file, var0d, glstr0d);
+    PIO_TF_CHECK_ERR(ret, "Failed to get 0d char var with large buf in file " // trim(filename))
+
+    PIO_TF_CHECK_VAL((glstr0d, exp_sstr0d), "Got wrong value for 0d char var with large buf")
+
+    ! This calls get_var_1d_text()
+    ret = PIO_get_var(pio_file, var1d, glstr1d);
+    PIO_TF_CHECK_ERR(ret, "Failed to get 1d char var with large buf in file " // trim(filename))
+
+    PIO_TF_CHECK_VAL((glstr1d, exp_sstr1d), "Got wrong value for 1d char var")
+
+    ! This calls get_var_2d_text()
+    ret = PIO_get_var(pio_file, var2d, glstr2d);
+    PIO_TF_CHECK_ERR(ret, "Failed to get 2d char var with large buf in file " // trim(filename))
+
+    PIO_TF_CHECK_VAL((glstr2d, exp_sstr2d), "Got wrong value for 2d char var")
+
+    ! Re-write the variables in the file to test hyperslab puts
+    do row=1,NUM_ROWS
+      write(exp_str1d(row), VNAME_WITH_1D_IDX_FMT1) var1d_name, row
+      write(exp_sstr1d(row), VNAME_WITH_1D_IDX_FMT1) var1d_name, row
+      do col=1,NUM_COLS
+        write(exp_str2d(row,col), VNAME_WITH_2D_IDX_FMT1) var2d_name, row, col
+        write(exp_sstr2d(row,col), VNAME_WITH_2D_IDX_FMT1) var2d_name, row, col
+        do step=1,NUM_STEPS
+          write(exp_str3d(row,col,step), VNAME_WITH_3D_IDX_FMT1) var3d_name, row, col, step
+        end do
+      end do
+    end do
+
+    strt = 1
+    cnt = 0
+    cnt(1) = STR_LEN
+    cnt(2) = NUM_ROWS
+
+    ! This calls put_vara_1d_text()
+    ret = PIO_put_var(pio_file, var1d, strt, cnt, exp_str1d);
+    PIO_TF_CHECK_ERR(ret, "Failed to put 1d array of strings in file " // trim(filename))
+
+    strt = 1
+    cnt = 0
+    cnt(1) = STR_LEN
+    cnt(2) = NUM_ROWS
+    cnt(3) = NUM_COLS
+
+    ! This calls put_vara_2d_text()
+    ret = PIO_put_var(pio_file, var2d, strt, cnt, exp_str2d);
+    PIO_TF_CHECK_ERR(ret, "Failed to put 2d array of strings in file " // trim(filename))
+
+    strt = 1
+    cnt = 0
+    cnt(1) = STR_LEN
+    cnt(2) = NUM_ROWS
+    cnt(3) = NUM_COLS
+    cnt(4) = NUM_STEPS
+
+    ! This calls put_vara_3d_text()
+    ret = PIO_put_var(pio_file, var3d, strt, cnt, exp_str3d);
+    PIO_TF_CHECK_ERR(ret, "Failed to put 3d array of strings in file " // trim(filename))
+
+    ! Sync data to disk
+#ifdef PIO_TEST_CLOSE_OPEN_FOR_SYNC
+    call PIO_closefile(pio_file)
+
+    ret = PIO_openfile(pio_tf_iosystem_, pio_file, iotypes(i), filename, PIO_nowrite)
+    PIO_TF_CHECK_ERR(ret, "Failed to reopen:" // trim(filename))
+
+    ret = PIO_inq_varid(pio_file, var1d_name, var1d)
+    PIO_TF_CHECK_ERR(ret, "Failed to inquire 1d array of strings var in file " // trim(filename))
+
+    ret = PIO_inq_varid(pio_file, var2d_name, var2d)
+    PIO_TF_CHECK_ERR(ret, "Failed to inquire 2d array of strings var in file " // trim(filename))
+
+    ret = PIO_inq_varid(pio_file, var3d_name, var3d)
+    PIO_TF_CHECK_ERR(ret, "Failed to inquire 3d array of strings var in file " // trim(filename))
+#else
+    call PIO_syncfile(pio_file)
+#endif
+
+    ! This calls get_var_1d_text()
+    ret = PIO_get_var(pio_file, var1d, gstr1d);
+    PIO_TF_CHECK_ERR(ret, "Failed to get 1d char var in file " // trim(filename))
+
+    PIO_TF_CHECK_VAL((gstr1d, exp_str1d), "Got wrong value for 1d char var")
+
+    ! This calls get_var_2d_text()
+    ret = PIO_get_var(pio_file, var2d, gstr2d);
+    PIO_TF_CHECK_ERR(ret, "Failed to get 2d char var in file " // trim(filename))
+
+    PIO_TF_CHECK_VAL((gstr2d, exp_str2d), "Got wrong value for 2d char var")
+
+    ! This calls get_var_3d_text()
+    ret = PIO_get_var(pio_file, var3d, gstr3d);
+    PIO_TF_CHECK_ERR(ret, "Failed to get 3d char var in file " // trim(filename))
+
+    PIO_TF_CHECK_VAL((gstr3d, exp_str3d), "Got wrong value for 3d char var")
+
+    call PIO_closefile(pio_file)
+    call PIO_deletefile(pio_tf_iosystem_, filename);
+  end do
+  if(allocated(iotypes)) then
+    deallocate(iotypes)
+    deallocate(iotype_descs)
+  end if
+
+PIO_TF_AUTO_TEST_SUB_END test_put_get_misc_str
+

--- a/tests/general/ncdf_get_put.F90.in
+++ b/tests/general/ncdf_get_put.F90.in
@@ -1162,13 +1162,13 @@ PIO_TF_AUTO_TEST_SUB_BEGIN test_put_get_misc_str
     ret = PIO_get_var(pio_file, var1d, glstr1d);
     PIO_TF_CHECK_ERR(ret, "Failed to get 1d char var with large buf in file " // trim(filename))
 
-    PIO_TF_CHECK_VAL((glstr1d, exp_sstr1d), "Got wrong value for 1d char var")
+    PIO_TF_CHECK_VAL((glstr1d, exp_sstr1d), "Got wrong value for 1d char var with large buf")
 
     ! This calls get_var_2d_text()
     ret = PIO_get_var(pio_file, var2d, glstr2d);
     PIO_TF_CHECK_ERR(ret, "Failed to get 2d char var with large buf in file " // trim(filename))
 
-    PIO_TF_CHECK_VAL((glstr2d, exp_sstr2d), "Got wrong value for 2d char var")
+    PIO_TF_CHECK_VAL((glstr2d, exp_sstr2d), "Got wrong value for 2d char var with large buf")
 
     ! Re-write the variables in the file to test hyperslab puts
     do row=1,NUM_ROWS
@@ -1190,7 +1190,7 @@ PIO_TF_AUTO_TEST_SUB_BEGIN test_put_get_misc_str
 
     ! This calls put_vara_1d_text()
     ret = PIO_put_var(pio_file, var1d, strt, cnt, exp_str1d);
-    PIO_TF_CHECK_ERR(ret, "Failed to put 1d array of strings in file " // trim(filename))
+    PIO_TF_CHECK_ERR(ret, "Failed to put hslab of 1d array of strings in file " // trim(filename))
 
     strt = 1
     cnt = 0
@@ -1200,7 +1200,7 @@ PIO_TF_AUTO_TEST_SUB_BEGIN test_put_get_misc_str
 
     ! This calls put_vara_2d_text()
     ret = PIO_put_var(pio_file, var2d, strt, cnt, exp_str2d);
-    PIO_TF_CHECK_ERR(ret, "Failed to put 2d array of strings in file " // trim(filename))
+    PIO_TF_CHECK_ERR(ret, "Failed to put hslab of 2d array of strings in file " // trim(filename))
 
     strt = 1
     cnt = 0
@@ -1211,7 +1211,7 @@ PIO_TF_AUTO_TEST_SUB_BEGIN test_put_get_misc_str
 
     ! This calls put_vara_3d_text()
     ret = PIO_put_var(pio_file, var3d, strt, cnt, exp_str3d);
-    PIO_TF_CHECK_ERR(ret, "Failed to put 3d array of strings in file " // trim(filename))
+    PIO_TF_CHECK_ERR(ret, "Failed to put hslab of 3d array of strings in file " // trim(filename))
 
     ! Sync data to disk
 #ifdef PIO_TEST_CLOSE_OPEN_FOR_SYNC
@@ -1236,19 +1236,19 @@ PIO_TF_AUTO_TEST_SUB_BEGIN test_put_get_misc_str
     ret = PIO_get_var(pio_file, var1d, gstr1d);
     PIO_TF_CHECK_ERR(ret, "Failed to get 1d char var in file " // trim(filename))
 
-    PIO_TF_CHECK_VAL((gstr1d, exp_str1d), "Got wrong value for 1d char var")
+    PIO_TF_CHECK_VAL((gstr1d, exp_str1d), "Got wrong value for 1d char var written with hslab put")
 
     ! This calls get_var_2d_text()
     ret = PIO_get_var(pio_file, var2d, gstr2d);
     PIO_TF_CHECK_ERR(ret, "Failed to get 2d char var in file " // trim(filename))
 
-    PIO_TF_CHECK_VAL((gstr2d, exp_str2d), "Got wrong value for 2d char var")
+    PIO_TF_CHECK_VAL((gstr2d, exp_str2d), "Got wrong value for 2d char var written with hslab put")
 
     ! This calls get_var_3d_text()
     ret = PIO_get_var(pio_file, var3d, gstr3d);
     PIO_TF_CHECK_ERR(ret, "Failed to get 3d char var in file " // trim(filename))
 
-    PIO_TF_CHECK_VAL((gstr3d, exp_str3d), "Got wrong value for 3d char var")
+    PIO_TF_CHECK_VAL((gstr3d, exp_str3d), "Got wrong value for 3d char var written with hslab put")
 
     call PIO_closefile(pio_file)
     call PIO_deletefile(pio_tf_iosystem_, filename);
@@ -1374,7 +1374,7 @@ PIO_TF_AUTO_TEST_SUB_BEGIN test_put_get_str_frames
       frame_str1d(1) = exp_str1d(row)
       ! This calls put_vara_1d_text()
       ret = PIO_put_var(pio_file, var1d, strt, cnt, frame_str1d);
-      PIO_TF_CHECK_ERR(ret, "Failed to put 1d array of strings in file " // trim(filename))
+      PIO_TF_CHECK_ERR(ret, "Failed to put 1d array of strings 1 frame at a time in file " // trim(filename))
     end do
 
     ! Write the 2d text variable, 1 array/row of strings at a time
@@ -1391,7 +1391,7 @@ PIO_TF_AUTO_TEST_SUB_BEGIN test_put_get_str_frames
       frame_str2d(:,1) = exp_str2d(:,col)
       ! This calls put_vara_2d_text()
       ret = PIO_put_var(pio_file, var2d, strt, cnt, frame_str2d);
-      PIO_TF_CHECK_ERR(ret, "Failed to put 2d array of strings in file " // trim(filename))
+      PIO_TF_CHECK_ERR(ret, "Failed to put 2d array of strings 1 frame at a time in file " // trim(filename))
     end do
 
     ! Write the 3d text variable, 1 2d array (row x col) of strings at a time
@@ -1410,7 +1410,7 @@ PIO_TF_AUTO_TEST_SUB_BEGIN test_put_get_str_frames
       frame_str3d(:,:,1) = exp_str3d(:,:,step)
       ! This calls put_vara_3d_text()
       ret = PIO_put_var(pio_file, var3d, strt, cnt, frame_str3d);
-      PIO_TF_CHECK_ERR(ret, "Failed to put 3d array of strings in file " // trim(filename))
+      PIO_TF_CHECK_ERR(ret, "Failed to put 3d array of strings 1 frame at a time in file " // trim(filename))
     end do
 
     ! Sync data to disk
@@ -1653,7 +1653,7 @@ PIO_TF_AUTO_TEST_SUB_BEGIN test_put_get_str_hslabs
       end do
 
       ret = PIO_put_var(pio_file, var1d, strt, cnt, tmp_str);
-      PIO_TF_CHECK_ERR(ret, "Failed to put 1d array of strings in file " // trim(filename))
+      PIO_TF_CHECK_ERR(ret, "Failed to put string prefixes in file " // trim(filename))
 
       deallocate(tmp_str)
     end do
@@ -1685,7 +1685,7 @@ PIO_TF_AUTO_TEST_SUB_BEGIN test_put_get_str_hslabs
       end do
 
       ret = PIO_put_var(pio_file, var2d, strt, cnt, tmp_str);
-      PIO_TF_CHECK_ERR(ret, "Failed to put 2d array of strings in file " // trim(filename))
+      PIO_TF_CHECK_ERR(ret, "Failed to put 1d array of string prefixes in file " // trim(filename))
 
       deallocate(tmp_str)
     end do
@@ -1722,7 +1722,7 @@ PIO_TF_AUTO_TEST_SUB_BEGIN test_put_get_str_hslabs
       end do
 
       ret = PIO_put_var(pio_file, var3d, strt, cnt, tmp_str);
-      PIO_TF_CHECK_ERR(ret, "Failed to put 3d array of strings in file " // trim(filename))
+      PIO_TF_CHECK_ERR(ret, "Failed to put 2d array of string prefixes in file " // trim(filename))
 
       deallocate(tmp_str)
     end do
@@ -1805,7 +1805,7 @@ PIO_TF_AUTO_TEST_SUB_BEGIN test_put_get_str_hslabs
       end do
 
       ret = PIO_put_var(pio_file, var1d, strt, cnt, tmp_str);
-      PIO_TF_CHECK_ERR(ret, "Failed to put 1d array of strings in file " // trim(filename))
+      PIO_TF_CHECK_ERR(ret, "Failed to put string suffixes in file " // trim(filename))
 
       deallocate(tmp_str)
     end do
@@ -1838,7 +1838,7 @@ PIO_TF_AUTO_TEST_SUB_BEGIN test_put_get_str_hslabs
       end do
 
       ret = PIO_put_var(pio_file, var2d, strt, cnt, tmp_str);
-      PIO_TF_CHECK_ERR(ret, "Failed to put 2d array of strings in file " // trim(filename))
+      PIO_TF_CHECK_ERR(ret, "Failed to put 1d array of string suffixes in file " // trim(filename))
 
       deallocate(tmp_str)
     end do
@@ -1876,7 +1876,7 @@ PIO_TF_AUTO_TEST_SUB_BEGIN test_put_get_str_hslabs
       end do
 
       ret = PIO_put_var(pio_file, var3d, strt, cnt, tmp_str);
-      PIO_TF_CHECK_ERR(ret, "Failed to put 3d array of strings in file " // trim(filename))
+      PIO_TF_CHECK_ERR(ret, "Failed to put 2d array of string suffixes in file " // trim(filename))
 
       deallocate(tmp_str)
     end do
@@ -1903,17 +1903,17 @@ PIO_TF_AUTO_TEST_SUB_BEGIN test_put_get_str_hslabs
     ret = PIO_get_var(pio_file, var1d, gstr1d);
     PIO_TF_CHECK_ERR(ret, "Failed to get 1d char var in file " // trim(filename))
 
-    PIO_TF_CHECK_VAL((gstr1d, exp_str1d), "Got wrong value for 1d char var")
+    PIO_TF_CHECK_VAL((gstr1d, exp_str1d), "Got wrong value for 1d char var with modified suffixes")
 
     ret = PIO_get_var(pio_file, var2d, gstr2d);
     PIO_TF_CHECK_ERR(ret, "Failed to get 2d char var in file " // trim(filename))
 
-    PIO_TF_CHECK_VAL((gstr2d, exp_str2d), "Got wrong value for 2d char var")
+    PIO_TF_CHECK_VAL((gstr2d, exp_str2d), "Got wrong value for 2d char var with modified suffixes")
 
     ret = PIO_get_var(pio_file, var3d, gstr3d);
     PIO_TF_CHECK_ERR(ret, "Failed to get 3d char var in file " // trim(filename))
 
-    PIO_TF_CHECK_VAL((gstr3d, exp_str3d), "Got wrong value for 3d char var")
+    PIO_TF_CHECK_VAL((gstr3d, exp_str3d), "Got wrong value for 3d char var with modified suffixes")
 
     call PIO_closefile(pio_file)
     call PIO_deletefile(pio_tf_iosystem_, filename);

--- a/tests/general/ncdf_get_put.F90.in
+++ b/tests/general/ncdf_get_put.F90.in
@@ -1442,3 +1442,444 @@ PIO_TF_AUTO_TEST_SUB_BEGIN test_put_get_str_frames
 
 PIO_TF_AUTO_TEST_SUB_END test_put_get_str_frames
 
+PIO_TF_AUTO_TEST_SUB_BEGIN test_put_get_str_hslabs
+  Implicit none
+  type(file_desc_t) :: pio_file
+  character(len=*), parameter :: filename = "test_pio_ncdf_get_str_hslabs.testfile"
+  type(var_desc_t)  :: var1d, var2d, var3d
+
+  integer, parameter :: SHORT_STR_LEN = 32
+  integer, parameter :: LONG_STR_LEN = 128
+  integer, parameter :: STR_LEN = 64
+
+  character(len=*), parameter :: VAR_NAME_PREFIX1 = "var"
+  character(len=*), parameter :: VAR_NAME_PREFIX2 = "v__"
+  character(len=*), parameter :: VAR_NAME_SUFFIX1 = "d"
+  character(len=*), parameter :: VAR_NAME_SUFFIX2 = "_"
+  integer, parameter :: VAR1D_ID = 1
+  integer, parameter :: VAR2D_ID = 2
+  integer, parameter :: VAR3D_ID = 3
+  character(len=STR_LEN) :: var1d_name, var1d_name_tmp_buf
+  character(len=STR_LEN) :: var2d_name, var2d_name_tmp_buf
+  character(len=STR_LEN) :: var3d_name, var3d_name_tmp_buf
+  ! var*d_name = VAR_NAME_PREFIX* + VAR*D_ID + VAR_NAME_SUFFIX*
+  character(len=*), parameter :: VAR_NAME_FMT = '(A3,I1,A1)'
+
+  integer, parameter :: NDIMS = 4
+  integer, dimension(NDIMS) :: pio_dims
+  integer, parameter :: NUM_ROWS = 4
+  integer, parameter :: NUM_COLS = 8
+  integer, parameter :: NUM_STEPS = 6
+  character(len=*), parameter :: dim0_name = "slen"
+  character(len=*), parameter :: dim1_name = "row"
+  character(len=*), parameter :: dim2_name = "col"
+  character(len=*), parameter :: dim3_name = "step"
+
+  character(len=STR_LEN) :: exp_str1d(NUM_ROWS)
+  character(len=STR_LEN) :: exp_str2d(NUM_ROWS, NUM_COLS)
+  character(len=STR_LEN) :: exp_str3d(NUM_ROWS, NUM_COLS, NUM_STEPS)
+  character(len=1), dimension(:), allocatable :: tmp_str
+  character(len=STR_LEN) :: gstr1d(NUM_ROWS)
+  character(len=STR_LEN) :: gstr2d(NUM_ROWS, NUM_COLS)
+  character(len=STR_LEN) :: gstr3d(NUM_ROWS, NUM_COLS, NUM_STEPS)
+
+  integer, dimension(NDIMS) :: strt, cnt
+
+  integer, dimension(:), allocatable :: iotypes
+  character(len=PIO_TF_MAX_STR_LEN), dimension(:), allocatable :: iotype_descs
+  integer :: num_iotypes
+
+  character(len=*), parameter :: VNAME_WITH_1D_IDX_FMT1 = '(A5,"(",I5,")")'
+  character(len=*), parameter :: VNAME_WITH_2D_IDX_FMT1 = '(A5,"(",I5,",",I5,")")'
+  character(len=*), parameter :: VNAME_WITH_3D_IDX_FMT1 = '(A5,"(",I5,",",I5,",",I5,")")'
+  character(len=*), parameter :: VNAME_WITH_1D_IDX_FMT2 = '(A5,"[",I5,"]")'
+  character(len=*), parameter :: VNAME_WITH_2D_IDX_FMT2 = '(A5,"[",I5,",",I5,"]")'
+  character(len=*), parameter :: VNAME_WITH_3D_IDX_FMT2 = '(A5,"[",I5,",",I5,",",I5,"]")'
+
+  integer :: i, j, k, l, m, row, col, step, ret
+
+  num_iotypes = 0
+  call PIO_TF_Get_nc_iotypes(iotypes, iotype_descs, num_iotypes)
+  ! var1d_name = "var1d", var2d_name = "var2d", var3d_name="var3d"
+  write(var1d_name, VAR_NAME_FMT) VAR_NAME_PREFIX1, VAR1D_ID, VAR_NAME_SUFFIX1
+  write(var2d_name, VAR_NAME_FMT) VAR_NAME_PREFIX1, VAR2D_ID, VAR_NAME_SUFFIX1
+  write(var3d_name, VAR_NAME_FMT) VAR_NAME_PREFIX1, VAR3D_ID, VAR_NAME_SUFFIX1
+
+  do i=1,num_iotypes
+    var1d_name_tmp_buf = var1d_name
+    var2d_name_tmp_buf = var2d_name
+    var3d_name_tmp_buf = var3d_name
+    do row=1,NUM_ROWS
+      write(exp_str1d(row), VNAME_WITH_1D_IDX_FMT1) var1d_name_tmp_buf, row
+      do col=1,NUM_COLS
+        write(exp_str2d(row,col), VNAME_WITH_2D_IDX_FMT1) var2d_name_tmp_buf, row, col
+        do step=1,NUM_STEPS
+          write(exp_str3d(row,col,step), VNAME_WITH_3D_IDX_FMT1) var3d_name_tmp_buf, row, col, step
+        end do
+      end do
+    end do
+
+    PIO_TF_LOG(0,*) "Testing type :", iotype_descs(i)
+    ret = PIO_createfile(pio_tf_iosystem_, pio_file, iotypes(i), filename, PIO_CLOBBER)
+    PIO_TF_CHECK_ERR(ret, "Failed to open:" // trim(filename))
+
+    ret = PIO_def_dim(pio_file, dim0_name, STR_LEN, pio_dims(1))
+    PIO_TF_CHECK_ERR(ret, "Failed to define dim 0:" // trim(filename))
+
+    ret = PIO_def_dim(pio_file, dim1_name, NUM_ROWS, pio_dims(2))
+    PIO_TF_CHECK_ERR(ret, "Failed to define dim 1:" // trim(filename))
+
+    ret = PIO_def_dim(pio_file, dim2_name, NUM_COLS, pio_dims(3))
+    PIO_TF_CHECK_ERR(ret, "Failed to define dim 2:" // trim(filename))
+
+    ret = PIO_def_dim(pio_file, dim3_name, NUM_STEPS, pio_dims(4))
+    PIO_TF_CHECK_ERR(ret, "Failed to define dim 3:" // trim(filename))
+
+    ret = PIO_def_var(pio_file, var1d_name, PIO_char, (/pio_dims(1), pio_dims(2)/), var1d)
+    PIO_TF_CHECK_ERR(ret, "Failed to define 1 dim char array or 1d array of strings in file " // trim(filename))
+
+    ret = PIO_def_var(pio_file, var2d_name, PIO_char, (/pio_dims(1), pio_dims(2), pio_dims(3)/), var2d)
+    PIO_TF_CHECK_ERR(ret, "Failed to define 2 dim char array or 2d array of strings in file " // trim(filename))
+
+    ret = PIO_def_var(pio_file, var3d_name, PIO_char, pio_dims, var3d)
+    PIO_TF_CHECK_ERR(ret, "Failed to define 3 dim char array or 3d array of strings in file " // trim(filename))
+
+    ret = PIO_enddef(pio_file)
+    PIO_TF_CHECK_ERR(ret, "Failed to enddef:" // trim(filename))
+
+    ! Write the entire contents of the user array/buffer
+    ! Each buffer value, the variable name with index, is of the form
+    ! VAR_NAME_PREFIX1 + VAR1D_ID + VAR_NAME_SUFFIX1(VAR1D_INDEX)
+    ! = "var" + VAR1D_ID + "d"(VAR1D_INDEX)
+    ! e.g. var1d(1) = "var1d(1)"
+    ret = PIO_put_var(pio_file, var1d, exp_str1d);
+    PIO_TF_CHECK_ERR(ret, "Failed to put 1d array of strings in file " // trim(filename))
+
+    ret = PIO_put_var(pio_file, var2d, exp_str2d);
+    PIO_TF_CHECK_ERR(ret, "Failed to put 2d array of strings in file " // trim(filename))
+
+    ret = PIO_put_var(pio_file, var3d, exp_str3d);
+    PIO_TF_CHECK_ERR(ret, "Failed to put 3d array of strings in file " // trim(filename))
+
+    ! Sync data to disk
+#ifdef PIO_TEST_CLOSE_OPEN_FOR_SYNC
+    call PIO_closefile(pio_file)
+
+    ret = PIO_openfile(pio_tf_iosystem_, pio_file, iotypes(i), filename, PIO_nowrite)
+    PIO_TF_CHECK_ERR(ret, "Failed to reopen:" // trim(filename))
+
+    ret = PIO_inq_varid(pio_file, var1d_name, var1d)
+    PIO_TF_CHECK_ERR(ret, "Failed to inquire 1d array of strings var in file " // trim(filename))
+
+    ret = PIO_inq_varid(pio_file, var2d_name, var2d)
+    PIO_TF_CHECK_ERR(ret, "Failed to inquire 2d array of strings var in file " // trim(filename))
+
+    ret = PIO_inq_varid(pio_file, var3d_name, var3d)
+    PIO_TF_CHECK_ERR(ret, "Failed to inquire 3d array of strings var in file " // trim(filename))
+#else
+    call PIO_syncfile(pio_file)
+#endif
+
+    ! Modify the prefixes in the buffer contents
+    ! Each buffer value, the variable name with index, is of the form
+    ! VAR_NAME_PREFIX1 + VAR1D_ID + VAR_NAME_SUFFIX1(VAR1D_INDEX)
+    ! = "var" + VAR1D_ID + "d"(VAR1D_INDEX)
+    ! e.g. var1d(1) = "var1d(1)" would be changed to "v__1d(1)
+
+    ! var1d_name = "v__1d", var2d_name = "v__2d", var3d_name="v__3d"
+    write(var1d_name_tmp_buf, VAR_NAME_FMT) VAR_NAME_PREFIX2, VAR1D_ID, VAR_NAME_SUFFIX1
+    write(var2d_name_tmp_buf, VAR_NAME_FMT) VAR_NAME_PREFIX2, VAR2D_ID, VAR_NAME_SUFFIX1
+    write(var3d_name_tmp_buf, VAR_NAME_FMT) VAR_NAME_PREFIX2, VAR3D_ID, VAR_NAME_SUFFIX1
+
+    do row=1,NUM_ROWS
+      write(exp_str1d(row), VNAME_WITH_1D_IDX_FMT1) var1d_name_tmp_buf, row
+      do col=1,NUM_COLS
+        write(exp_str2d(row,col), VNAME_WITH_2D_IDX_FMT1) var2d_name_tmp_buf, row, col
+        do step=1,NUM_STEPS
+          write(exp_str3d(row,col,step), VNAME_WITH_3D_IDX_FMT1) var3d_name_tmp_buf, row, col, step
+        end do
+      end do
+    end do
+
+    do row=1,NUM_ROWS
+      strt = 1
+      cnt = 0
+      strt(1) = 1
+      strt(2) = row
+      cnt(1) = len_trim(VAR_NAME_PREFIX2)
+      cnt(2) = 1
+
+      ! Pack the data written out into an array of strings, each of length 1
+      ! tmp_str(1) = "v", tmp_str(2) = "_", tmp_str(3) = "_"
+      ! tmp_str(4) = "v", tmp_str(5) = "_", tmp_str(6) = "_"
+      ! ...
+      allocate(tmp_str(cnt(1) * cnt(2)))
+      do j=1, cnt(2)
+        do k=1, cnt(1)
+          tmp_str((j - 1) * cnt(1) + k)(1:1) = VAR_NAME_PREFIX2(k:k)
+        end do
+      end do
+
+      ret = PIO_put_var(pio_file, var1d, strt, cnt, tmp_str);
+      PIO_TF_CHECK_ERR(ret, "Failed to put 1d array of strings in file " // trim(filename))
+
+      deallocate(tmp_str)
+    end do
+
+    do col=1,NUM_COLS
+      strt = 1
+      cnt = 0
+      strt(1) = 1
+      strt(2) = 1
+      strt(3) = col
+      cnt(1) = len_trim(VAR_NAME_PREFIX2)
+      cnt(2) = NUM_ROWS
+      cnt(3) = 1
+
+      ! Pack the data written out into an array of strings, each of length 1
+      ! tmp_str(1) = "v", tmp_str(2) = "_", tmp_str(3) = "_"
+      ! tmp_str(4) = "v", tmp_str(5) = "_", tmp_str(6) = "_"
+      ! ...
+      allocate(tmp_str(cnt(1) * cnt(2) * cnt(3)))
+      do l=1, cnt(3)
+        do j=1, cnt(2)
+          do k=1, cnt(1)
+            tmp_str((l - 1) * cnt(2) * cnt(1) +&
+                    (j - 1) * cnt(1) + k)(1:1) = VAR_NAME_PREFIX2(k:k)
+          end do
+        end do
+      end do
+
+      ret = PIO_put_var(pio_file, var2d, strt, cnt, tmp_str);
+      PIO_TF_CHECK_ERR(ret, "Failed to put 2d array of strings in file " // trim(filename))
+
+      deallocate(tmp_str)
+    end do
+
+    do step=1,NUM_STEPS
+      strt = 1
+      cnt = 0
+      strt(1) = 1
+      strt(2) = 1
+      strt(3) = 1
+      strt(4) = step
+      cnt(1) = len_trim(VAR_NAME_PREFIX2)
+      cnt(2) = NUM_ROWS
+      cnt(3) = NUM_COLS
+      cnt(4) = 1
+
+      ! Pack the data written out into an array of strings, each of length 1
+      ! tmp_str(1) = "v", tmp_str(2) = "_", tmp_str(3) = "_"
+      ! tmp_str(4) = "v", tmp_str(5) = "_", tmp_str(6) = "_"
+      ! ...
+      allocate(tmp_str(cnt(1) * cnt(2) * cnt(3) * cnt(4)))
+      do m=1, cnt(4)
+        do l=1, cnt(3)
+          do j=1, cnt(2)
+            do k=1, cnt(1)
+              tmp_str((m - 1) * cnt(3) * cnt(2) * cnt(1) +&
+                      (l - 1) * cnt(2) * cnt(1) +&
+                      (j - 1) * cnt(1) + k)(1:1) = VAR_NAME_PREFIX2(k:k)
+            end do
+          end do
+        end do
+      end do
+
+      ret = PIO_put_var(pio_file, var3d, strt, cnt, tmp_str);
+      PIO_TF_CHECK_ERR(ret, "Failed to put 3d array of strings in file " // trim(filename))
+
+      deallocate(tmp_str)
+    end do
+
+    ! Sync data to disk
+#ifdef PIO_TEST_CLOSE_OPEN_FOR_SYNC
+    call PIO_closefile(pio_file)
+
+    ret = PIO_openfile(pio_tf_iosystem_, pio_file, iotypes(i), filename, PIO_nowrite)
+    PIO_TF_CHECK_ERR(ret, "Failed to reopen:" // trim(filename))
+
+    ret = PIO_inq_varid(pio_file, var1d_name, var1d)
+    PIO_TF_CHECK_ERR(ret, "Failed to inquire 1d array of strings var in file " // trim(filename))
+
+    ret = PIO_inq_varid(pio_file, var2d_name, var2d)
+    PIO_TF_CHECK_ERR(ret, "Failed to inquire 2d array of strings var in file " // trim(filename))
+
+    ret = PIO_inq_varid(pio_file, var3d_name, var3d)
+    PIO_TF_CHECK_ERR(ret, "Failed to inquire 3d array of strings var in file " // trim(filename))
+#else
+    call PIO_syncfile(pio_file)
+#endif
+
+    ret = PIO_get_var(pio_file, var1d, gstr1d);
+    PIO_TF_CHECK_ERR(ret, "Failed to get 1d char var in file " // trim(filename))
+
+    PIO_TF_CHECK_VAL((gstr1d, exp_str1d), "Got wrong value for 1d char var with modified prefix")
+
+    ret = PIO_get_var(pio_file, var2d, gstr2d);
+    PIO_TF_CHECK_ERR(ret, "Failed to get 2d char var in file " // trim(filename))
+
+    PIO_TF_CHECK_VAL((gstr2d, exp_str2d), "Got wrong value for 2d char var with modified prefix")
+
+    ret = PIO_get_var(pio_file, var3d, gstr3d);
+    PIO_TF_CHECK_ERR(ret, "Failed to get 3d char var in file " // trim(filename))
+
+    PIO_TF_CHECK_VAL((gstr3d, exp_str3d), "Got wrong value for 3d char var with modified prefix")
+
+    ! Modify the suffixes in the buffer contents
+    ! Each buffer value, the variable name with index, is of the form
+    ! VAR_NAME_PREFIX2 + VAR1D_ID + VAR_NAME_SUFFIX1(VAR1D_INDEX)
+    ! = "v__" + VAR1D_ID + "d"(VAR1D_INDEX)
+    ! e.g. var1d(1) = "v__1d(1)" would be changed to "v__1_(1)
+
+    ! var1d_name = "v__1_", var2d_name = "v__2_", var3d_name="v__3_"
+    write(var1d_name_tmp_buf, VAR_NAME_FMT) VAR_NAME_PREFIX2, VAR1D_ID, VAR_NAME_SUFFIX2
+    write(var2d_name_tmp_buf, VAR_NAME_FMT) VAR_NAME_PREFIX2, VAR2D_ID, VAR_NAME_SUFFIX2
+    write(var3d_name_tmp_buf, VAR_NAME_FMT) VAR_NAME_PREFIX2, VAR3D_ID, VAR_NAME_SUFFIX2
+
+    do row=1,NUM_ROWS
+      write(exp_str1d(row), VNAME_WITH_1D_IDX_FMT1) var1d_name_tmp_buf, row
+      do col=1,NUM_COLS
+        write(exp_str2d(row,col), VNAME_WITH_2D_IDX_FMT1) var2d_name_tmp_buf, row, col
+        do step=1,NUM_STEPS
+          write(exp_str3d(row,col,step), VNAME_WITH_3D_IDX_FMT1) var3d_name_tmp_buf, row, col, step
+        end do
+      end do
+    end do
+
+    do row=1,NUM_ROWS
+      strt = 1
+      cnt = 0
+      ! Skip VAR_NAME_PREFIX2 and VAR1D_ID
+      strt(1) = (len_trim(VAR_NAME_PREFIX2) + 1) + 1
+      strt(2) = row
+      cnt(1) = len_trim(VAR_NAME_SUFFIX2)
+      cnt(2) = 1
+
+      ! Pack the data/suffix written out into an array of strings, each of length 1
+      ! tmp_str(1) = "_",
+      ! tmp_str(2) = "_",
+      ! ...
+      allocate(tmp_str(cnt(1) * cnt(2)))
+      do j=1, cnt(2)
+        do k=1, cnt(1)
+          tmp_str((j - 1) * cnt(1) + k)(1:1) = VAR_NAME_SUFFIX2(k:k)
+        end do
+      end do
+
+      ret = PIO_put_var(pio_file, var1d, strt, cnt, tmp_str);
+      PIO_TF_CHECK_ERR(ret, "Failed to put 1d array of strings in file " // trim(filename))
+
+      deallocate(tmp_str)
+    end do
+
+    do col=1,NUM_COLS
+      strt = 1
+      cnt = 0
+      ! Skip VAR_NAME_PREFIX2 and VAR2D_ID
+      strt(1) = (len_trim(VAR_NAME_PREFIX2) + 1) + 1
+      strt(2) = 1
+      strt(3) = col
+      cnt(1) = len_trim(VAR_NAME_SUFFIX2)
+      cnt(2) = NUM_ROWS
+      cnt(3) = 1
+
+      ! Pack the data/suffix written out into an array of strings, each of length 1
+      ! tmp_str(1) = "_",
+      ! tmp_str(2) = "_",
+      ! ...
+      allocate(tmp_str(cnt(1) * cnt(2) * cnt(3)))
+      do l=1, cnt(3)
+        do j=1, cnt(2)
+          do k=1, cnt(1)
+            tmp_str((l - 1) * cnt(2) * cnt(1) +&
+                    (j - 1) * cnt(1) + k)(1:1) = VAR_NAME_SUFFIX2(k:k)
+          end do
+        end do
+      end do
+
+      ret = PIO_put_var(pio_file, var2d, strt, cnt, tmp_str);
+      PIO_TF_CHECK_ERR(ret, "Failed to put 2d array of strings in file " // trim(filename))
+
+      deallocate(tmp_str)
+    end do
+
+    do step=1,NUM_STEPS
+      strt = 1
+      cnt = 0
+      ! Skip VAR_NAME_PREFIX2 and VAR3D_ID
+      strt(1) = (len_trim(VAR_NAME_PREFIX2) + 1) + 1
+      strt(2) = 1
+      strt(3) = 1
+      strt(4) = step
+      cnt(1) = len_trim(VAR_NAME_SUFFIX2)
+      cnt(2) = NUM_ROWS
+      cnt(3) = NUM_COLS
+      cnt(4) = 1
+
+      ! Pack the data/suffix written out into an array of strings, each of length 1
+      ! tmp_str(1) = "_",
+      ! tmp_str(2) = "_",
+      ! ...
+      allocate(tmp_str(cnt(1) * cnt(2) * cnt(3) * cnt(4)))
+      do m=1, cnt(4)
+        do l=1, cnt(3)
+          do j=1, cnt(2)
+            do k=1, cnt(1)
+              tmp_str((m - 1) * cnt(3) * cnt(2) * cnt(1) +&
+                      (l - 1) * cnt(2) * cnt(1) +&
+                      (j - 1) * cnt(1) + k)(1:1) = VAR_NAME_SUFFIX2(k:k)
+            end do
+          end do
+        end do
+      end do
+
+      ret = PIO_put_var(pio_file, var3d, strt, cnt, tmp_str);
+      PIO_TF_CHECK_ERR(ret, "Failed to put 3d array of strings in file " // trim(filename))
+
+      deallocate(tmp_str)
+    end do
+
+    ! Sync data to disk
+#ifdef PIO_TEST_CLOSE_OPEN_FOR_SYNC
+    call PIO_closefile(pio_file)
+
+    ret = PIO_openfile(pio_tf_iosystem_, pio_file, iotypes(i), filename, PIO_nowrite)
+    PIO_TF_CHECK_ERR(ret, "Failed to reopen:" // trim(filename))
+
+    ret = PIO_inq_varid(pio_file, var1d_name, var1d)
+    PIO_TF_CHECK_ERR(ret, "Failed to inquire 1d array of strings var in file " // trim(filename))
+
+    ret = PIO_inq_varid(pio_file, var2d_name, var2d)
+    PIO_TF_CHECK_ERR(ret, "Failed to inquire 2d array of strings var in file " // trim(filename))
+
+    ret = PIO_inq_varid(pio_file, var3d_name, var3d)
+    PIO_TF_CHECK_ERR(ret, "Failed to inquire 3d array of strings var in file " // trim(filename))
+#else
+    call PIO_syncfile(pio_file)
+#endif
+
+    ret = PIO_get_var(pio_file, var1d, gstr1d);
+    PIO_TF_CHECK_ERR(ret, "Failed to get 1d char var in file " // trim(filename))
+
+    PIO_TF_CHECK_VAL((gstr1d, exp_str1d), "Got wrong value for 1d char var")
+
+    ret = PIO_get_var(pio_file, var2d, gstr2d);
+    PIO_TF_CHECK_ERR(ret, "Failed to get 2d char var in file " // trim(filename))
+
+    PIO_TF_CHECK_VAL((gstr2d, exp_str2d), "Got wrong value for 2d char var")
+
+    ret = PIO_get_var(pio_file, var3d, gstr3d);
+    PIO_TF_CHECK_ERR(ret, "Failed to get 3d char var in file " // trim(filename))
+
+    PIO_TF_CHECK_VAL((gstr3d, exp_str3d), "Got wrong value for 3d char var")
+
+    call PIO_closefile(pio_file)
+    call PIO_deletefile(pio_tf_iosystem_, filename);
+  end do
+  if(allocated(iotypes)) then
+    deallocate(iotypes)
+    deallocate(iotype_descs)
+  end if
+
+PIO_TF_AUTO_TEST_SUB_END test_put_get_str_hslabs
+

--- a/tests/general/ncdf_get_put.F90.in
+++ b/tests/general/ncdf_get_put.F90.in
@@ -1067,7 +1067,7 @@ PIO_TF_AUTO_TEST_SUB_BEGIN test_put_get_misc_str
 #ifdef PIO_TEST_CLOSE_OPEN_FOR_SYNC
     call PIO_closefile(pio_file)
 
-    ret = PIO_openfile(pio_tf_iosystem_, pio_file, iotypes(i), filename, PIO_nowrite)
+    ret = PIO_openfile(pio_tf_iosystem_, pio_file, iotypes(i), filename, PIO_write)
     PIO_TF_CHECK_ERR(ret, "Failed to reopen:" // trim(filename))
 
     ret = PIO_inq_varid(pio_file, var0d_name, var0d)
@@ -1135,7 +1135,7 @@ PIO_TF_AUTO_TEST_SUB_BEGIN test_put_get_misc_str
 #ifdef PIO_TEST_CLOSE_OPEN_FOR_SYNC
     call PIO_closefile(pio_file)
 
-    ret = PIO_openfile(pio_tf_iosystem_, pio_file, iotypes(i), filename, PIO_nowrite)
+    ret = PIO_openfile(pio_tf_iosystem_, pio_file, iotypes(i), filename, PIO_write)
     PIO_TF_CHECK_ERR(ret, "Failed to reopen:" // trim(filename))
 
     ret = PIO_inq_varid(pio_file, var0d_name, var0d)
@@ -1596,7 +1596,7 @@ PIO_TF_AUTO_TEST_SUB_BEGIN test_put_get_str_hslabs
 #ifdef PIO_TEST_CLOSE_OPEN_FOR_SYNC
     call PIO_closefile(pio_file)
 
-    ret = PIO_openfile(pio_tf_iosystem_, pio_file, iotypes(i), filename, PIO_nowrite)
+    ret = PIO_openfile(pio_tf_iosystem_, pio_file, iotypes(i), filename, PIO_write)
     PIO_TF_CHECK_ERR(ret, "Failed to reopen:" // trim(filename))
 
     ret = PIO_inq_varid(pio_file, var1d_name, var1d)
@@ -1731,7 +1731,7 @@ PIO_TF_AUTO_TEST_SUB_BEGIN test_put_get_str_hslabs
 #ifdef PIO_TEST_CLOSE_OPEN_FOR_SYNC
     call PIO_closefile(pio_file)
 
-    ret = PIO_openfile(pio_tf_iosystem_, pio_file, iotypes(i), filename, PIO_nowrite)
+    ret = PIO_openfile(pio_tf_iosystem_, pio_file, iotypes(i), filename, PIO_write)
     PIO_TF_CHECK_ERR(ret, "Failed to reopen:" // trim(filename))
 
     ret = PIO_inq_varid(pio_file, var1d_name, var1d)


### PR DESCRIPTION
* Explicitly convert C strings to Fortran strings during get.
   This fix is required for gets to work correctly with the pgi
   compiler (and is compatible with other compilers)
* Refactor put and get routines to improve the error handling
   and provide better user warning/error messages
* More tests for put/get of text variables
* Enhancement to the testing framework utils to compare
   arrays of strings