### PR TITLE
Use SCORPIO_SOURCE_DIR instead of CMAKE_SOURCE_DIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,7 +97,7 @@ endif()
 #==============================================================================
 
 #===== Local modules =====
-list (APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
+list (APPEND CMAKE_MODULE_PATH ${SCORPIO_SOURCE_DIR}/cmake)
 
 #===== External modules =====
 if (DEFINED USER_CMAKE_MODULE_PATH)

--- a/cmake/LibMPI.cmake
+++ b/cmake/LibMPI.cmake
@@ -128,7 +128,7 @@ function (add_mpi_test TESTNAME)
     else ()
                         
         # Run tests from the platform-specific executable
-        set (EXE_CMD ${CMAKE_SOURCE_DIR}/cmake/mpiexec.${PLATFORM} 
+        set (EXE_CMD ${SCORPIO_SOURCE_DIR}/cmake/mpiexec.${PLATFORM} 
                      ${num_procs} ${VALGRIND_COMMAND} ${VALGRIND_COMMAND_OPTIONS} ${exec_file} ${exec_args})
                      
     endif ()

--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -772,7 +772,7 @@ INPUT                  = @CMAKE_CURRENT_SOURCE_DIR@/source \
                          @CMAKE_CURRENT_SOURCE_DIR@/../src/flib \
                          @CMAKE_CURRENT_SOURCE_DIR@/../examples/c \
                          @CMAKE_CURRENT_SOURCE_DIR@/../examples/f03 \
-                         @CMAKE_BINARY_DIR@/src/flib \
+                         @SCORPIO_BINARY_DIR@/src/flib \
 			 @C_SRC_FILES@
 
 # Uncomment this after the async code is fully merged into PIO.
@@ -818,8 +818,8 @@ RECURSIVE              = YES
 # run.
 
 EXCLUDE                = gptl \
-		         @CMAKE_BINARY_DIR@/src/flib/*.dir \
-		         @CMAKE_BINARY_DIR@/src/flib/genf90 \
+		         @SCORPIO_BINARY_DIR@/src/flib/*.dir \
+		         @SCORPIO_BINARY_DIR@/src/flib/genf90 \
                          _UNUSED_
 
 # The EXCLUDE_SYMLINKS tag can be used to select whether or not files or

--- a/examples/adios/CMakeLists.txt
+++ b/examples/adios/CMakeLists.txt
@@ -4,7 +4,7 @@
 
 # Include PIO include and lib directories
 INCLUDE_DIRECTORIES(${PIO_INCLUDE_DIRS})
-include_directories("${CMAKE_SOURCE_DIR}/examples/adios")
+include_directories("${SCORPIO_SOURCE_DIR}/examples/adios")
 LINK_DIRECTORIES(${PIO_LIB_DIR})
 
 # Compiler-specific compiler options

--- a/examples/c/CMakeLists.txt
+++ b/examples/c/CMakeLists.txt
@@ -4,7 +4,7 @@
 
 # Include PIO include and lib directories
 INCLUDE_DIRECTORIES(${PIO_INCLUDE_DIRS})
-include_directories("${CMAKE_SOURCE_DIR}/examples/c")
+include_directories("${SCORPIO_SOURCE_DIR}/examples/c")
 LINK_DIRECTORIES(${PIO_LIB_DIR})
 
 # Compiler-specific compiler options

--- a/src/flib/CMakeLists.txt
+++ b/src/flib/CMakeLists.txt
@@ -99,7 +99,7 @@ install (FILES ${PIO_Fortran_MODS} DESTINATION include)
 
 #===== genf90 =====
 if (NOT DEFINED GENF90_PATH)
-  set (GENF90_PATH ${CMAKE_SOURCE_DIR}/src/genf90)
+  set (GENF90_PATH ${SCORPIO_SOURCE_DIR}/src/genf90)
 endif ()
 add_custom_target(genf90
   DEPENDS ${GENF90_PATH}/genf90.pl)

--- a/tests/cunit/CMakeLists.txt
+++ b/tests/cunit/CMakeLists.txt
@@ -1,6 +1,6 @@
 include (LibMPI)
 
-include_directories("${CMAKE_SOURCE_DIR}/tests/cunit" "${CMAKE_BINARY_DIR}/src/clib")
+include_directories("${SCORPIO_SOURCE_DIR}/tests/cunit" "${SCORPIO_BINARY_DIR}/src/clib")
 
 # Compiler-specific compiler options
 string (TOUPPER "${CMAKE_C_COMPILER_ID}" CMAKE_C_COMPILER_NAME)

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -1,6 +1,6 @@
 include (LibMPI)
 
-include_directories("${CMAKE_SOURCE_DIR}/tests/unit")
+include_directories("${SCORPIO_SOURCE_DIR}/tests/unit")
 
 #==============================================================================
 #  PREPARE FOR TESTING

--- a/tools/adios2pio-nm/CMakeLists.txt
+++ b/tools/adios2pio-nm/CMakeLists.txt
@@ -2,7 +2,7 @@
 ### CMakeList.txt for adios2pio 
 ###-------------------------------------------------------------------------###
 
-list (APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
+list (APPEND CMAKE_MODULE_PATH ${SCORPIO_SOURCE_DIR}/cmake)
 
 # Adding PIO definitions - defined in the root directory
 ADD_DEFINITIONS(${PIO_DEFINITIONS})
@@ -20,16 +20,16 @@ else ()
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 endif ()
 
-SET(SRC ${CMAKE_SOURCE_DIR}/tools/util/argparser.cxx adios2pio-nm.cxx)
+SET(SRC ${SCORPIO_SOURCE_DIR}/tools/util/argparser.cxx adios2pio-nm.cxx)
 add_library(adios2pio-nm-lib adios2pio-nm-lib.cxx)
 include_directories(
   "${PROJECT_SOURCE_DIR}"   # to find foo/foo.h
   "${PROJECT_BINARY_DIR}")  # to find foo/config.h
 
 target_include_directories(adios2pio-nm-lib PUBLIC 
-  ${CMAKE_SOURCE_DIR}/src/clib
-  ${CMAKE_BINARY_DIR}/src/clib
-  ${CMAKE_SOURCE_DIR}/tools/util
+  ${SCORPIO_SOURCE_DIR}/src/clib
+  ${SCORPIO_BINARY_DIR}/src/clib
+  ${SCORPIO_SOURCE_DIR}/tools/util
   ${NETCDF_C_INCLUDE_DIRS} 
   ${PnetCDF_C_INCLUDE_DIRS} 
   ${PIO_C_EXTRA_INCLUDE_DIRS})

--- a/tools/spio_finfo/CMakeLists.txt
+++ b/tools/spio_finfo/CMakeLists.txt
@@ -17,9 +17,9 @@ else ()
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 endif ()
 
-set(SRC ${CMAKE_SOURCE_DIR}/tools/util/argparser.cxx
-    ${CMAKE_SOURCE_DIR}/tools/util/spio_misc_tool_utils.cxx
-    ${CMAKE_SOURCE_DIR}/tools/util/spio_lib_info.cxx
+set(SRC ${SCORPIO_SOURCE_DIR}/tools/util/argparser.cxx
+    ${SCORPIO_SOURCE_DIR}/tools/util/spio_misc_tool_utils.cxx
+    ${SCORPIO_SOURCE_DIR}/tools/util/spio_lib_info.cxx
     spio_file_test_utils.cxx
     spio_finfo.cxx
     spio_finfo_tool.cxx)
@@ -31,9 +31,9 @@ add_executable(spio_finfo.exe ${SRC})
 link_directories(${PIO_LIB_DIR})
 target_include_directories(spio_finfo.exe PRIVATE
   ${PIO_INCLUDE_DIRS}
-  ${CMAKE_BINARY_DIR}/src/clib
-  ${CMAKE_SOURCE_DIR}/src/clib
-  ${CMAKE_SOURCE_DIR}/tools/util
+  ${SCORPIO_BINARY_DIR}/src/clib
+  ${SCORPIO_SOURCE_DIR}/src/clib
+  ${SCORPIO_SOURCE_DIR}/tools/util
   ${NETCDF_C_INCLUDE_DIRS} 
   ${PnetCDF_C_INCLUDE_DIRS} 
   ${PIO_C_EXTRA_INCLUDE_DIRS})


### PR DESCRIPTION
Using \<PROJECT\>\_[SOURCE|BINARY]\_DIR instead of
CMAKE\_[SOURCE|BINARY]\_DIR.

These are more flexible than the CMAKE counterparts, since they
allow correct behavior even if scorpio is added as a subdirectory
inside another cmake project.

Fixes #342