### PR TITLE
Increase the default pio_buffer_size_limit

### DIFF
--- a/src/clib/pio_darray.c
+++ b/src/clib/pio_darray.c
@@ -21,8 +21,8 @@
 #include <stdint.h>
 #endif
 
-/* 10MB default limit. */
-PIO_Offset pio_buffer_size_limit = 10485760;
+/* 64MB default limit. */
+PIO_Offset pio_buffer_size_limit = 67108864;
 
 /* Maximum buffer usage. */
 PIO_Offset maxusage = 0;

--- a/tests/cunit/test_iosystem2_simple.c
+++ b/tests/cunit/test_iosystem2_simple.c
@@ -26,8 +26,8 @@
 #define BASE 0
 #define REARRANGER 1
 
-/* Ten megabytes. */
-#define TEN_MEG 10485760
+/* Sixty-four megabytes. */
+#define SIXTY_FOUR_MB 67108864
 
 /* Run test. */
 int main(int argc, char **argv)
@@ -56,9 +56,9 @@ int main(int argc, char **argv)
 
         /* Try setting the buffer size limit. */
         oldlimit = PIOc_set_buffer_size_limit(200000);
-        if (oldlimit != TEN_MEG)
+        if (oldlimit != SIXTY_FOUR_MB)
             ERR(ERR_WRONG);
-        oldlimit = PIOc_set_buffer_size_limit(TEN_MEG);
+        oldlimit = PIOc_set_buffer_size_limit(SIXTY_FOUR_MB);
 
         /* Figure out iotypes. */
         if ((ret = get_iotypes(&num_flavors, flavor)))

--- a/tools/adios2pio-nm/adios2pio-nm-lib.cxx
+++ b/tools/adios2pio-nm/adios2pio-nm-lib.cxx
@@ -293,6 +293,10 @@ int InitPIO(MPI_Comm comm, int mpirank, int nproc)
     int ret = PIO_NOERR;
     int iosysid;
 
+    /* For the conversion tool, increase pio_buffer_size_limit to 128MB by default */
+    const PIO_Offset new_buffer_size_limit = 134217728;
+    PIOc_set_buffer_size_limit(new_buffer_size_limit);
+
     ret = PIOc_Init_Intracomm(comm, nproc, 1, 0, PIO_REARR_BOX, &iosysid);
     if (ret != PIO_NOERR)
         return BP2PIO_ERROR;


### PR DESCRIPTION
For the default case, we just increase the buffer size limit from
10MB to 64MB.

For ADIOS conversion tool, increase the limit to 128MB by
default to get it working for E3SM.

In addition to this short-term fix, a planned long-term fix would
provide an option for the conversion tool to set the limit to a
larger value during run time.