### PR TITLE
Stop GPTL timers on error

### DIFF
--- a/src/clib/gptl_skel.h
+++ b/src/clib/gptl_skel.h
@@ -1,0 +1,13 @@
+#ifndef __GPTL_SKEL_H__
+#define __GPTL_SKEL_H__
+
+/* Defining GPTL macros to noops allows us to write cleaner
+ * code without #ifdef TIMING blocks around these function
+ * names
+ */
+#ifndef TIMING
+#define GPTLstart(tname) do{ }while(0)
+#define GPTLstop(tname) do{ }while(0)
+#endif
+
+#endif /* __GPTL_SKEL_H__ */

--- a/src/clib/pio_darray.c
+++ b/src/clib/pio_darray.c
@@ -222,7 +222,10 @@ int PIOc_write_darray_multi(int ncid, const int *varids, int ioid, int nvars,
 
         /* Share results known only on computation tasks with IO tasks. */
         if ((mpierr = MPI_Bcast(&fndims, 1, MPI_INT, ios->comproot, ios->my_comm)))
-            check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
+        {
+            GPTLstop("PIO:PIOc_write_darray_multi");
+            return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
+        }
         LOG((3, "shared fndims = %d", fndims));
     }
 
@@ -1783,7 +1786,7 @@ int PIOc_read_darray(int ncid, int varid, int ioid, PIO_Offset arraylen,
         if(mpierr != MPI_SUCCESS)
         {
             GPTLstop("PIO:PIOc_read_darray");
-            check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
+            return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
         }
         LOG((3, "shared fndims = %d", fndims));
     }

--- a/src/clib/pio_darray.c
+++ b/src/clib/pio_darray.c
@@ -119,9 +119,7 @@ int PIOc_write_darray_multi(int ncid, const int *varids, int ioid, int nvars,
     int mpierr = MPI_SUCCESS;  /* Return code from MPI function calls. */
     int ierr = PIO_NOERR;              /* Return code. */
 
-#ifdef TIMING
     GPTLstart("PIO:PIOc_write_darray_multi");
-#endif
     /* Get the file info. */
     if ((ierr = pio_get_file(ncid, &file)))
     {
@@ -520,9 +518,7 @@ int PIOc_write_darray_multi(int ncid, const int *varids, int ioid, int nvars,
         file->wb_pend = 0;
     }
 
-#ifdef TIMING
     GPTLstop("PIO:PIOc_write_darray_multi");
-#endif
     return PIO_NOERR;
 }
 
@@ -1242,9 +1238,7 @@ int PIOc_write_darray(int ncid, int varid, int ioid, PIO_Offset arraylen, void *
     int mpierr = MPI_SUCCESS;  /* Return code from MPI functions. */
     int ierr = PIO_NOERR;  /* Return code. */
 
-#ifdef TIMING
     GPTLstart("PIO:PIOc_write_darray");
-#endif
     LOG((1, "PIOc_write_darray ncid = %d varid = %d ioid = %d arraylen = %d",
          ncid, varid, ioid, arraylen));
 
@@ -1256,11 +1250,9 @@ int PIOc_write_darray(int ncid, int varid, int ioid, PIO_Offset arraylen, void *
     }
     ios = file->iosystem;
 
-#ifdef TIMING
 #ifdef _ADIOS2 /* TAHSIN: timing */
     if (file->iotype == PIO_IOTYPE_ADIOS)
         GPTLstart("PIO:PIOc_write_darray_adios"); /* TAHSIN: start */
-#endif
 #endif
 
     LOG((1, "PIOc_write_darray ncid=%d varid=%d wb_pend=%llu file_wb_pend=%llu",
@@ -1346,10 +1338,8 @@ int PIOc_write_darray(int ncid, int varid, int ioid, PIO_Offset arraylen, void *
     if (file->iotype == PIO_IOTYPE_ADIOS)
     {
         ierr = PIOc_write_darray_adios(file, varid, ioid, iodesc, arraylen, array, fillvalue);
-#ifdef TIMING
         GPTLstop("PIO:PIOc_write_darray_adios"); /* TAHSIN: stop */
         GPTLstop("PIO:PIOc_write_darray");
-#endif
         return ierr;
     }
 #endif
@@ -1600,9 +1590,7 @@ int PIOc_write_darray(int ncid, int varid, int ioid, PIO_Offset arraylen, void *
 #ifdef PIO_MICRO_TIMING
     mtimer_stop(file->varlist[varid].wr_mtimer, get_var_desc_str(ncid, varid, NULL));
 #endif
-#ifdef TIMING
     GPTLstop("PIO:PIOc_write_darray");
-#endif
     return PIO_NOERR;
 }
 
@@ -1634,9 +1622,7 @@ int PIOc_read_darray(int ncid, int varid, int ioid, PIO_Offset arraylen,
     int ierr = PIO_NOERR, mpierr = MPI_SUCCESS;           /* Return code. */
     int fndims = 0;
 
-#ifdef TIMING
     GPTLstart("PIO:PIOc_read_darray");
-#endif
     /* Get the file info. */
     if ((ierr = pio_get_file(ncid, &file)))
     {
@@ -1802,8 +1788,6 @@ int PIOc_read_darray(int ncid, int varid, int ioid, PIO_Offset arraylen,
 #ifdef PIO_MICRO_TIMING
     mtimer_stop(file->varlist[varid].rd_mtimer, get_var_desc_str(ncid, varid, NULL));
 #endif
-#ifdef TIMING
     GPTLstop("PIO:PIOc_read_darray");
-#endif
     return PIO_NOERR;
 }

--- a/src/clib/pio_darray_int.c
+++ b/src/clib/pio_darray_int.c
@@ -176,10 +176,8 @@ int write_darray_multi_par(file_desc_t *file, int nvars, int fndims, const int *
          "iodesc->maxregions = %d iodesc->llen = %d", nvars, iodesc->ndims,
          iodesc->mpitype, iodesc->maxregions, iodesc->llen));
 
-#ifdef TIMING
     /* Start timing this function. */
     GPTLstart("PIO:write_darray_multi_par");
-#endif
 
     /* Get pointer to iosystem. */
     ios = file->iosystem;
@@ -438,10 +436,8 @@ int write_darray_multi_par(file_desc_t *file, int nvars, int fndims, const int *
     /* Check the return code from the netCDF/pnetcdf call. */
     ierr = check_netcdf(NULL, file, ierr, __FILE__,__LINE__);
 
-#ifdef TIMING
     /* Stop timing this function. */
     GPTLstop("PIO:write_darray_multi_par");
-#endif
 
     return ierr;
 }
@@ -858,10 +854,8 @@ int write_darray_multi_serial(file_desc_t *file, int nvars, int fndims, const in
     PIO_Offset llen = fill ? iodesc->holegridsize : iodesc->llen;
     void *iobuf = fill ? vdesc->fillbuf : file->iobuf[iodesc->ioid - PIO_IODESC_START_ID];
 
-#ifdef TIMING
     /* Start timing this function. */
     GPTLstart("PIO:write_darray_multi_serial");
-#endif
 
     /* Only IO tasks participate in this code. */
     if (ios->ioproc)
@@ -915,10 +909,8 @@ int write_darray_multi_serial(file_desc_t *file, int nvars, int fndims, const in
                         "Writing multiple variables (number of variables = %d) to file (%s, ncid=%d) using serial I/O failed. Internal error in I/O processes finding/sending/receiving start/count of I/O regions to write to file", nvars, pio_get_fname_from_file(file), file->pio_ncid);
     }
 
-#ifdef TIMING
     /* Stop timing this function. */
     GPTLstop("PIO:write_darray_multi_serial");
-#endif
 
     return PIO_NOERR;
 }
@@ -953,10 +945,8 @@ int pio_read_darray_nc(file_desc_t *file, int fndims, io_desc_t *iodesc, int vid
     pioassert(file && (fndims > 0) && file->iosystem && iodesc && vid <= PIO_MAX_VARS, "invalid input",
               __FILE__, __LINE__);
 
-#ifdef TIMING
     /* Start timing this function. */
     GPTLstart("PIO:read_darray_nc");
-#endif
 
     /* Get the IO system info. */
     ios = file->iosystem;
@@ -1170,10 +1160,8 @@ int pio_read_darray_nc(file_desc_t *file, int fndims, io_desc_t *iodesc, int vid
                         "Reading variable (%s, varid=%d) from file (%s, ncid=%d) failed with iotype=%s. The underlying I/O library (%s) call, nc*_get_var*, failed.", pio_get_vname_from_file(file, vid), vid, pio_get_fname_from_file(file), file->pio_ncid, pio_iotype_to_string(file->iotype), (file->iotype == PIO_IOTYPE_NETCDF4P) ? "NetCDF" : "PnetCDF");
     }
 
-#ifdef TIMING
     /* Stop timing this function. */
     GPTLstop("PIO:read_darray_nc");
-#endif
 
     return PIO_NOERR;
 }
@@ -1213,10 +1201,8 @@ int pio_read_darray_nc_serial(file_desc_t *file, int fndims, io_desc_t *iodesc, 
     pioassert(file && (fndims > 0) && file->iosystem && iodesc && vid >= 0 && vid <= PIO_MAX_VARS,
               "invalid input", __FILE__, __LINE__);
 
-#ifdef TIMING
     /* Start timing this function. */
     GPTLstart("PIO:read_darray_nc_serial");
-#endif
     ios = file->iosystem;
 
     /* Get var info for this var. */
@@ -1484,10 +1470,8 @@ int pio_read_darray_nc_serial(file_desc_t *file, int fndims, io_desc_t *iodesc, 
                         "Reading variable (%s, varid=%d) from file (%s, ncid=%d) with serial I/O failed. The underlying I/O library call to write data failed on root I/O process", pio_get_vname_from_file(file, vid), vid, pio_get_fname_from_file(file), file->pio_ncid);
     }
 
-#ifdef TIMING
     /* Stop timing this function. */
     GPTLstop("PIO:read_darray_nc_serial");
-#endif
 
     return PIO_NOERR;
 }
@@ -1811,9 +1795,7 @@ int flush_output_buffer(file_desc_t *file, bool force, PIO_Offset addsize)
     int mpierr = MPI_SUCCESS;  /* Return code from MPI functions. */
     int ierr = PIO_NOERR;
 
-#ifdef TIMING
     GPTLstart("PIO:flush_output_buffer");
-#endif
 #ifdef _PNETCDF
     var_desc_t *vdesc;
     PIO_Offset usage = 0;
@@ -2078,9 +2060,7 @@ int flush_output_buffer(file_desc_t *file, bool force, PIO_Offset addsize)
     }
 
 #endif /* _PNETCDF */
-#ifdef TIMING
     GPTLstop("PIO:flush_output_buffer");
-#endif
     return ierr;
 }
 
@@ -2146,9 +2126,7 @@ int flush_buffer(int ncid, wmulti_buffer *wmb, bool flushtodisk)
     file_desc_t *file;
     int ret;
 
-#ifdef TIMING
     GPTLstart("PIO:flush_buffer");
-#endif
     /* Check input. */
     pioassert(wmb, "invalid input", __FILE__, __LINE__);
 
@@ -2197,9 +2175,7 @@ int flush_buffer(int ncid, wmulti_buffer *wmb, bool flushtodisk)
         }
     }
 
-#ifdef TIMING
     GPTLstop("PIO:flush_buffer");
-#endif
     return PIO_NOERR;
 }
 

--- a/src/clib/pio_file.c
+++ b/src/clib/pio_file.c
@@ -132,13 +132,11 @@ int PIOc_createfile(int iosysid, int *ncidp, int *iotype, const char *filename,
     iosystem_desc_t *ios;  /* Pointer to io system information. */
     int ret;               /* Return code from function calls. */
 
-#ifdef TIMING
     GPTLstart("PIO:PIOc_createfile");
 
 #ifdef _ADIOS2 /* TAHSIN: timing */
     if (*iotype == PIO_IOTYPE_ADIOS)
         GPTLstart("PIO:PIOc_createfile_adios"); /* TAHSIN: start */
-#endif
 #endif
 
     /* Get the IO system info from the id. */
@@ -151,13 +149,11 @@ int PIOc_createfile(int iosysid, int *ncidp, int *iotype, const char *filename,
     /* Create the file. */
     if ((ret = PIOc_createfile_int(iosysid, ncidp, iotype, filename, mode)))
     {
-#ifdef TIMING
         GPTLstop("PIO:PIOc_createfile");
 
 #ifdef _ADIOS2 /* TAHSIN: timing */
         if (*iotype == PIO_IOTYPE_ADIOS)
             GPTLstop("PIO:PIOc_createfile_adios"); /* TAHSIN: stop */
-#endif
 #endif
 
         return pio_err(ios, NULL, ret, __FILE__, __LINE__,
@@ -178,13 +174,11 @@ int PIOc_createfile(int iosysid, int *ncidp, int *iotype, const char *filename,
         }
     }
 
-#ifdef TIMING
     GPTLstop("PIO:PIOc_createfile");
 
 #ifdef _ADIOS2 /* TAHSIN: timing */
     if (*iotype == PIO_IOTYPE_ADIOS)
         GPTLstop("PIO:PIOc_createfile_adios"); /* TAHSIN: stop */
-#endif
 #endif
 
     return ret;
@@ -373,9 +367,7 @@ int PIOc_closefile(int ncid)
     size_t len = 0;
 #endif
 
-#ifdef TIMING
     GPTLstart("PIO:PIOc_closefile");
-#endif
     LOG((1, "PIOc_closefile ncid = %d", ncid));
 
     /* Find the info about this file. */
@@ -386,7 +378,6 @@ int PIOc_closefile(int ncid)
     }
     ios = file->iosystem;
 
-#ifdef TIMING
 #ifdef _ADIOS2 /* TAHSIN: timing */
     if (file->iotype == PIO_IOTYPE_ADIOS)
         GPTLstart("PIO:PIOc_closefile_adios"); /* TAHSIN: start */
@@ -394,7 +385,6 @@ int PIOc_closefile(int ncid)
 
     if (file->mode & PIO_WRITE)
         GPTLstart("PIO:PIOc_closefile_write_mode");
-#endif
 
     /* Sync changes before closing on all tasks if async is not in
      * use, but only on non-IO tasks if async is in use. */
@@ -502,20 +492,16 @@ int PIOc_closefile(int ncid)
 
         free(file->filename);
 
-#ifdef TIMING
         if (file->iotype == PIO_IOTYPE_ADIOS)
             GPTLstop("PIO:PIOc_closefile_adios"); /* TAHSIN: stop */
 
         if (file->mode & PIO_WRITE)
             GPTLstop("PIO:PIOc_closefile_write_mode");
-#endif
 
         /* Delete file from our list of open files. */
         pio_delete_file_from_list(ncid);
 
-#ifdef TIMING
         GPTLstop("PIO:PIOc_closefile");
-#endif
 
         return PIO_NOERR;
     }
@@ -559,17 +545,13 @@ int PIOc_closefile(int ncid)
                         "Closing file (%s, ncid=%d) failed. Underlying I/O library (iotype=%s) call failed", pio_get_fname_from_file(file), file->pio_ncid, pio_iotype_to_string(file->iotype));
     }
 
-#ifdef TIMING
     if (file->mode & PIO_WRITE)
         GPTLstop("PIO:PIOc_closefile_write_mode");
-#endif
 
     /* Delete file from our list of open files. */
     pio_delete_file_from_list(ncid);
 
-#ifdef TIMING
     GPTLstop("PIO:PIOc_closefile");
-#endif
     return ierr;
 }
 
@@ -589,9 +571,7 @@ int PIOc_deletefile(int iosysid, const char *filename)
      int msg = PIO_MSG_DELETE_FILE;
     size_t len;
 
-#ifdef TIMING
     GPTLstart("PIO:PIOc_deletefile");
-#endif
     LOG((1, "PIOc_deletefile iosysid = %d filename = %s", iosysid, filename));
 
     /* Get the IO system info from the id. */
@@ -640,9 +620,7 @@ int PIOc_deletefile(int iosysid, const char *filename)
                     "Deleting file (%s) failed. Internal I/O library call failed.", (filename) ? filename : "NULL");
     }
 
-#ifdef TIMING
     GPTLstop("PIO:PIOc_deletefile");
-#endif
     return ierr;
 }
 
@@ -662,16 +640,12 @@ int PIOc_sync(int ncid)
 {
     int ierr = PIO_NOERR;  /* Return code from function calls. */
 
-#ifdef TIMING
     GPTLstart("PIO:PIOc_sync");
-#endif
 
     LOG((1, "PIOc_sync ncid = %d", ncid));
 
     ierr = sync_file(ncid);
 
-#ifdef TIMING
     GPTLstop("PIO:PIOc_sync");
-#endif
     return ierr;
 }

--- a/src/clib/pio_getput_int.c
+++ b/src/clib/pio_getput_int.c
@@ -43,19 +43,21 @@ int PIOc_put_att_tc(int ncid, int varid, const char *name, nc_type atttype,
     /* Find the info about this file. */
     if ((ierr = pio_get_file(ncid, &file)))
     {
+        GPTLstop("PIO:PIOc_put_att_tc");
         return pio_err(NULL, NULL, ierr, __FILE__, __LINE__,
                         "Writing variable (varid=%d) attribute (%s) to file failed. Invalid file id (ncid=%d) provided", varid, (name) ? name : "NULL", ncid);
     }
     ios = file->iosystem;
 
-#ifdef _ADIOS2 /* TAHSIN: timing */
     if (file->iotype == PIO_IOTYPE_ADIOS)
-        GPTLstart("PIO:PIOc_put_att_tc_adios"); /* TAHSIN: start */
-#endif
+        GPTLstart("PIO:PIOc_put_att_tc_adios");
 
     /* User must provide some valid parameters. */
     if (!name || !op || strlen(name) > PIO_MAX_NAME || len < 0)
     {
+        GPTLstop("PIO:PIOc_put_att_tc");
+        if (file->iotype == PIO_IOTYPE_ADIOS)
+            GPTLstop("PIO:PIOc_put_att_tc_adios");
         return pio_err(ios, file, PIO_EINVAL, __FILE__, __LINE__,
                         "Writing variable (%s, varid=%d) attribute (%s) to file (%s, ncid=%d) failed. Invalid arguments provided, Attribute name (name) is %s (expected not NULL), Attribute data pointer (op) is %s (expected not NULL), Attribute name length is %lld (expected <= %d), Attribute length is %lld (expected >= 0)", pio_get_vname_from_file(file, varid), varid, PIO_IS_NULL(name), pio_get_fname_from_file(file), file->pio_ncid, PIO_IS_NULL(name), PIO_IS_NULL(op), (name) ? ((unsigned long long )strlen(name)) : 0,  PIO_MAX_NAME, (unsigned long long ) len);
     }
@@ -71,6 +73,9 @@ int PIOc_put_att_tc(int ncid, int varid, const char *name, nc_type atttype,
         ierr = PIOc_inq_type(ncid, atttype, NULL, &atttype_len);
         if(ierr != PIO_NOERR){
             LOG((1, "PIOc_inq_type failed, ierr = %d", ierr));
+            GPTLstop("PIO:PIOc_put_att_tc");
+            if (file->iotype == PIO_IOTYPE_ADIOS)
+                GPTLstop("PIO:PIOc_put_att_tc_adios");
             return ierr;
         }
 
@@ -81,6 +86,9 @@ int PIOc_put_att_tc(int ncid, int varid, const char *name, nc_type atttype,
         {
             ierr = PIOc_inq_type(ncid, memtype, NULL, &memtype_len);
             if(ierr != PIO_NOERR){
+                GPTLstop("PIO:PIOc_put_att_tc");
+                if (file->iotype == PIO_IOTYPE_ADIOS)
+                    GPTLstop("PIO:PIOc_put_att_tc_adios");
                 LOG((1, "PIOc_inq_type failed, ierr = %d", ierr));
                 return ierr;
             }
@@ -99,6 +107,9 @@ int PIOc_put_att_tc(int ncid, int varid, const char *name, nc_type atttype,
             len * memtype_len, op);
         if(ierr != PIO_NOERR)
         {
+            GPTLstop("PIO:PIOc_put_att_tc");
+            if (file->iotype == PIO_IOTYPE_ADIOS)
+                GPTLstop("PIO:PIOc_put_att_tc_adios");
             return pio_err(ios, NULL, ierr, __FILE__, __LINE__,
                             "Writing variable (%s, varid=%d) attribute (%s) to file (%s, ncid=%d) failed. Error sending asynchronous message, PIO_MSG_PUT_ATT",  pio_get_vname_from_file(file, varid), varid, name, pio_get_fname_from_file(file), file->pio_ncid);
         }
@@ -138,6 +149,9 @@ int PIOc_put_att_tc(int ncid, int varid, const char *name, nc_type atttype,
         if (num_attrs >= PIO_MAX_VARS)
         {
             fprintf(stderr, "ERROR: Num of attributes exceeds maximum (%d).\n", PIO_MAX_VARS);
+            GPTLstop("PIO:PIOc_put_att_tc");
+            if (file->iotype == PIO_IOTYPE_ADIOS)
+                GPTLstop("PIO:PIOc_put_att_tc_adios");
             return PIO_EMAXATTS;
         }
         file->adios_attrs[num_attrs].att_name = strdup(name);
@@ -160,16 +174,17 @@ int PIOc_put_att_tc(int ncid, int varid, const char *name, nc_type atttype,
 
             if (attributeH == NULL)
             {
+                GPTLstop("PIO:PIOc_put_att_tc");
+                if (file->iotype == PIO_IOTYPE_ADIOS)
+                    GPTLstop("PIO:PIOc_put_att_tc_adios");
                 return pio_err(ios, file, PIO_EADIOS2ERR, __FILE__, __LINE__, "Defining (ADIOS) attribute (name=%s) failed for file (%s, ncid=%d)", att_name, pio_get_fname_from_file(file), file->pio_ncid);
             }
         }
 
         GPTLstop("PIO:PIOc_put_att_tc");
 
-#ifdef _ADIOS2 /* TAHSIN: timing */
         if (file->iotype == PIO_IOTYPE_ADIOS)
-            GPTLstop("PIO:PIOc_put_att_tc_adios"); /* TAHSIN: stop */
-#endif
+            GPTLstop("PIO:PIOc_put_att_tc_adios");
 
         return PIO_NOERR;
     }
@@ -205,6 +220,7 @@ int PIOc_put_att_tc(int ncid, int varid, const char *name, nc_type atttype,
                 ierr = ncmpi_put_att_double(file->fh, varid, name, atttype, len, op);
                 break;
             default:
+                GPTLstop("PIO:PIOc_put_att_tc");
                 return pio_err(ios, file, PIO_EBADTYPE, __FILE__, __LINE__,
                                 "Writing variable (%s, varid=%d) attribute (%s) to file (%s, ncid=%d) failed. Unsupported PnetCDF attribute type (memtype = %x)", pio_get_vname_from_file(file, varid), varid, name, pio_get_fname_from_file(file), file->pio_ncid, memtype);
             }
@@ -260,6 +276,7 @@ int PIOc_put_att_tc(int ncid, int varid, const char *name, nc_type atttype,
                 /*      break; */
 #endif /* _NETCDF4 */
             default:
+                GPTLstop("PIO:PIOc_put_att_tc");
                 return pio_err(ios, file, PIO_EBADTYPE, __FILE__, __LINE__,
                                 "Writing variable (%s, varid=%d) attribute (%s) to file (%s, ncid=%d) failed. Unsupported attribute type (memtype = %x)", pio_get_vname_from_file(file, varid), varid, name, pio_get_fname_from_file(file), file->pio_ncid, memtype);
             }
@@ -269,6 +286,7 @@ int PIOc_put_att_tc(int ncid, int varid, const char *name, nc_type atttype,
     ierr = check_netcdf(NULL, file, ierr, __FILE__, __LINE__);
     if(ierr != PIO_NOERR){
         LOG((1, "nc*_put_att_* failed, ierr = %d", ierr));
+        GPTLstop("PIO:PIOc_put_att_tc");
         return pio_err(NULL, file, ierr, __FILE__, __LINE__,
                         "Writing variable (%s, varid=%d) attribute (%s) to file (%s, ncid=%d) failed. Internal I/O library (%s) call failed", pio_get_vname_from_file(file, varid), varid, name, pio_get_fname_from_file(file), file->pio_ncid, pio_iotype_to_string(file->iotype));
     }
@@ -310,6 +328,7 @@ int PIOc_get_att_tc(int ncid, int varid, const char *name, nc_type memtype, void
     /* Find the info about this file. */
     if ((ierr = pio_get_file(ncid, &file)))
     {
+        GPTLstop("PIO:PIOc_get_att_tc");
         return pio_err(NULL, NULL, ierr, __FILE__, __LINE__,
                         "Reading attribute (%s) from file failed. Invalid file id (ncid=%d) provided", (name) ? name : "NULL", ncid);
     }
@@ -318,6 +337,7 @@ int PIOc_get_att_tc(int ncid, int varid, const char *name, nc_type memtype, void
     /* User must provide a name and destination pointer. */
     if (!name || !ip || strlen(name) > PIO_MAX_NAME)
     {
+        GPTLstop("PIO:PIOc_get_att_tc");
         return pio_err(ios, file, PIO_EINVAL, __FILE__, __LINE__,
                         "Reading variable (%s, varid=%d) attribute (%s) failed. Invalid arguments provided, Attribute name is %s (expected not NULL), attribute data pointer is %s (expected not NULL), attribute name length = %lld (expected <= %d)", pio_get_vname_from_file(file, varid), varid, (name) ? name : "UNKNOWN", PIO_IS_NULL(name), PIO_IS_NULL(ip), (name) ? ((unsigned long long )strlen(name)) : 0, PIO_MAX_NAME);
     }
@@ -333,14 +353,7 @@ int PIOc_get_att_tc(int ncid, int varid, const char *name, nc_type memtype, void
         ierr = PIOc_inq_att(ncid, varid, name, &atttype, &attlen);
         if(ierr != PIO_NOERR){
             LOG((1, "PIOc_inq_att failed, ierr = %d", ierr));
-#ifdef TIMING
-            /* Failure to get an attribute is not considered
-             * as a fatal error by some users/apps (this case is
-             * considered similar to failure to inquire an
-             * attribute)
-             */
             GPTLstop("PIO:PIOc_get_att_tc");
-#endif
             return ierr;
         }
         LOG((2, "atttype = %d attlen = %d", atttype, attlen));
@@ -349,6 +362,7 @@ int PIOc_get_att_tc(int ncid, int varid, const char *name, nc_type memtype, void
         ierr = PIOc_inq_type(ncid, atttype, NULL, &atttype_len);
         if(ierr != PIO_NOERR){
             LOG((1, "PIOc_inq_type failed, ierr=%d", ierr));
+            GPTLstop("PIO:PIOc_get_att_tc");
             return ierr;
         }
 
@@ -361,6 +375,7 @@ int PIOc_get_att_tc(int ncid, int varid, const char *name, nc_type memtype, void
             ierr = PIOc_inq_type(ncid, memtype, NULL, &memtype_len);
             if(ierr != PIO_NOERR){
                 LOG((1, "PIOc_inq_type failed, ierr = %d", ierr));
+                GPTLstop("PIO:PIOc_get_att_tc");
                 return ierr;
             }
         }
@@ -378,6 +393,7 @@ int PIOc_get_att_tc(int ncid, int varid, const char *name, nc_type memtype, void
         if(ierr != PIO_NOERR)
         {
             LOG((1, "Error sending async msg for PIO_MSG_GET_ATT"));
+            GPTLstop("PIO:PIOc_get_att_tc");
             return pio_err(ios, NULL, ierr, __FILE__, __LINE__,
                             "Reading variable (%s, varid=%d) attribute (%s) failed. Error sending asynchronous message, PIO_MSG_GET_ATT", (varid != PIO_GLOBAL) ? file->varlist[varid].vname : "PIO_GLOBAL", varid, name);
         }
@@ -385,11 +401,20 @@ int PIOc_get_att_tc(int ncid, int varid, const char *name, nc_type memtype, void
         /* Broadcast values currently only known on computation tasks to IO tasks. */
         LOG((2, "PIOc_get_att_tc bcast from comproot = %d attlen = %d atttype_len = %d", ios->comproot, attlen, atttype_len));
         if ((mpierr = MPI_Bcast(&attlen, 1, MPI_OFFSET, ios->comproot, ios->my_comm)))
+        {
+            GPTLstop("PIO:PIOc_get_att_tc");
             return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
+        }
         if ((mpierr = MPI_Bcast(&atttype_len, 1, MPI_OFFSET, ios->comproot, ios->my_comm)))
+        {
+            GPTLstop("PIO:PIOc_get_att_tc");
             return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
+        }
         if ((mpierr = MPI_Bcast(&memtype_len, 1, MPI_OFFSET, ios->comproot, ios->my_comm)))
+        {
+            GPTLstop("PIO:PIOc_get_att_tc");
             return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
+        }
         LOG((2, "PIOc_get_att_tc bcast complete attlen = %d atttype_len = %d memtype_len = %d", attlen, atttype_len,
              memtype_len));
     }
@@ -425,6 +450,7 @@ int PIOc_get_att_tc(int ncid, int varid, const char *name, nc_type memtype, void
                 ierr = ncmpi_get_att_double(file->fh, varid, name, ip);
                 break;
             default:
+                GPTLstop("PIO:PIOc_get_att_tc");
                 return pio_err(ios, file, PIO_EBADTYPE, __FILE__, __LINE__,
                                 "Reading variable (%s, varid=%d) attribute (%s) failed. Unsupported PnetCDF attribute type (type = %x)", (varid != PIO_GLOBAL) ? file->varlist[varid].vname : "PIO_GLOBAL", varid, name, memtype);
             }
@@ -480,6 +506,7 @@ int PIOc_get_att_tc(int ncid, int varid, const char *name, nc_type memtype, void
                 /*      break; */
 #endif /* _NETCDF4 */
             default:
+                GPTLstop("PIO:PIOc_get_att_tc");
                 return pio_err(ios, file, PIO_EBADTYPE, __FILE__, __LINE__,
                                 "Reading variable (%s, varid=%d) attribute (%s) failed. Unsupported attribute type (type = %x)", (varid != PIO_GLOBAL) ? file->varlist[varid].vname : "PIO_GLOBAL", varid, name, memtype);
             }
@@ -489,14 +516,7 @@ int PIOc_get_att_tc(int ncid, int varid, const char *name, nc_type memtype, void
     ierr = check_netcdf(NULL, file, ierr, __FILE__, __LINE__);
     if(ierr != PIO_NOERR){
         LOG((1, "nc*_get_att_* failed, ierr = %d", ierr));
-#ifdef TIMING
-        /* Failure to get an attribute is not considered
-         * as a fatal error by some users/apps (this case is
-         * considered similar to failure to inquire an
-         * attribute)
-         */
         GPTLstop("PIO:PIOc_get_att_tc");
-#endif
         return pio_err(NULL, file, ierr, __FILE__, __LINE__,
                         "Reading variable (%s, varid=%d) attribute (%s) failed. Internal I/O library (%s) call failed", (varid != PIO_GLOBAL) ? file->varlist[varid].vname : "PIO_GLOBAL", varid, name, pio_iotype_to_string(file->iotype));
     }
@@ -505,7 +525,10 @@ int PIOc_get_att_tc(int ncid, int varid, const char *name, nc_type memtype, void
     LOG((2, "bcasting att values attlen = %d memtype_len = %d", attlen, memtype_len));
     if ((mpierr = MPI_Bcast(ip, (int)attlen * memtype_len, MPI_BYTE, ios->ioroot,
                             ios->my_comm)))
+    {
+        GPTLstop("PIO:PIOc_get_att_tc");
         return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
+    }
 
     LOG((2, "get_att_tc data bcast complete"));
     GPTLstop("PIO:PIOc_get_att_tc");
@@ -570,6 +593,7 @@ int PIOc_get_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
     /* Find the info about this file. */
     if ((ierr = pio_get_file(ncid, &file)))
     {
+        GPTLstop("PIO:PIOc_get_vars_tc");
         return pio_err(NULL, NULL, ierr, __FILE__, __LINE__,
                         "Reading variable (varid=%d) from file failed. Invalid file id (ncid=%d) provided", varid, ncid);
     }
@@ -578,6 +602,7 @@ int PIOc_get_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
     /* User must provide a place to put some data. */
     if (!buf)
     {
+        GPTLstop("PIO:PIOc_get_vars_tc");
         return pio_err(ios, file, PIO_EINVAL, __FILE__, __LINE__,
                         "Reading variable (%s, varid=%d) from file (%s, ncid=%d) failed. The user buffer (buf) provided is NULL (expected a valid user buffer to read data)", pio_get_vname_from_file(file, varid), varid, pio_get_fname_from_file(file), ncid);
     }
@@ -589,6 +614,7 @@ int PIOc_get_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
         /* Get the type of this var. */
         ierr = PIOc_inq_vartype(ncid, varid, &vartype);
         if(ierr != PIO_NOERR){
+            GPTLstop("PIO:PIOc_get_vars_tc");
             return pio_err(NULL, NULL, ierr, __FILE__, __LINE__,
                         "Reading variable (%s, varid=%d) from file (%s, ncid=%d) failed. Inquiring the variable type failed", pio_get_vname_from_file(file, varid), varid, pio_get_fname_from_file(file), ncid);
         }
@@ -604,6 +630,7 @@ int PIOc_get_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
         {
             ierr = PIOc_inq_type(ncid, xtype, NULL, &typelen);
             if(ierr != PIO_NOERR){
+                GPTLstop("PIO:PIOc_get_vars_tc");
                 return pio_err(NULL, NULL, ierr, __FILE__, __LINE__,
                             "Reading variable (%s, varid=%d) from file (%s, ncid=%d) failed. Inquiring the variable type length failed", pio_get_vname_from_file(file, varid), varid, pio_get_vname_from_file(file, varid), ncid);
             }
@@ -612,6 +639,7 @@ int PIOc_get_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
         /* Get the number of dims for this var. */
         ierr = PIOc_inq_varndims(ncid, varid, &ndims);
         if(ierr != PIO_NOERR){
+            GPTLstop("PIO:PIOc_get_vars_tc");
             return pio_err(NULL, NULL, ierr, __FILE__, __LINE__,
                         "Reading variable (%s, varid=%d) from file (%s, ncid=%d) failed. Inquiring the number of variable dimensions failed", pio_get_vname_from_file(file, varid), varid, pio_get_fname_from_file(file), ncid);
         }
@@ -659,6 +687,7 @@ int PIOc_get_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
                             xtype, num_elem, typelen);
         if(ierr != PIO_NOERR)
         {
+            GPTLstop("PIO:PIOc_get_vars_tc");
             return pio_err(ios, NULL, ierr, __FILE__, __LINE__,
                             "Reading variable (%s, varid=%d) from file (%s, ncid=%d) failed. Error sending asynchronous message, PIO_MSG_GET_VARS", pio_get_vname_from_file(file, varid), varid, pio_get_fname_from_file(file), ncid);
         }
@@ -696,6 +725,7 @@ int PIOc_get_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
             /* Turn on independent access for pnetcdf file. */
             if ((ierr = ncmpi_begin_indep_data(file->fh)))
             {
+                GPTLstop("PIO:PIOc_get_vars_tc");
                 return pio_err(ios, file, ierr, __FILE__, __LINE__,
                                 "Reading variable (%s, varid=%d) from file (%s, ncid=%d) failed. Starting independent (across processes) access failed on the file", pio_get_vname_from_file(file, varid), varid, pio_get_fname_from_file(file), ncid);
             }
@@ -728,6 +758,7 @@ int PIOc_get_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
                     ierr = ncmpi_get_vars_double(file->fh, varid, start, count, stride, buf);
                     break;
                 default:
+                    GPTLstop("PIO:PIOc_get_vars_tc");
                     return pio_err(ios, file, PIO_EBADIOTYPE, __FILE__, __LINE__,
                                     "Reading variable (%s, varid=%d) from file (%s, ncid=%d) failed. Unsupported variable type (type=%x)", pio_get_vname_from_file(file, varid), varid, pio_get_fname_from_file(file), ncid, xtype);
                 }
@@ -736,6 +767,7 @@ int PIOc_get_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
             /* Turn off independent access for pnetcdf file. */
             if ((ierr = ncmpi_end_indep_data(file->fh)))
             {
+                GPTLstop("PIO:PIOc_get_vars_tc");
                 return pio_err(ios, file, ierr, __FILE__, __LINE__,
                                 "Reading variable (%s, varid=%d) from file (%s, ncid=%d) failed. Ending independent (across processes) access failed on the file", pio_get_vname_from_file(file, varid), varid, pio_get_vname_from_file(file, varid), ncid);
             }
@@ -803,6 +835,7 @@ int PIOc_get_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
                 /*      break; */
 #endif /* _NETCDF4 */
             default:
+                GPTLstop("PIO:PIOc_get_vars_tc");
                 return pio_err(ios, file, PIO_EBADTYPE, __FILE__, __LINE__,
                                 "Reading variable (%s, varid=%d) from file (%s, ncid=%d) failed. Unsupported variable type (type=%x)", pio_get_vname_from_file(file, varid), varid, pio_get_fname_from_file(file), ncid, xtype);
             }
@@ -811,6 +844,7 @@ int PIOc_get_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
     ierr = check_netcdf(NULL, file, ierr, __FILE__, __LINE__);
     if(ierr != PIO_NOERR){
         LOG((1, "nc*_get_vars_* failed, ierr = %d", ierr));
+        GPTLstop("PIO:PIOc_get_vars_tc");
         return pio_err(NULL, file, ierr, __FILE__, __LINE__,
                         "Reading variable (%s, varid=%d) from file (%s, ncid=%d) failed. The internal I/O library (%s) call failed", pio_get_vname_from_file(file, varid), varid, pio_get_fname_from_file(file), ncid, pio_iotype_to_string(file->iotype));
     }
@@ -819,7 +853,10 @@ int PIOc_get_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
     LOG((2, "PIOc_get_vars_tc bcasting data num_elem = %d typelen = %d ios->ioroot = %d", num_elem,
          typelen, ios->ioroot));
     if ((mpierr = MPI_Bcast(buf, num_elem * typelen, MPI_BYTE, ios->ioroot, ios->my_comm)))
+    {
+        GPTLstop("PIO:PIOc_get_vars_tc");
         return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
+    }
     LOG((2, "PIOc_get_vars_tc bcasting data complete"));
 
     GPTLstop("PIO:PIOc_get_vars_tc");
@@ -1017,6 +1054,7 @@ int PIOc_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
     /* Get file info. */
     if ((ierr = pio_get_file(ncid, &file)))
     {
+        GPTLstop("PIO:PIOc_put_vars_tc");
         return pio_err(NULL, NULL, ierr, __FILE__, __LINE__,
                         "Writing variable (varid=%d) to file failed. Invalid file id (ncid=%d) provided", varid, ncid);
     }
@@ -1025,6 +1063,7 @@ int PIOc_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
     /* User must provide a place to put some data. */
     if (!buf)
     {
+        GPTLstop("PIO:PIOc_put_vars_tc");
         return pio_err(ios, file, PIO_EINVAL, __FILE__, __LINE__,
                         "Writing variable (%s, varid=%d) to file (%s, ncid=%d) failed. Invalid/NULL user buffer provided", pio_get_vname_from_file(file, varid), varid, pio_get_fname_from_file(file), ncid);
     }
@@ -1036,6 +1075,7 @@ int PIOc_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
         /* Get the type of this var. */
         ierr = PIOc_inq_vartype(ncid, varid, &vartype);
         if(ierr != PIO_NOERR){
+            GPTLstop("PIO:PIOc_put_vars_tc");
             return pio_err(NULL, NULL, ierr, __FILE__, __LINE__,
                             "Writing variable (%s, varid=%d) to file (%s, ncid=%d) failed. Inquiring variable type failed", pio_get_vname_from_file(file, varid), varid, pio_get_fname_from_file(file), ncid);
         }
@@ -1047,6 +1087,7 @@ int PIOc_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
         /* Get the number of dims for this var. */
         ierr = PIOc_inq_varndims(ncid, varid, &ndims);
         if(ierr != PIO_NOERR){
+            GPTLstop("PIO:PIOc_put_vars_tc");
             return pio_err(NULL, NULL, ierr, __FILE__, __LINE__,
                             "Writing variable (%s, varid=%d) to file (%s, ncid=%d) failed. Inquiring number of dimensions of the variable failed", pio_get_vname_from_file(file, varid), varid, pio_get_fname_from_file(file), ncid);
         }
@@ -1058,6 +1099,7 @@ int PIOc_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
         {
             ierr = PIOc_inq_type(ncid, xtype, NULL, &typelen);
             if(ierr != PIO_NOERR){
+                GPTLstop("PIO:PIOc_put_vars_tc");
                 return pio_err(NULL, NULL, ierr, __FILE__, __LINE__,
                                 "Writing variable (%s, varid=%d) to file (%s, ncid=%d) failed. Inquiring variable type length failed", pio_get_vname_from_file(file, varid), varid, pio_get_fname_from_file(file), ncid);
             }
@@ -1105,6 +1147,7 @@ int PIOc_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
                             num_elem * typelen, buf); 
         if(ierr != PIO_NOERR)
         {
+            GPTLstop("PIO:PIOc_put_vars_tc");
             return pio_err(ios, NULL, ierr, __FILE__, __LINE__,
                             "Writing variable (%s, varid=%d) to file (%s, ncid=%d) failed. Error sending asynchronous message, PIO_MSG_PUT_VARS", pio_get_vname_from_file(file, varid), varid, pio_get_fname_from_file(file), ncid);
         }
@@ -1125,9 +1168,15 @@ int PIOc_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
         /* Broadcast values currently only known on computation tasks to IO tasks. */
         LOG((2, "PIOc_put_vars_tc bcast from comproot"));
         if ((mpierr = MPI_Bcast(&ndims, 1, MPI_INT, ios->comproot, ios->my_comm)))
+        {
+            GPTLstop("PIO:PIOc_put_vars_tc");
             return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
+        }
         if ((mpierr = MPI_Bcast(&xtype, 1, MPI_INT, ios->comproot, ios->my_comm)))
+        {
+            GPTLstop("PIO:PIOc_put_vars_tc");
             return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
+        }
         LOG((2, "PIOc_put_vars_tc complete bcast from comproot ndims = %d", ndims));
     }
 
@@ -1137,6 +1186,7 @@ int PIOc_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
     {
         if (varid < 0 || varid >= file->num_vars)
         {
+            GPTLstop("PIO:PIOc_put_vars_tc");
             return pio_err(ios, file, PIO_EBADID, __FILE__, __LINE__,
                             "Writing variable to file (%s, ncid=%d) failed. Invalid variable id (varid=%d, expected >=0 and < number of variables in the file, %d) provided", pio_get_fname_from_file(file), ncid, varid, file->num_vars);
         }
@@ -1182,6 +1232,7 @@ int PIOc_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
                                                              adios2_constant_dims_false);
                     if (av->adios_varid == NULL)
                     {
+                        GPTLstop("PIO:PIOc_put_vars_tc");
                         return pio_err(NULL, file, PIO_EADIOS2ERR, __FILE__, __LINE__, "Defining (ADIOS) variable (name=%s) failed for file (%s, ncid=%d)", av->name, pio_get_fname_from_file(file), file->pio_ncid);
                     }
                 }
@@ -1189,6 +1240,7 @@ int PIOc_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
                 adiosErr = adios2_put(file->engineH, av->adios_varid, buf, adios2_mode_sync);
                 if (adiosErr != adios2_error_none)
                 {
+                    GPTLstop("PIO:PIOc_put_vars_tc");
                     return pio_err(ios, file, PIO_EADIOS2ERR, __FILE__, __LINE__, "Putting (ADIOS) variable (name=%s) failed (adios2_error=%s) for file (%s, ncid=%d)", av->name, adios2_error_to_string(adiosErr), pio_get_fname_from_file(file), file->pio_ncid);
                 }
             }
@@ -1209,6 +1261,7 @@ int PIOc_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
                                                              adios2_constant_dims_false);
                     if (av->adios_varid == NULL)
                     {
+                        GPTLstop("PIO:PIOc_put_vars_tc");
                         return pio_err(ios, file, PIO_EADIOS2ERR, __FILE__, __LINE__, "Defining (ADIOS) variable (name=%s) failed for file (%s, ncid=%d)", av->name, pio_get_fname_from_file(file), file->pio_ncid);
                     }
                 }
@@ -1216,6 +1269,7 @@ int PIOc_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
                 adiosErr = adios2_put(file->engineH, av->adios_varid, buf, adios2_mode_sync);
                 if (adiosErr != adios2_error_none)
                 {
+                    GPTLstop("PIO:PIOc_put_vars_tc");
                     return pio_err(ios, file, PIO_EADIOS2ERR, __FILE__, __LINE__, "Putting (ADIOS) variable (name=%s) failed (adios2_error=%s) for file (%s, ncid=%d)", av->name, adios2_error_to_string(adiosErr), pio_get_fname_from_file(file), file->pio_ncid);
                 }
 
@@ -1234,6 +1288,7 @@ int PIOc_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
                     attributeH = adios2_define_attribute_array(file->ioH, att_name, adios2_type_string, dimnames, av->ndims);
                     if (attributeH == NULL)
                     {
+                        GPTLstop("PIO:PIOc_put_vars_tc");
                         return pio_err(ios, file, PIO_EADIOS2ERR, __FILE__, __LINE__, "Defining (ADIOS) attribute array (name=%s, size=%d) failed for file (%s, ncid=%d)", att_name, av->ndims, pio_get_fname_from_file(file), file->pio_ncid);
                     }
                 }
@@ -1283,6 +1338,7 @@ int PIOc_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
                                                          adios2_constant_dims_false);
                 if (av->adios_varid == NULL)
                 {
+                    GPTLstop("PIO:PIOc_put_vars_tc");
                     return pio_err(ios, file, PIO_EADIOS2ERR, __FILE__, __LINE__, "Defining (ADIOS) variable (name=%s) failed for file (%s, ncid=%d)", av->name, pio_get_fname_from_file(file), file->pio_ncid);
                 }
             }
@@ -1291,6 +1347,7 @@ int PIOc_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
                 adiosErr = adios2_set_selection(av->adios_varid, av->ndims - d_start, av_start, av_count);
                 if (adiosErr != adios2_error_none)
                 {
+                    GPTLstop("PIO:PIOc_put_vars_tc");
                     return pio_err(ios, file, PIO_EADIOS2ERR, __FILE__, __LINE__, "Setting (ADIOS) selection to variable (name=%s) failed (adios2_error=%s) for file (%s, ncid=%d)", av->name, adios2_error_to_string(adiosErr), pio_get_fname_from_file(file), file->pio_ncid);
                 }
             }
@@ -1298,6 +1355,7 @@ int PIOc_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
             adiosErr = adios2_put(file->engineH, av->adios_varid, buf, adios2_mode_sync);
             if (adiosErr != adios2_error_none)
             {
+                GPTLstop("PIO:PIOc_put_vars_tc");
                 return pio_err(ios, file, PIO_EADIOS2ERR, __FILE__, __LINE__, "Putting (ADIOS) variable (name=%s) failed (adios2_error=%s) for file (%s, ncid=%d)", av->name, adios2_error_to_string(adiosErr), pio_get_fname_from_file(file), file->pio_ncid);
             }
 
@@ -1318,6 +1376,7 @@ int PIOc_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
                 attributeH = adios2_define_attribute_array(file->ioH, att_name, adios2_type_string, dimnames, av->ndims);
                 if (attributeH == NULL)
                 {
+                    GPTLstop("PIO:PIOc_put_vars_tc");
                     return pio_err(ios, file, PIO_EADIOS2ERR, __FILE__, __LINE__, "Defining (ADIOS) attribute array (name=%s, size=%d) failed for file (%s, ncid=%d)", att_name, av->ndims, pio_get_fname_from_file(file), file->pio_ncid);
                 }
             }
@@ -1333,6 +1392,7 @@ int PIOc_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
                 attributeH = adios2_define_attribute(file->ioH, att_name, adios2_type_int32_t, &av->ndims);
                 if (attributeH == NULL)
                 {
+                    GPTLstop("PIO:PIOc_put_vars_tc");
                     return pio_err(ios, file, PIO_EADIOS2ERR, __FILE__, __LINE__, "Defining (ADIOS) attribute (name=%s) failed for file (%s, ncid=%d)", att_name, pio_get_fname_from_file(file), file->pio_ncid);
                 }
             }
@@ -1344,6 +1404,7 @@ int PIOc_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
                 attributeH = adios2_define_attribute(file->ioH, att_name, adios2_type_int32_t, &av->nc_type);
                 if (attributeH == NULL)
                 {
+                    GPTLstop("PIO:PIOc_put_vars_tc");
                     return pio_err(ios, file, PIO_EADIOS2ERR, __FILE__, __LINE__, "Defining (ADIOS) attribute (name=%s) failed for file (%s, ncid=%d)", att_name, pio_get_fname_from_file(file), file->pio_ncid);
                 }
             }
@@ -1355,6 +1416,7 @@ int PIOc_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
                 attributeH = adios2_define_attribute(file->ioH, att_name, adios2_type_string, "put_var");
                 if (attributeH == NULL)
                 {
+                    GPTLstop("PIO:PIOc_put_vars_tc");
                     return pio_err(ios, file, PIO_EADIOS2ERR, __FILE__, __LINE__, "Defining (ADIOS) attribute (name=%s) failed for file (%s, ncid=%d)", att_name, pio_get_fname_from_file(file), file->pio_ncid);
                 }
             }
@@ -1375,6 +1437,7 @@ int PIOc_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
                 if (!(vdesc->request = realloc(vdesc->request,
                                                sizeof(int) * (vdesc->nreqs + PIO_REQUEST_ALLOC_CHUNK))))
                 {
+                    GPTLstop("PIO:PIOc_put_vars_tc");
                     return pio_err(ios, file, PIO_ENOMEM, __FILE__, __LINE__,
                                     "Writing variable (%s, varid=%d) to file (%s, ncid=%d) failed. Out of memory, reallocating memory (%lld bytes) for array to store PnetCDF request handles", pio_get_vname_from_file(file, varid), varid, pio_get_fname_from_file(file), ncid, (long long int) (sizeof(int) * (vdesc->nreqs + PIO_REQUEST_ALLOC_CHUNK)));
                 }
@@ -1385,6 +1448,7 @@ int PIOc_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
                                               PIO_REQUEST_ALLOC_CHUNK));
                 if(!(vdesc->request_sz))
                 {
+                    GPTLstop("PIO:PIOc_put_vars_tc");
                     return pio_err(ios, file, PIO_ENOMEM, __FILE__, __LINE__,
                                     "Writing variable (%s, varid=%d) to file (%s, ncid=%d) failed. Out of memory, reallocating memory (%lld bytes) for array to store PnetCDF request handles", pio_get_vname_from_file(file, varid), varid, pio_get_fname_from_file(file), ncid, (long long int) (sizeof(int) * (vdesc->nreqs + PIO_REQUEST_ALLOC_CHUNK)));
                 }
@@ -1429,6 +1493,7 @@ int PIOc_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
                         ierr = ncmpi_bput_var_double(file->fh, varid, buf, request);
                         break;
                     default:
+                        GPTLstop("PIO:PIOc_put_vars_tc");
                         return pio_err(ios, file, PIO_EBADIOTYPE, __FILE__, __LINE__,
                                         "Writing variable (%s, varid=%d) to file (%s, ncid=%d) failed. Unsupported PnetCDF variable type (type=%x)", pio_get_vname_from_file(file, varid), varid, pio_get_fname_from_file(file), ncid, xtype);
                     }
@@ -1458,6 +1523,7 @@ int PIOc_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
                     LOG((2, "stride not present"));
                     if (!(fake_stride = malloc(ndims * sizeof(PIO_Offset))))
                     {
+                        GPTLstop("PIO:PIOc_put_vars_tc");
                         return pio_err(ios, file, PIO_ENOMEM, __FILE__, __LINE__,
                                         "Writing variable (%s, varid=%d) to file (%s, ncid=%d) failed. Out of memory, allocating memory (%lld bytes) for default variable stride", pio_get_vname_from_file(file, varid), varid, pio_get_fname_from_file(file), ncid, (long long int) (ndims * sizeof(PIO_Offset)));
                     }
@@ -1494,6 +1560,7 @@ int PIOc_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
                         ierr = ncmpi_bput_vars_double(file->fh, varid, start, count, fake_stride, buf, request);
                         break;
                     default:
+                        GPTLstop("PIO:PIOc_put_vars_tc");
                         return pio_err(ios, file, PIO_EBADTYPE, __FILE__, __LINE__,
                                         "Writing variable (%s, varid=%d) to file (%s, ncid=%d) failed. Unsupported PnetCDF variable type (%x)", pio_get_vname_from_file(file, varid), varid, pio_get_fname_from_file(file), ncid, xtype);
                     }
@@ -1583,6 +1650,7 @@ int PIOc_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
                 /*      break; */
 #endif /* _NETCDF4 */
             default:
+                GPTLstop("PIO:PIOc_put_vars_tc");
                 return pio_err(ios, file, PIO_EBADTYPE, __FILE__, __LINE__,
                                 "Writing variable (%s, varid=%d) to file (%s, ncid=%d) failed. Unsupported variable type (%x) for iotype=%s", pio_get_vname_from_file(file, varid), varid, pio_get_fname_from_file(file), ncid, xtype, pio_iotype_to_string(file->iotype));
             }
@@ -1593,6 +1661,7 @@ int PIOc_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
     ierr = check_netcdf(NULL, file, ierr, __FILE__, __LINE__);
     if(ierr != PIO_NOERR){
         LOG((1, "nc*_put_vars_* failed, ierr = %d", ierr));
+        GPTLstop("PIO:PIOc_put_vars_tc");
         return pio_err(NULL, file, ierr, __FILE__, __LINE__,
                         "Writing variable (%s, varid=%d) to file (%s, ncid=%d) failed. Underlying I/O library call failed(iotype=%x:%s) ", pio_get_vname_from_file(file, varid), varid, pio_get_fname_from_file(file), ncid, xtype, pio_iotype_to_string(file->iotype));
                     

--- a/src/clib/pio_getput_int.c
+++ b/src/clib/pio_getput_int.c
@@ -116,9 +116,19 @@ int PIOc_put_att_tc(int ncid, int varid, const char *name, nc_type atttype,
 
         /* Broadcast values currently only known on computation tasks to IO tasks. */
         if ((mpierr = MPI_Bcast(&atttype_len, 1, MPI_OFFSET, ios->comproot, ios->my_comm)))
-            check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
+        {
+            GPTLstop("PIO:PIOc_put_att_tc");
+            if (file->iotype == PIO_IOTYPE_ADIOS)
+                GPTLstop("PIO:PIOc_put_att_tc_adios");
+            return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
+        }
         if ((mpierr = MPI_Bcast(&memtype_len, 1, MPI_OFFSET, ios->comproot, ios->my_comm)))
-            check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
+        {
+            GPTLstop("PIO:PIOc_put_att_tc");
+            if (file->iotype == PIO_IOTYPE_ADIOS)
+                GPTLstop("PIO:PIOc_put_att_tc_adios");
+            return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
+        }
         LOG((2, "PIOc_put_att bcast from comproot = %d atttype_len = %d", ios->comproot,
              atttype_len, memtype_len));
     }
@@ -707,11 +717,20 @@ int PIOc_get_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
 
         /* Broadcast values currently only known on computation tasks to IO tasks. */
         if ((mpierr = MPI_Bcast(&num_elem, 1, MPI_OFFSET, ios->comproot, ios->my_comm)))
-            check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
+        {
+            GPTLstop("PIO:PIOc_get_vars_tc");
+            return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
+        }
         if ((mpierr = MPI_Bcast(&typelen, 1, MPI_OFFSET, ios->comproot, ios->my_comm)))
-            check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
+        {
+            GPTLstop("PIO:PIOc_get_vars_tc");
+            return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
+        }
         if ((mpierr = MPI_Bcast(&xtype, 1, MPI_INT, ios->comproot, ios->my_comm)))
-            check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
+        {
+            GPTLstop("PIO:PIOc_get_vars_tc");
+            return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
+        }
     }
 
     /* If this is an IO task, then call the netCDF function. */

--- a/src/clib/pio_getput_int.c
+++ b/src/clib/pio_getput_int.c
@@ -39,9 +39,7 @@ int PIOc_put_att_tc(int ncid, int varid, const char *name, nc_type atttype,
     int mpierr = MPI_SUCCESS;  /* Return code from MPI function codes. */
     int ierr = PIO_NOERR;           /* Return code from function calls. */
 
-#ifdef TIMING
     GPTLstart("PIO:PIOc_put_att_tc");
-#endif
     /* Find the info about this file. */
     if ((ierr = pio_get_file(ncid, &file)))
     {
@@ -50,11 +48,9 @@ int PIOc_put_att_tc(int ncid, int varid, const char *name, nc_type atttype,
     }
     ios = file->iosystem;
 
-#ifdef TIMING
 #ifdef _ADIOS2 /* TAHSIN: timing */
     if (file->iotype == PIO_IOTYPE_ADIOS)
         GPTLstart("PIO:PIOc_put_att_tc_adios"); /* TAHSIN: start */
-#endif
 #endif
 
     /* User must provide some valid parameters. */
@@ -168,13 +164,11 @@ int PIOc_put_att_tc(int ncid, int varid, const char *name, nc_type atttype,
             }
         }
 
-#ifdef TIMING
         GPTLstop("PIO:PIOc_put_att_tc");
 
 #ifdef _ADIOS2 /* TAHSIN: timing */
         if (file->iotype == PIO_IOTYPE_ADIOS)
             GPTLstop("PIO:PIOc_put_att_tc_adios"); /* TAHSIN: stop */
-#endif
 #endif
 
         return PIO_NOERR;
@@ -279,9 +273,7 @@ int PIOc_put_att_tc(int ncid, int varid, const char *name, nc_type atttype,
                         "Writing variable (%s, varid=%d) attribute (%s) to file (%s, ncid=%d) failed. Internal I/O library (%s) call failed", pio_get_vname_from_file(file, varid), varid, name, pio_get_fname_from_file(file), file->pio_ncid, pio_iotype_to_string(file->iotype));
     }
 
-#ifdef TIMING
     GPTLstop("PIO:PIOc_put_att_tc");
-#endif
     return PIO_NOERR;
 }
 
@@ -314,9 +306,7 @@ int PIOc_get_att_tc(int ncid, int varid, const char *name, nc_type memtype, void
     int mpierr = MPI_SUCCESS;  /* Return code from MPI function calls. */
     int ierr = PIO_NOERR;               /* Return code from function calls. */
 
-#ifdef TIMING
     GPTLstart("PIO:PIOc_get_att_tc");
-#endif
     /* Find the info about this file. */
     if ((ierr = pio_get_file(ncid, &file)))
     {
@@ -518,9 +508,7 @@ int PIOc_get_att_tc(int ncid, int varid, const char *name, nc_type memtype, void
         return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
 
     LOG((2, "get_att_tc data bcast complete"));
-#ifdef TIMING
     GPTLstop("PIO:PIOc_get_att_tc");
-#endif
     return PIO_NOERR;
 }
 
@@ -574,9 +562,7 @@ int PIOc_get_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
     int mpierr = MPI_SUCCESS;  /* Return code from MPI function codes. */
     int ierr = PIO_NOERR;                           /* Return code. */
 
-#ifdef TIMING
     GPTLstart("PIO:PIOc_get_vars_tc");
-#endif
     LOG((1, "PIOc_get_vars_tc ncid = %d varid = %d xtype = %d start_present = %d "
          "count_present = %d stride_present = %d", ncid, varid, xtype, start_present,
          count_present, stride_present));
@@ -836,9 +822,7 @@ int PIOc_get_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
         return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
     LOG((2, "PIOc_get_vars_tc bcasting data complete"));
 
-#ifdef TIMING
     GPTLstop("PIO:PIOc_get_vars_tc");
-#endif
     return PIO_NOERR;
 }
 
@@ -1025,9 +1009,7 @@ int PIOc_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
     int mpierr = MPI_SUCCESS;  /* Return code from MPI function codes. */
     int ierr = PIO_NOERR;          /* Return code from function calls. */
 
-#ifdef TIMING
     GPTLstart("PIO:PIOc_put_vars_tc");
-#endif
     LOG((1, "PIOc_put_vars_tc ncid = %d varid = %d start_present = %d "
          "count_present = %d stride_present = %d xtype = %d", ncid, varid,
          start_present, count_present, stride_present, xtype));
@@ -1618,9 +1600,7 @@ int PIOc_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
 
     LOG((2, "PIOc_put_vars_tc bcast netcdf return code %d complete", ierr));
 
-#ifdef TIMING
     GPTLstop("PIO:PIOc_put_vars_tc");
-#endif
     return PIO_NOERR;
 }
 

--- a/src/clib/pio_internal.h
+++ b/src/clib/pio_internal.h
@@ -45,6 +45,8 @@
 #include <math.h>
 #ifdef TIMING
 #include <gptl.h>
+#else
+#include "gptl_skel.h"
 #endif
 #include <assert.h>
 

--- a/src/clib/pio_nc.c
+++ b/src/clib/pio_nc.c
@@ -1383,7 +1383,7 @@ int PIOc_inq_varid(int ncid, const char *name, int *varidp)
     /* Broadcast results to all tasks. Ignore NULL parameters. */
     if (varidp)
         if ((mpierr = MPI_Bcast(varidp, 1, MPI_INT, ios->ioroot, ios->my_comm)))
-            check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
+            return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
 
 #ifdef PIO_MICRO_TIMING
     /* Create timers for the variable
@@ -1543,10 +1543,10 @@ int PIOc_inq_att(int ncid, int varid, const char *name, nc_type *xtypep,
     /* Broadcast results. */
     if (xtypep)
         if ((mpierr = MPI_Bcast(xtypep, 1, MPI_INT, ios->ioroot, ios->my_comm)))
-            check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
+            return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
     if (lenp)
         if ((mpierr = MPI_Bcast(lenp, 1, MPI_OFFSET, ios->ioroot, ios->my_comm)))
-            check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
+            return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
 
     return PIO_NOERR;
 }
@@ -1669,10 +1669,10 @@ int PIOc_inq_attname(int ncid, int varid, int attnum, char *name)
     {
         int namelen = strlen(name);
         if ((mpierr = MPI_Bcast(&namelen, 1, MPI_INT, ios->ioroot, ios->my_comm)))
-            check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
+            return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
         /* Casting to void to avoid warnings on some compilers. */
         if ((mpierr = MPI_Bcast((void *)name, namelen + 1, MPI_CHAR, ios->ioroot, ios->my_comm)))
-            check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
+            return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
     }
 
     return PIO_NOERR;
@@ -1775,7 +1775,7 @@ int PIOc_inq_attid(int ncid, int varid, const char *name, int *idp)
     /* Broadcast results. */
     if (idp)
         if ((mpierr = MPI_Bcast(idp, 1, MPI_INT, ios->ioroot, ios->my_comm)))
-            check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
+            return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
 
     return PIO_NOERR;
 }
@@ -2233,7 +2233,7 @@ int PIOc_set_fill(int ncid, int fillmode, int *old_modep)
     {
         LOG((2, "old_mode = %d", *old_modep));
         if ((mpierr = MPI_Bcast(old_modep, 1, MPI_INT, ios->ioroot, ios->my_comm)))
-            check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
+            return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
     }
 
     LOG((2, "PIOc_set_fill succeeded"));
@@ -2416,7 +2416,7 @@ int PIOc_def_dim(int ncid, const char *name, PIO_Offset len, int *idp)
     /* Broadcast results to all tasks. Ignore NULL parameters. */
     if (idp)
         if ((mpierr = MPI_Bcast(idp , 1, MPI_INT, ios->ioroot, ios->my_comm)))
-            check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
+            return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
 
     if(len == PIO_UNLIMITED)
     {
@@ -2526,7 +2526,7 @@ int PIOc_def_var(int ncid, const char *name, nc_type xtype, int ndims,
 
         /* Broadcast values currently only known on computation tasks to IO tasks. */
         if ((mpierr = MPI_Bcast(&invalid_unlim_dim, 1, MPI_INT, ios->comproot, ios->my_comm)))
-            check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
+            return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
     }
 
     /* Check that only one unlimited dim is specified, and that it is
@@ -2705,7 +2705,7 @@ int PIOc_def_var(int ncid, const char *name, nc_type xtype, int ndims,
     /* FIXME: varidp should be valid, no need to check it here */
     if (varidp)
         if ((mpierr = MPI_Bcast(varidp, 1, MPI_INT, ios->ioroot, ios->my_comm)))
-            check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
+            return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
 
     strncpy(file->varlist[*varidp].vname, name, PIO_MAX_NAME);
     if(file->num_unlim_dimids > 0)
@@ -2872,9 +2872,9 @@ int PIOc_def_var_fill(int ncid, int varid, int fill_mode, const void *fill_value
 
         /* Broadcast values currently only known on computation tasks to IO tasks. */
         if ((mpierr = MPI_Bcast(&xtype, 1, MPI_INT, ios->comproot, ios->my_comm)))
-            check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
+            return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
         if ((mpierr = MPI_Bcast(&type_size, 1, MPI_OFFSET, ios->comproot, ios->my_comm)))
-            check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
+            return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
     }
 
     if (ios->ioproc)
@@ -2996,9 +2996,9 @@ int PIOc_inq_var_fill(int ncid, int varid, int *no_fill, void *fill_valuep)
 
         /* Broadcast values currently only known on computation tasks to IO tasks. */
         if ((mpierr = MPI_Bcast(&xtype, 1, MPI_INT, ios->comproot, ios->my_comm)))
-            check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
+            return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
         if ((mpierr = MPI_Bcast(&type_size, 1, MPI_OFFSET, ios->comproot, ios->my_comm)))
-            check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
+            return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
     }
 
     /* If this is an IO task, then call the netCDF function. */
@@ -3094,10 +3094,10 @@ int PIOc_inq_var_fill(int ncid, int varid, int *no_fill, void *fill_valuep)
     /* Broadcast results to all tasks. Ignore NULL parameters. */
     if (no_fill)
         if ((mpierr = MPI_Bcast(no_fill, 1, MPI_INT, ios->ioroot, ios->my_comm)))
-            check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
+            return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
     if (fill_valuep)
         if ((mpierr = MPI_Bcast(fill_valuep, type_size, MPI_CHAR, ios->ioroot, ios->my_comm)))
-            check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
+            return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
 
     return PIO_NOERR;
 }

--- a/src/clib/pio_nc4.c
+++ b/src/clib/pio_nc4.c
@@ -281,7 +281,7 @@ int PIOc_def_var_chunking(int ncid, int varid, int storage, const PIO_Offset *ch
 
         /* Broadcast values currently only known on computation tasks to IO tasks. */
         if ((mpierr = MPI_Bcast(&ndims, 1, MPI_INT, ios->comproot, ios->my_comm)))
-            check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
+            return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
     }
 
     LOG((2, "PIOc_def_var_chunking ndims = %d", ndims));
@@ -395,7 +395,7 @@ int PIOc_inq_var_chunking(int ncid, int varid, int *storagep, PIO_Offset *chunks
 
         /* Broadcast values currently only known on computation tasks to IO tasks. */
         if ((mpierr = MPI_Bcast(&ndims, 1, MPI_INT, ios->comproot, ios->my_comm)))
-            check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
+            return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
     }
 
     /* If this is an IO task, then call the netCDF function. */

--- a/src/clib/pio_rearrange.c
+++ b/src/clib/pio_rearrange.c
@@ -856,9 +856,7 @@ int rearrange_comp2io(iosystem_desc_t *ios, io_desc_t *iodesc, void *sbuf,
     int mpierr;       /* Return code from MPI calls. */
     int ret;
 
-#ifdef TIMING
     GPTLstart("PIO:rearrange_comp2io");
-#endif
 
     /* Caller must provide these. */
     pioassert(ios && iodesc && nvars > 0, "invalid input", __FILE__, __LINE__);
@@ -1034,9 +1032,7 @@ int rearrange_comp2io(iosystem_desc_t *ios, io_desc_t *iodesc, void *sbuf,
                 return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
     }
 
-#ifdef TIMING
     GPTLstop("PIO:rearrange_comp2io");
-#endif
 
     return PIO_NOERR;
 }
@@ -1064,9 +1060,7 @@ int rearrange_io2comp(iosystem_desc_t *ios, io_desc_t *iodesc, void *sbuf,
     /* Check inputs. */
     pioassert(ios && iodesc, "invalid input", __FILE__, __LINE__);
 
-#ifdef TIMING
     GPTLstart("PIO:rearrange_io2comp");
-#endif
 
     /* Different rearrangers use different communicators and number of
      * IO tasks. */
@@ -1164,9 +1158,7 @@ int rearrange_io2comp(iosystem_desc_t *ios, io_desc_t *iodesc, void *sbuf,
                         "Rearranging data from I/O to compute processes failed. pio_swapm() call failed to transfer data between the processes");
     }
 
-#ifdef TIMING
     GPTLstop("PIO:rearrange_io2comp");
-#endif
 
     return PIO_NOERR;
 }
@@ -1273,9 +1265,7 @@ int box_rearrange_create(iosystem_desc_t *ios, int maplen, const PIO_Offset *com
 {
     int ret;
 
-#ifdef TIMING
     GPTLstart("PIO:box_rearrange_create");
-#endif
     /* Check inputs. */
     pioassert(ios && maplen >= 0 && compmap && gdimlen && ndims > 0 && iodesc,
               "invalid input", __FILE__, __LINE__);
@@ -1584,9 +1574,7 @@ int box_rearrange_create(iosystem_desc_t *ios, int maplen, const PIO_Offset *com
     }
     LOG((3, "iodesc->maxbytes = %d", iodesc->maxbytes));
 
-#ifdef TIMING
     GPTLstop("PIO:box_rearrange_create");
-#endif
     return PIO_NOERR;
 }
 
@@ -1598,9 +1586,7 @@ int box_rearrange_create_with_holes(iosystem_desc_t *ios, int maplen, const PIO_
 {
     int ret;
 
-#ifdef TIMING
     GPTLstart("PIO:box_rearrange_create_with_holes");
-#endif
     /* Check inputs. */
     pioassert(ios && maplen >= 0 && compmap && gdimlen && ndims > 0 && iodesc,
               "invalid input", __FILE__, __LINE__);
@@ -1893,9 +1879,7 @@ int box_rearrange_create_with_holes(iosystem_desc_t *ios, int maplen, const PIO_
     }
     LOG((3, "iodesc->maxbytes = %d", iodesc->maxbytes));
 
-#ifdef TIMING
     GPTLstop("PIO:box_rearrange_create_with_holes");
-#endif
     return PIO_NOERR;
 }
 
@@ -2164,9 +2148,7 @@ int subset_rearrange_create(iosystem_desc_t *ios, int maplen, PIO_Offset *compma
     int mpierr; /* Return call from MPI function calls. */
     int ret;
 
-#ifdef TIMING
     GPTLstart("PIO:subset_rearrange_create");
-#endif
     /* Check inputs. */
     pioassert(ios && maplen >= 0 && compmap && gdimlen && ndims >= 0 && iodesc,
               "invalid input", __FILE__, __LINE__);
@@ -2618,9 +2600,7 @@ int subset_rearrange_create(iosystem_desc_t *ios, int maplen, PIO_Offset *compma
                             "Creating SUBSET rearranger failed for I/O decomposition (ioid=%d) on iosystem (iosysid=%d). Calculating maximum aggregate bytes for the I/O decomposition failed", iodesc->ioid, ios->iosysid);
     }
 
-#ifdef TIMING
     GPTLstop("PIO:subset_rearrange_create");
-#endif
     return PIO_NOERR;
 }
 

--- a/src/clib/pio_rearrange.c
+++ b/src/clib/pio_rearrange.c
@@ -1249,7 +1249,7 @@ int determine_fill(iosystem_desc_t *ios, io_desc_t *iodesc, const int *gdimlen,
          totalllen, totalgridsize));
     if ((mpierr = MPI_Allreduce(MPI_IN_PLACE, &totalllen, 1, PIO_OFFSET, MPI_SUM,
                                 ios->union_comm)))
-        check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+        return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
     LOG((2, "after allreduce totalllen = %d", totalllen));
 
     /* If the total size of the data provided to be written is < the

--- a/src/clib/pio_spmd.c
+++ b/src/clib/pio_spmd.c
@@ -92,9 +92,7 @@ int pio_swapm(void *sendbuf, int *sendcounts, int *sdispls, MPI_Datatype *sendty
     MPI_Status status; /* Not actually used - replace with MPI_STATUSES_IGNORE. */
     int mpierr;  /* Return code from MPI functions. */
 
-#ifdef TIMING
     GPTLstart("PIO:pio_swapm");
-#endif
     LOG((2, "pio_swapm fc->hs = %d fc->isend = %d fc->max_pend_req = %d", fc->hs,
          fc->isend, fc->max_pend_req));
 
@@ -131,9 +129,7 @@ int pio_swapm(void *sendbuf, int *sendcounts, int *sdispls, MPI_Datatype *sendty
         if ((mpierr = MPI_Alltoallw(sendbuf, sendcounts, sdispls, sendtypes, recvbuf,
                                     recvcounts, rdispls, recvtypes, comm)))
             return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
-#ifdef TIMING
         GPTLstop("PIO:pio_swapm");
-#endif
         return PIO_NOERR;
     }
 
@@ -181,9 +177,7 @@ int pio_swapm(void *sendbuf, int *sendcounts, int *sdispls, MPI_Datatype *sendty
      * ntasks==1. */
     if (ntasks == 1)
     {
-#ifdef TIMING
         GPTLstop("PIO:pio_swapm");
-#endif
         return PIO_NOERR;
     }
 
@@ -213,9 +207,7 @@ int pio_swapm(void *sendbuf, int *sendcounts, int *sdispls, MPI_Datatype *sendty
 
     if (steps == 0)
     {
-#ifdef TIMING
         GPTLstop("PIO:pio_swapm");
-#endif
         return PIO_NOERR;
     }
 
@@ -384,9 +376,7 @@ int pio_swapm(void *sendbuf, int *sendcounts, int *sdispls, MPI_Datatype *sendty
                 return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
     }
 
-#ifdef TIMING
     GPTLstop("PIO:pio_swapm");
-#endif
     return PIO_NOERR;
 }
 

--- a/src/clib/pio_spmd.c
+++ b/src/clib/pio_spmd.c
@@ -98,9 +98,15 @@ int pio_swapm(void *sendbuf, int *sendcounts, int *sdispls, MPI_Datatype *sendty
 
     /* Get my rank and size of communicator. */
     if ((mpierr = MPI_Comm_size(comm, &ntasks)))
+    {
+        GPTLstop("PIO:pio_swapm");
         return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+    }
     if ((mpierr = MPI_Comm_rank(comm, &my_rank)))
+    {
+        GPTLstop("PIO:pio_swapm");
         return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+    }
 
     LOG((2, "ntasks = %d my_rank = %d", ntasks, my_rank));
 
@@ -128,7 +134,10 @@ int pio_swapm(void *sendbuf, int *sendcounts, int *sdispls, MPI_Datatype *sendty
         LOG((3, "Calling MPI_Alltoallw without flow control."));
         if ((mpierr = MPI_Alltoallw(sendbuf, sendcounts, sdispls, sendtypes, recvbuf,
                                     recvcounts, rdispls, recvtypes, comm)))
+        {
+            GPTLstop("PIO:pio_swapm");
             return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+        }
         GPTLstop("PIO:pio_swapm");
         return PIO_NOERR;
     }
@@ -157,17 +166,29 @@ int pio_swapm(void *sendbuf, int *sendcounts, int *sdispls, MPI_Datatype *sendty
         if ((mpierr = MPI_Sendrecv(sptr, sendcounts[my_rank],sendtypes[my_rank],
                                    my_rank, tag, rptr, recvcounts[my_rank], recvtypes[my_rank],
                                    my_rank, tag, comm, &status)))
+        {
+            GPTLstop("PIO:pio_swapm");
             return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+        }
 #else
         if ((mpierr = MPI_Irecv(rptr, recvcounts[my_rank], recvtypes[my_rank],
                                 my_rank, tag, comm, rcvids)))
+        {
+            GPTLstop("PIO:pio_swapm");
             return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+        }
         if ((mpierr = MPI_Send(sptr, sendcounts[my_rank], sendtypes[my_rank],
                                my_rank, tag, comm)))
+        {
+            GPTLstop("PIO:pio_swapm");
             return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+        }
 
         if ((mpierr = MPI_Wait(rcvids, &status)))
+        {
+            GPTLstop("PIO:pio_swapm");
             return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+        }
 #endif
     }
 
@@ -254,7 +275,10 @@ int pio_swapm(void *sendbuf, int *sendcounts, int *sdispls, MPI_Datatype *sendty
             {
                 tag = my_rank + offset_t;
                 if ((mpierr = MPI_Irecv(&hs, 1, MPI_INT, p, tag, comm, hs_rcvids + istep)))
+                {
+                    GPTLstop("PIO:pio_swapm");
                     return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+                }
             }
         }
     }
@@ -270,11 +294,17 @@ int pio_swapm(void *sendbuf, int *sendcounts, int *sdispls, MPI_Datatype *sendty
 
             if ((mpierr = MPI_Irecv(ptr, recvcounts[p], recvtypes[p], p, tag, comm,
                                     rcvids + istep)))
+            {
+                GPTLstop("PIO:pio_swapm");
                 return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+            }
 
             if (fc->hs)
                 if ((mpierr = MPI_Send(&hs, 1, MPI_INT, p, tag, comm)))
+                {
+                    GPTLstop("PIO:pio_swapm");
                     return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+                }
         }
     }
 
@@ -291,7 +321,10 @@ int pio_swapm(void *sendbuf, int *sendcounts, int *sdispls, MPI_Datatype *sendty
             if (fc->hs)
             {
                 if ((mpierr = MPI_Wait(hs_rcvids + istep, &status)))
+                {
+                    GPTLstop("PIO:pio_swapm");
                     return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+                }
                 hs_rcvids[istep] = MPI_REQUEST_NULL;
             }
             ptr = (char *)sendbuf + sdispls[p];
@@ -308,23 +341,35 @@ int pio_swapm(void *sendbuf, int *sendcounts, int *sdispls, MPI_Datatype *sendty
 #ifndef _USE_MPI_RSEND
                 if ((mpierr = MPI_Isend(ptr, sendcounts[p], sendtypes[p], p, tag, comm,
                                         sndids + istep)))
+                {
+                    GPTLstop("PIO:pio_swapm");
                     return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+                }
 #else
                 if ((mpierr = MPI_Irsend(ptr, sendcounts[p], sendtypes[p], p, tag, comm,
                                          sndids + istep)))
+                {
+                    GPTLstop("PIO:pio_swapm");
                     return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+                }
 #endif
             }
             else if (fc->isend)
             {
                 if ((mpierr = MPI_Isend(ptr, sendcounts[p], sendtypes[p], p, tag, comm,
                                          sndids + istep)))
+                {
+                    GPTLstop("PIO:pio_swapm");
                     return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+                }
             }
             else
             {
                 if ((mpierr = MPI_Send(ptr, sendcounts[p], sendtypes[p], p, tag, comm)))
+                {
+                    GPTLstop("PIO:pio_swapm");
                     return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+                }
             }
         }
 
@@ -336,7 +381,10 @@ int pio_swapm(void *sendbuf, int *sendcounts, int *sdispls, MPI_Datatype *sendty
             if (rcvids[p] != MPI_REQUEST_NULL)
             {
                 if ((mpierr = MPI_Wait(rcvids + p, &status)))
+                {
+                    GPTLstop("PIO:pio_swapm");
                     return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+                }
                 rcvids[p] = MPI_REQUEST_NULL;
             }
             if (rstep < steps)
@@ -346,7 +394,10 @@ int pio_swapm(void *sendbuf, int *sendcounts, int *sdispls, MPI_Datatype *sendty
                 {
                     tag = my_rank + offset_t;
                     if ((mpierr = MPI_Irecv(&hs, 1, MPI_INT, p, tag, comm, hs_rcvids+rstep)))
+                    {
+                        GPTLstop("PIO:pio_swapm");
                         return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+                    }
                 }
                 if (recvcounts[p] > 0)
                 {
@@ -354,10 +405,16 @@ int pio_swapm(void *sendbuf, int *sendcounts, int *sdispls, MPI_Datatype *sendty
 
                     ptr = (char *)recvbuf + rdispls[p];
                     if ((mpierr = MPI_Irecv(ptr, recvcounts[p], recvtypes[p], p, tag, comm, rcvids + rstep)))
+                    {
+                        GPTLstop("PIO:pio_swapm");
                         return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+                    }
                     if (fc->hs)
                         if ((mpierr = MPI_Send(&hs, 1, MPI_INT, p, tag, comm)))
+                        {
+                            GPTLstop("PIO:pio_swapm");
                             return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+                        }
                 }
                 rstep++;
             }
@@ -370,10 +427,16 @@ int pio_swapm(void *sendbuf, int *sendcounts, int *sdispls, MPI_Datatype *sendty
     {
         LOG((2, "Waiting for outstanding msgs"));
         if ((mpierr = MPI_Waitall(steps, rcvids, MPI_STATUSES_IGNORE)))
+        {
+            GPTLstop("PIO:pio_swapm");
             return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+        }
         if (fc->isend)
             if ((mpierr = MPI_Waitall(steps, sndids, MPI_STATUSES_IGNORE)))
+            {
+                GPTLstop("PIO:pio_swapm");
                 return check_mpi(NULL, NULL, mpierr, __FILE__, __LINE__);
+            }
     }
 
     GPTLstop("PIO:pio_swapm");

--- a/src/clib/pioc.c
+++ b/src/clib/pioc.c
@@ -530,9 +530,7 @@ int PIOc_InitDecomp(int iosysid, int pio_type, int ndims, const int *gdimlen, in
     int mpierr = MPI_SUCCESS;  /* Return code from MPI function calls. */
     int ierr;              /* Return code. */
 
-#ifdef TIMING
     GPTLstart("PIO:PIOc_initdecomp");
-#endif
     LOG((1, "PIOc_InitDecomp iosysid = %d pio_type = %d ndims = %d maplen = %d",
          iosysid, pio_type, ndims, maplen));
 
@@ -775,9 +773,7 @@ int PIOc_InitDecomp(int iosysid, int pio_type, int ndims, const int *gdimlen, in
      * PERFTUNE is set. */
     performance_tune_rearranger(ios, iodesc);
 
-#ifdef TIMING
     GPTLstop("PIO:PIOc_initdecomp");
-#endif
     return PIO_NOERR;
 }
 
@@ -989,8 +985,8 @@ int PIOc_Init_Intracomm(MPI_Comm comp_comm, int num_iotasks, int stride, int bas
 #ifdef TIMING_INTERNAL
     pio_init_gptl();
 #endif
-    GPTLstart("PIO:PIOc_Init_Intracomm");
 #endif
+    GPTLstart("PIO:PIOc_Init_Intracomm");
     /* Turn on the logging system. */
     pio_init_logging();
 
@@ -1152,9 +1148,7 @@ int PIOc_Init_Intracomm(MPI_Comm comp_comm, int num_iotasks, int stride, int bas
 
     LOG((2, "Init_Intracomm complete iosysid = %d", *iosysidp));
 
-#ifdef TIMING
     GPTLstop("PIO:PIOc_Init_Intracomm");
-#endif
     return PIO_NOERR;
 }
 
@@ -1275,9 +1269,7 @@ int PIOc_finalize(int iosysid)
     char gptl_log_fname[PIO_MAX_NAME];
 #endif
 
-#ifdef TIMING
     GPTLstart("PIO:PIOc_finalize");
-#endif
     LOG((1, "PIOc_finalize iosysid = %d MPI_COMM_NULL = %d", iosysid,
          MPI_COMM_NULL));
 
@@ -1372,8 +1364,8 @@ int PIOc_finalize(int iosysid)
     pio_finalize_logging();
 
     LOG((2, "PIOc_finalize completed successfully"));
-#ifdef TIMING
     GPTLstop("PIO:PIOc_finalize");
+#ifdef TIMING
 #ifdef TIMING_INTERNAL
     if(ios->io_comm != MPI_COMM_NULL)
     {
@@ -1582,8 +1574,9 @@ int PIOc_init_async(MPI_Comm world, int num_io_procs, int *io_proc_list,
 #ifdef TIMING_INTERNAL
     pio_init_gptl();
 #endif
-    GPTLstart("PIO:PIOc_init_async");
 #endif
+    GPTLstart("PIO:PIOc_init_async");
+
     /* Check input parameters. */
     if (num_io_procs < 1 || component_count < 1 || !num_procs_per_comp || !iosysidp ||
         (rearranger != PIO_REARR_BOX && rearranger != PIO_REARR_SUBSET))
@@ -2007,9 +2000,7 @@ int PIOc_init_async(MPI_Comm world, int num_io_procs, int *io_proc_list,
         return check_mpi(NULL, NULL, ret, __FILE__, __LINE__);
 
     LOG((2, "successfully done with PIO_Init_Async"));
-#ifdef TIMING
     GPTLstop("PIO:PIOc_init_async");
-#endif
     return PIO_NOERR;
 }
 
@@ -2067,8 +2058,8 @@ int PIOc_init_intercomm(int component_count, const MPI_Comm peer_comm,
 #ifdef TIMING_INTERNAL
     pio_init_gptl();
 #endif
-    GPTLstart("PIO:PIOc_init_intercomm");
 #endif
+    GPTLstart("PIO:PIOc_init_intercomm");
     assert((component_count > 0) && ucomp_comms && iosysidps);
     if((component_count <= 0) || (ucomp_comms == NULL) ||
         ((rearranger != PIO_REARR_BOX) && (rearranger != PIO_REARR_SUBSET)) ||
@@ -2575,9 +2566,7 @@ int PIOc_init_intercomm(int component_count, const MPI_Comm peer_comm,
         LOG((2, "Returned from pio_msg_handler2() ret = %d", ret));
     }
 
-#ifdef TIMING
     GPTLstop("PIO:PIOc_init_intercomm");
-#endif
     return PIO_NOERR;
 }
 

--- a/src/clib/pioc_support.c
+++ b/src/clib/pioc_support.c
@@ -956,9 +956,7 @@ int PIOc_freedecomp(int iosysid, int ioid)
     int mpierr = MPI_SUCCESS;  /* Return code from MPI function calls. */
     int ret = 0;
 
-#ifdef TIMING
     GPTLstart("PIO:PIOc_freedecomp");
-#endif
     if (!(ios = pio_get_iosystem_from_id(iosysid)))
     {
         return pio_err(NULL, NULL, PIO_EBADID, __FILE__, __LINE__,
@@ -1042,9 +1040,7 @@ int PIOc_freedecomp(int iosysid, int ioid)
         return pio_err(ios, NULL, ret, __FILE__, __LINE__,
                         "Freeing PIO decomposition failed (iosysid = %d, ioid=%d). Error while trying to delete I/O descriptor from internal list", iosysid, ioid); 
     }
-#ifdef TIMING
     GPTLstop("PIO:PIOc_freedecomp");
-#endif
 
     return ret;
 }
@@ -2194,12 +2190,10 @@ int PIOc_createfile_int(int iosysid, int *ncidp, int *iotype, const char *filena
     int mpierr = MPI_SUCCESS;  /* Return code from MPI function codes. */
     int ierr = PIO_NOERR;              /* Return code from function calls. */
 
-#ifdef TIMING
     GPTLstart("PIO:PIOc_createfile_int");
 #ifdef _ADIOS2 /* TAHSIN: timing */
     if (*iotype == PIO_IOTYPE_ADIOS)
         GPTLstart("PIO:PIOc_createfile_int_adios"); /* TAHSIN: start */
-#endif
 #endif
     /* Get the IO system info from the iosysid. */
     if (!(ios = pio_get_iosystem_from_id(iosysid)))
@@ -2579,17 +2573,13 @@ int PIOc_createfile_int(int iosysid, int *ncidp, int *iotype, const char *filena
     /* If there was an error, free the memory we allocated and handle error. */
     if(ierr != PIO_NOERR){
 #ifdef _ADIOS2
-#ifdef TIMING /* TAHSIN: timing */
         if (file->iotype == PIO_IOTYPE_ADIOS)
             GPTLstop("PIO:PIOc_createfile_int_adios"); /* TAHSIN: stop */
-#endif
         free(file->filename);
 #endif
 
         free(file);
-#ifdef TIMING
         GPTLstop("PIO:PIOc_createfile_int");
-#endif
         return pio_err(ios, NULL, ierr, __FILE__, __LINE__,
                         "Creating file (%s) failed. Internal error", filename);
     }
@@ -2617,12 +2607,10 @@ int PIOc_createfile_int(int iosysid, int *ncidp, int *iotype, const char *filena
     LOG((2, "Created file %s file->fh = %d file->pio_ncid = %d", filename,
          file->fh, file->pio_ncid));
 
-#ifdef TIMING
     GPTLstop("PIO:PIOc_createfile_int");
 #ifdef _ADIOS2 /* TAHSIN: timing */
     if (file->iotype == PIO_IOTYPE_ADIOS)
         GPTLstop("PIO:PIOc_createfile_int_adios"); /* TAHSIN: stop */
-#endif
 #endif
 
     return ierr;

--- a/src/clib/pioc_support.c
+++ b/src/clib/pioc_support.c
@@ -959,12 +959,14 @@ int PIOc_freedecomp(int iosysid, int ioid)
     GPTLstart("PIO:PIOc_freedecomp");
     if (!(ios = pio_get_iosystem_from_id(iosysid)))
     {
+        GPTLstop("PIO:PIOc_freedecomp");
         return pio_err(NULL, NULL, PIO_EBADID, __FILE__, __LINE__,
                         "Freeing PIO decomposition failed. Invalid iosystem id (%d) provided", iosysid);
     }
 
     if (!(iodesc = pio_get_iodesc_from_id(ioid)))
     {
+        GPTLstop("PIO:PIOc_freedecomp");
         return pio_err(ios, NULL, PIO_EBADID, __FILE__, __LINE__,
                         "Freeing PIO decomposition failed. Invalid io decomposition id (%d) provided", ioid);
     }
@@ -977,6 +979,7 @@ int PIOc_freedecomp(int iosysid, int ioid)
         PIO_SEND_ASYNC_MSG(ios, msg, &ret, iosysid, ioid);
         if(ret != PIO_NOERR)
         {
+            GPTLstop("PIO:PIOc_freedecomp");
             return pio_err(ios, NULL, ret, __FILE__, __LINE__,
                             "Freeing PIO decomposition failed (iosysid = %d, iodesc id=%d). Error sending asynchronous message, PIO_MSG_FREEDECOMP, on iosystem", iosysid, ioid);
         }
@@ -996,7 +999,10 @@ int PIOc_freedecomp(int iosysid, int ioid)
         for (int i = 0; i < iodesc->nrecvs; i++)
             if (iodesc->rtype[i] != PIO_DATATYPE_NULL)
                 if ((mpierr = MPI_Type_free(&iodesc->rtype[i])))
+                {
+                    GPTLstop("PIO:PIOc_freedecomp");
                     return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
+                }
 
         free(iodesc->rtype);
     }
@@ -1006,7 +1012,10 @@ int PIOc_freedecomp(int iosysid, int ioid)
         for (int i = 0; i < iodesc->num_stypes; i++)
             if (iodesc->stype[i] != PIO_DATATYPE_NULL)
                 if ((mpierr = MPI_Type_free(iodesc->stype + i)))
+                {
+                    GPTLstop("PIO:PIOc_freedecomp");
                     return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
+                }
 
         iodesc->num_stypes = 0;
         free(iodesc->stype);
@@ -1032,11 +1041,15 @@ int PIOc_freedecomp(int iosysid, int ioid)
 
     if (iodesc->rearranger == PIO_REARR_SUBSET)
         if ((mpierr = MPI_Comm_free(&iodesc->subset_comm)))
+        {
+            GPTLstop("PIO:PIOc_freedecomp");
             return check_mpi(ios, NULL, mpierr, __FILE__, __LINE__);
+        }
 
     ret = pio_delete_iodesc_from_list(ioid);
     if (ret != PIO_NOERR)
     {
+        GPTLstop("PIO:PIOc_freedecomp");
         return pio_err(ios, NULL, ret, __FILE__, __LINE__,
                         "Freeing PIO decomposition failed (iosysid = %d, ioid=%d). Error while trying to delete I/O descriptor from internal list", iosysid, ioid); 
     }
@@ -2191,13 +2204,15 @@ int PIOc_createfile_int(int iosysid, int *ncidp, int *iotype, const char *filena
     int ierr = PIO_NOERR;              /* Return code from function calls. */
 
     GPTLstart("PIO:PIOc_createfile_int");
-#ifdef _ADIOS2 /* TAHSIN: timing */
     if (*iotype == PIO_IOTYPE_ADIOS)
-        GPTLstart("PIO:PIOc_createfile_int_adios"); /* TAHSIN: start */
-#endif
+        GPTLstart("PIO:PIOc_createfile_int_adios");
+
     /* Get the IO system info from the iosysid. */
     if (!(ios = pio_get_iosystem_from_id(iosysid)))
     {
+        GPTLstop("PIO:PIOc_createfile_int");
+        if (*iotype == PIO_IOTYPE_ADIOS)
+            GPTLstop("PIO:PIOc_createfile_int_adios");
         return pio_err(NULL, NULL, PIO_EBADID, __FILE__, __LINE__,
                         "Creating file (%s) failed. Invalid iosystem id (%d) provided", (filename) ? filename : "UNKNOWN", iosysid);
     }
@@ -2205,6 +2220,9 @@ int PIOc_createfile_int(int iosysid, int *ncidp, int *iotype, const char *filena
     /* User must provide valid input for these parameters. */
     if (!ncidp || !iotype || !filename || strlen(filename) > PIO_MAX_NAME)
     {
+        GPTLstop("PIO:PIOc_createfile_int");
+        if (*iotype == PIO_IOTYPE_ADIOS)
+            GPTLstop("PIO:PIOc_createfile_int_adios");
         return pio_err(ios, NULL, PIO_EINVAL, __FILE__, __LINE__,
                         "Creating file failed. Invalid arguments provided, ncidp is %s (expected not NULL), iotype is %s (expected not NULL), filename is %s (expected not NULL), filename length = %lld (expected <= %d)", PIO_IS_NULL(ncidp), PIO_IS_NULL(iotype), PIO_IS_NULL(filename), (filename) ? ((unsigned long long )strlen(filename)) : 0, (int )PIO_MAX_NAME);
     }
@@ -2214,6 +2232,9 @@ int PIOc_createfile_int(int iosysid, int *ncidp, int *iotype, const char *filena
     {
         char avail_iotypes[PIO_MAX_NAME + 1];
         PIO_get_avail_iotypes(avail_iotypes, PIO_MAX_NAME);
+        GPTLstop("PIO:PIOc_createfile_int");
+        if (*iotype == PIO_IOTYPE_ADIOS)
+            GPTLstop("PIO:PIOc_createfile_int_adios");
         return pio_err(ios, NULL, PIO_EBADIOTYPE, __FILE__, __LINE__,
                         "Creating file (%s) failed. Invalid iotype (%s:%d) specified. Available iotypes are : %s", filename, pio_iotype_to_string(*iotype), *iotype, avail_iotypes);
     }
@@ -2224,6 +2245,9 @@ int PIOc_createfile_int(int iosysid, int *ncidp, int *iotype, const char *filena
     /* Allocate space for the file info. */
     if (!(file = calloc(sizeof(file_desc_t), 1)))
     {
+        GPTLstop("PIO:PIOc_createfile_int");
+        if (*iotype == PIO_IOTYPE_ADIOS)
+            GPTLstop("PIO:PIOc_createfile_int_adios");
         return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__,
                         "Creating file (%s) failed. Out of memory allocating %lld bytes for the file descriptor", filename, (unsigned long long) (sizeof(file_desc_t)));
     }
@@ -2273,6 +2297,9 @@ int PIOc_createfile_int(int iosysid, int *ncidp, int *iotype, const char *filena
         PIO_SEND_ASYNC_MSG(ios, msg, &ierr, len, filename, file->iotype, file->mode);
         if(ierr != PIO_NOERR)
         {
+            GPTLstop("PIO:PIOc_createfile_int");
+            if (*iotype == PIO_IOTYPE_ADIOS)
+                GPTLstop("PIO:PIOc_createfile_int_adios");
             return pio_err(ios, NULL, ierr, __FILE__, __LINE__,
                             "Creating file (%s) failed. Error sending asynchronous message, PIO_MSG_CREATE_FILE, to create the file on iosystem (iosysid=%d)", filename, ios->iosysid);
         }
@@ -2289,6 +2316,9 @@ int PIOc_createfile_int(int iosysid, int *ncidp, int *iotype, const char *filena
         file->filename = malloc(len + 4);
         if (file->filename == NULL)
         {
+            GPTLstop("PIO:PIOc_createfile_int");
+            if (*iotype == PIO_IOTYPE_ADIOS)
+                GPTLstop("PIO:PIOc_createfile_int_adios");
             return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__,
                             "Creating file (%s) using ADIOS iotype failed. Out of memory allocating %lld bytes for the file name", filename, (unsigned long long) (len + 4));
         }
@@ -2318,7 +2348,12 @@ int PIOc_createfile_int(int iosysid, int *ncidp, int *iotype, const char *filena
             /* Make sure that no task is trying to operate on the
              * directory while it is being deleted */
             if ((mpierr = MPI_Barrier(ios->union_comm)))
+            {
+                GPTLstop("PIO:PIOc_createfile_int");
+                if (*iotype == PIO_IOTYPE_ADIOS)
+                    GPTLstop("PIO:PIOc_createfile_int_adios");
                 return check_mpi(ios, file, mpierr, __FILE__, __LINE__);
+            }
         }
 
         /* Create a new ADIOS group */
@@ -2330,12 +2365,18 @@ int PIOc_createfile_int(int iosysid, int *ncidp, int *iotype, const char *filena
             file->ioH = adios2_declare_io(ios->adiosH, (const char*)(declare_name));
             if (file->ioH == NULL)
             {
+                GPTLstop("PIO:PIOc_createfile_int");
+                if (*iotype == PIO_IOTYPE_ADIOS)
+                    GPTLstop("PIO:PIOc_createfile_int_adios");
                 return pio_err(ios, NULL, PIO_EADIOS2ERR, __FILE__, __LINE__, "Declaring (ADIOS) IO (name=%s) failed for file (%s)", declare_name, pio_get_fname_from_file(file));
             }
 
             adios2_error adiosErr = adios2_set_engine(file->ioH, "BP3");
             if (adiosErr != adios2_error_none)
             {
+                GPTLstop("PIO:PIOc_createfile_int");
+                if (*iotype == PIO_IOTYPE_ADIOS)
+                    GPTLstop("PIO:PIOc_createfile_int_adios");
                 return pio_err(ios, NULL, PIO_EADIOS2ERR, __FILE__, __LINE__, "Setting (ADIOS) engine (type=BP3) failed (adios2_error=%s) for file (%s)", adios2_error_to_string(adiosErr), pio_get_fname_from_file(file));
             }
 
@@ -2355,18 +2396,27 @@ int PIOc_createfile_int(int iosysid, int *ncidp, int *iotype, const char *filena
             adiosErr = adios2_set_parameter(file->ioH, "substreams", file->params);
             if (adiosErr != adios2_error_none)
             {
+                GPTLstop("PIO:PIOc_createfile_int");
+                if (*iotype == PIO_IOTYPE_ADIOS)
+                    GPTLstop("PIO:PIOc_createfile_int_adios");
                 return pio_err(ios, NULL, PIO_EADIOS2ERR, __FILE__, __LINE__, "Setting (ADIOS) parameter (substreams=%s) failed (adios2_error=%s) for file (%s)", file->params, adios2_error_to_string(adiosErr), pio_get_fname_from_file(file));
             }
 
             adiosErr = adios2_set_parameter(file->ioH, "CollectiveMetadata", "OFF");
             if (adiosErr != adios2_error_none)
             {
+                GPTLstop("PIO:PIOc_createfile_int");
+                if (*iotype == PIO_IOTYPE_ADIOS)
+                    GPTLstop("PIO:PIOc_createfile_int_adios");
                 return pio_err(ios, NULL, PIO_EADIOS2ERR, __FILE__, __LINE__, "Setting (ADIOS) parameter (CollectiveMetadata=OFF) failed (adios2_error=%s) for file (%s)", adios2_error_to_string(adiosErr), pio_get_fname_from_file(file));
             }
 
             file->engineH = adios2_open(file->ioH, file->filename, adios2_mode_write);
             if (file->engineH == NULL)
             {
+                GPTLstop("PIO:PIOc_createfile_int");
+                if (*iotype == PIO_IOTYPE_ADIOS)
+                    GPTLstop("PIO:PIOc_createfile_int_adios");
                 return pio_err(NULL, file, PIO_EADIOS2ERR, __FILE__, __LINE__, "Opening (ADIOS) file (%s) failed", pio_get_fname_from_file(file));
             }
 
@@ -2397,6 +2447,9 @@ int PIOc_createfile_int(int iosysid, int *ncidp, int *iotype, const char *filena
                                                        adios2_constant_dims_true);
                     if (variableH == NULL)
                     {
+                        GPTLstop("PIO:PIOc_createfile_int");
+                        if (*iotype == PIO_IOTYPE_ADIOS)
+                            GPTLstop("PIO:PIOc_createfile_int_adios");
                         return pio_err(ios, NULL, PIO_EADIOS2ERR, __FILE__, __LINE__, "Defining (ADIOS) variable (name=/__pio__/info/nproc) failed for file (%s)", pio_get_fname_from_file(file));
                     }
                 }
@@ -2404,6 +2457,9 @@ int PIOc_createfile_int(int iosysid, int *ncidp, int *iotype, const char *filena
                 adios2_error adiosErr = adios2_put(file->engineH, variableH, &ios->num_uniontasks, adios2_mode_sync);
                 if (adiosErr != adios2_error_none)
                 {
+                    GPTLstop("PIO:PIOc_createfile_int");
+                    if (*iotype == PIO_IOTYPE_ADIOS)
+                        GPTLstop("PIO:PIOc_createfile_int_adios");
                     return pio_err(ios, NULL, PIO_EADIOS2ERR, __FILE__, __LINE__, "Putting (ADIOS) variable (name=/__pio__/info/nproc) failed (adios2_error=%s) for file (%s)", adios2_error_to_string(adiosErr), pio_get_fname_from_file(file));
                 }
             }
@@ -2572,9 +2628,10 @@ int PIOc_createfile_int(int iosysid, int *ncidp, int *iotype, const char *filena
     ierr = check_netcdf(ios, NULL, ierr, __FILE__, __LINE__);
     /* If there was an error, free the memory we allocated and handle error. */
     if(ierr != PIO_NOERR){
-#ifdef _ADIOS2
         if (file->iotype == PIO_IOTYPE_ADIOS)
-            GPTLstop("PIO:PIOc_createfile_int_adios"); /* TAHSIN: stop */
+            GPTLstop("PIO:PIOc_createfile_int_adios");
+
+#ifdef _ADIOS2
         free(file->filename);
 #endif
 
@@ -2586,7 +2643,12 @@ int PIOc_createfile_int(int iosysid, int *ncidp, int *iotype, const char *filena
 
     /* Broadcast mode to all tasks. */
     if ((mpierr = MPI_Bcast(&file->mode, 1, MPI_INT, ios->ioroot, ios->union_comm)))
+    {
+        GPTLstop("PIO:PIOc_createfile_int");
+        if (*iotype == PIO_IOTYPE_ADIOS)
+            GPTLstop("PIO:PIOc_createfile_int_adios");
         return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
+    }
 
     /* This flag is implied by netcdf create functions but we need
        to know if its set. */
@@ -2608,10 +2670,8 @@ int PIOc_createfile_int(int iosysid, int *ncidp, int *iotype, const char *filena
          file->fh, file->pio_ncid));
 
     GPTLstop("PIO:PIOc_createfile_int");
-#ifdef _ADIOS2 /* TAHSIN: timing */
     if (file->iotype == PIO_IOTYPE_ADIOS)
-        GPTLstop("PIO:PIOc_createfile_int_adios"); /* TAHSIN: stop */
-#endif
+        GPTLstop("PIO:PIOc_createfile_int_adios");
 
     return ierr;
 }

--- a/src/gptl/CMakeLists.txt
+++ b/src/gptl/CMakeLists.txt
@@ -33,6 +33,13 @@ target_include_directories (gptl
 target_compile_definitions (gptl
   PUBLIC INCLUDE_CMAKE_FCI)
 
+if (PIO_ENABLE_TIMING)
+  if (PIO_ENABLE_INTERNAL_TIMING)
+    target_compile_definitions (gptl
+      PRIVATE GPTL_ASSERT_ON_RECURSION)
+  endif ()
+endif ()
+
 if (CMAKE_SYSTEM_NAME MATCHES "AIX")
   target_compile_definitions (gptl
     PRIVATE _AIX)

--- a/src/gptl/gptl.c
+++ b/src/gptl/gptl.c
@@ -627,6 +627,9 @@ int GPTLstart_instr (void *self)
   */
   
   if (ptr && ptr->onflg) {
+#ifdef GPTL_ASSERT_ON_RECURSION
+    assert(0);
+#endif
     ++ptr->recurselvl;
     return 0;
   }
@@ -714,6 +717,9 @@ int GPTLstart (const char *name)               /* timer name */
   */
 
   if (ptr && ptr->onflg) {
+#ifdef GPTL_ASSERT_ON_RECURSION
+    assert(0);
+#endif
     ++ptr->recurselvl;
     return 0;
   }
@@ -803,6 +809,9 @@ int GPTLstart_handle (const char *name,  /* timer name */
   */
 
   if (ptr && ptr->onflg) {
+#ifdef GPTL_ASSERT_ON_RECURSION
+    assert(0);
+#endif
     ++ptr->recurselvl;
     return 0;
   }

--- a/tests/general/ncdf_fail.F90.in
+++ b/tests/general/ncdf_fail.F90.in
@@ -68,6 +68,101 @@ PIO_TF_AUTO_TEST_SUB_BEGIN test_redef_twice
 
 PIO_TF_AUTO_TEST_SUB_END test_redef_twice
 
+PIO_TF_AUTO_TEST_SUB_BEGIN test_inq_missing
+  use ncdf_fail_tgv
+  Implicit none
+  type(file_desc_t) :: pio_file
+  character(len=PIO_TF_MAX_STR_LEN), parameter :: fname = "ncdf_fail_test_inq_missing.nc"
+  character(len=PIO_TF_MAX_STR_LEN), parameter :: missing_data = "MISSING_VAL"
+  character(len=PIO_TF_MAX_STR_LEN) :: tmp_str
+  ! The file has no variables
+  integer, parameter :: INVALID_ID = 1000
+  integer :: var_id, dim_id, att_id, tmp_val
+  integer(kind=PIO_OFFSET_KIND) :: tmp_val2
+  integer :: ret
+
+  ret = PIO_createfile(pio_tf_iosystem_, pio_file, tgv_iotype, fname, PIO_CLOBBER)
+  PIO_TF_CHECK_ERR(ret, "Failed to create:" // trim(fname))
+
+  ret = PIO_enddef(pio_file)
+  PIO_TF_CHECK_ERR(ret, "Failed to end redef mode" // trim(fname))
+
+  ret = PIO_inq_varid(pio_file, missing_data, var_id)
+  PIO_TF_PASSERT(ret /= PIO_NOERR, "Querying missing var id did not fail as expected")
+
+  var_id = INVALID_ID
+
+  ret = PIO_inq_varname(pio_file, var_id, tmp_str)
+  PIO_TF_PASSERT(ret /= PIO_NOERR, "Querying missing var name did not fail as expected")
+
+  ret = PIO_inq_vartype(pio_file, var_id, tmp_val)
+  PIO_TF_PASSERT(ret /= PIO_NOERR, "Querying missing var type did not fail as expected")
+
+  ret = PIO_inq_varndims(pio_file, var_id, tmp_val)
+  PIO_TF_PASSERT(ret /= PIO_NOERR, "Querying missing var ndims did not fail as expected")
+
+  ret = PIO_inq_varnatts(pio_file, var_id, tmp_val)
+  PIO_TF_PASSERT(ret /= PIO_NOERR, "Querying missing var natts did not fail as expected")
+
+  ret = PIO_inq_dimid(pio_file, missing_data, dim_id)
+  PIO_TF_PASSERT(ret /= PIO_NOERR, "Querying missing dim id did not fail as expected")
+
+  dim_id = INVALID_ID
+
+  ret = PIO_inq_dimname(pio_file, dim_id, tmp_str)
+  PIO_TF_PASSERT(ret /= PIO_NOERR, "Querying missing dim name did not fail as expected")
+
+  ret = PIO_inq_dimlen(pio_file, dim_id, tmp_val)
+  PIO_TF_PASSERT(ret /= PIO_NOERR, "Querying missing dim len did not fail as expected")
+
+  att_id = INVALID_ID
+
+  ret = PIO_inq_attname(pio_file, var_id, att_id, tmp_str)
+  PIO_TF_PASSERT(ret /= PIO_NOERR, "Querying missing att name did not fail as expected")
+
+  ret = PIO_inq_attlen(pio_file, var_id, missing_data, tmp_val2)
+  PIO_TF_PASSERT(ret /= PIO_NOERR, "Querying missing att len did not fail as expected")
+
+  call PIO_closefile(pio_file)
+
+  call PIO_deletefile(pio_tf_iosystem_, fname)
+PIO_TF_AUTO_TEST_SUB_END test_inq_missing
+
+PIO_TF_AUTO_TEST_SUB_BEGIN test_get_missing
+  use ncdf_fail_tgv
+  Implicit none
+  type(file_desc_t) :: pio_file
+  character(len=PIO_TF_MAX_STR_LEN), parameter :: fname = "ncdf_fail_test_get_missing.nc"
+  character(len=PIO_TF_MAX_STR_LEN), parameter :: missing_data = "MISSING_VAL"
+  character(len=PIO_TF_MAX_STR_LEN) :: tmp_str
+  integer :: tmp_val(1)
+  ! The file has no variables
+  integer, parameter :: INVALID_ID = 1000
+  integer :: var_id
+  integer :: ret
+
+  ret = PIO_createfile(pio_tf_iosystem_, pio_file, tgv_iotype, fname, PIO_CLOBBER)
+  PIO_TF_CHECK_ERR(ret, "Failed to create:" // trim(fname))
+
+  ret = PIO_enddef(pio_file)
+  PIO_TF_CHECK_ERR(ret, "Failed to end redef mode" // trim(fname))
+
+  ret = PIO_inq_varid(pio_file, missing_data, var_id)
+  PIO_TF_PASSERT(ret /= PIO_NOERR, "Querying missing var id did not fail as expected")
+
+  var_id = INVALID_ID
+
+  ret = PIO_get_var(pio_file, var_id, tmp_val)
+  PIO_TF_PASSERT(ret /= PIO_NOERR, "Getting missing var did not fail as expected")
+
+  ret = PIO_get_att(pio_file, PIO_GLOBAL, missing_data, tmp_str)
+  PIO_TF_PASSERT(ret /= PIO_NOERR, "Getting missing att did not fail as expected")
+
+  call PIO_closefile(pio_file)
+
+  call PIO_deletefile(pio_tf_iosystem_, fname)
+PIO_TF_AUTO_TEST_SUB_END test_get_missing
+
 PIO_TF_TEST_DRIVER_BEGIN
   use ncdf_fail_tgv
   Implicit none


### PR DESCRIPTION
* Stop GPTL timers when returning to the user (including on error)
* Fixing some missing error code returns to the user
* Some tests for missing variables, dimensions and attributes
* An option in internal GPTL library to assert on recursive timers
  (only enabled when internal Scorpio timing is enabled)

Fixes #350 