### PR TITLE
Disable using regex for IBM and PGI compilers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -177,12 +177,26 @@ set (CMAKE_Fortran_COMPILER_DIRECTIVE "CPR${CMAKE_Fortran_COMPILER_NAME}"
 #==============================================================================
 #  CHECK MIN VERSION OF COMPILERS REQD
 #==============================================================================
-# Regex is only available in GCC 4.9+ (> 4.8)
+# Regex is only available in GCC 4.9+ (>= 4.9)
 if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-  if (NOT CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 4.8)
-    message (FATAL_ERROR "SCORPIO requires GCC 4.9+ to build correctly")
+  if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS "4.9")
+    message (WARNING "C++11 regex support is disabled since the compiler does not support it")
+    add_definitions(-DSPIO_NO_CXX_REGEX)
   endif()
 endif ()
+
+# Disable C++11 regex usage for IBM XL and PGI compilers on Summit
+# The IBM XL compiler (16.1.1-8) and the PGI compiler (20.1) on Summit
+# have a buggy support for C++11 regex
+string (TOUPPER "${CMAKE_CXX_COMPILER_ID}" CMAKE_CXX_COMPILER_NAME)
+cmake_host_system_information (RESULT FQDN_SITENAME QUERY FQDN)
+if (FQDN_SITENAME MATCHES "^.*summit[.]olcf")
+  if ((CMAKE_CXX_COMPILER_NAME STREQUAL "XL") OR
+      (CMAKE_CXX_COMPILER_NAME STREQUAL "PGI"))
+    message (WARNING "C++11 regex support is disabled since the compiler does not support it")
+    add_definitions(-DSPIO_NO_CXX_REGEX)
+  endif()
+endif()
 
 #==============================================================================
 #  MIN VERSION OF LIBRARIES REQD

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -185,17 +185,15 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
   endif()
 endif ()
 
-# Disable C++11 regex usage for IBM XL and PGI compilers on Summit
-# The IBM XL compiler (16.1.1-8) and the PGI compiler (20.1) on Summit
-# have a buggy support for C++11 regex
+# Disable C++11 regex usage for IBM XL and PGI compilers
+# The IBM XL compiler (16.1.1-8) and the PGI compiler (20.1) on Summit,
+# and the PGI compiler (19.10) on compy have a buggy support for
+# C++11 regex
 string (TOUPPER "${CMAKE_CXX_COMPILER_ID}" CMAKE_CXX_COMPILER_NAME)
-cmake_host_system_information (RESULT FQDN_SITENAME QUERY FQDN)
-if (FQDN_SITENAME MATCHES "^.*summit[.]olcf")
-  if ((CMAKE_CXX_COMPILER_NAME STREQUAL "XL") OR
-      (CMAKE_CXX_COMPILER_NAME STREQUAL "PGI"))
-    message (WARNING "C++11 regex support is disabled since the compiler does not support it")
-    add_definitions(-DSPIO_NO_CXX_REGEX)
-  endif()
+if ((CMAKE_CXX_COMPILER_NAME STREQUAL "XL") OR
+    (CMAKE_CXX_COMPILER_NAME STREQUAL "PGI"))
+  message (WARNING "C++11 regex support is disabled since the compiler does not support it")
+  add_definitions(-DSPIO_NO_CXX_REGEX)
 endif()
 
 #==============================================================================

--- a/src/clib/pio_sdecomps_regex.cpp
+++ b/src/clib/pio_sdecomps_regex.cpp
@@ -611,6 +611,14 @@ namespace PIO_Util{
   }
 } // namespace PIO_Util
 
+#ifdef SPIO_NO_CXX_REGEX
+bool pio_save_decomps_regex_match(int ioid, const char *fname, const char *vname)
+{
+  LOG((1, "WARNING: Since C++11 regex support is not available all decomps are matched/saved"));
+  /* Match everything */
+  return true;
+}
+#else /* SPIO_NO_CXX_REGEX */
 static PIO_Util::PIO_save_decomp_regex pio_sdecomp_regex(PIO_SAVE_DECOMPS_REGEX);
 
 bool pio_save_decomps_regex_match(int ioid, const char *fname, const char *vname)
@@ -623,3 +631,4 @@ bool pio_save_decomps_regex_match(int ioid, const char *fname, const char *vname
   std::string vname_str((vname) ? vname : "");
   return pio_sdecomp_regex.matches(ioid, fname_str, vname_str);
 }
+#endif /* SPIO_NO_CXX_REGEX */

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -14,6 +14,13 @@ if (FQDN_SITENAME MATCHES "^.*summit[.]olcf")
   endif()
 endif()
 
+# GNU implemented a working version of C++11 regex
+# in version >= 4.9
+if ((CMAKE_CXX_COMPILER_NAME STREQUAL "GNU") AND
+    (CMAKE_CXX_COMPILER_VERSION VERSION_LESS "4.9"))
+  add_definitions(-DSPIO_NO_CXX_REGEX)
+endif()
+
 if (WITH_ADIOS2)
   find_package (ADIOS2 ${ADIOS_MIN_VER_REQD})
   if (ADIOS2_FOUND)

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -2,6 +2,16 @@
 ### CMakeList.txt for examples using pio
 ###-------------------------------------------------------------------------###
 
+# Disable C++11 regex usage for IBM XL compiler (16.*) on Summit
+# The IBM XL compiler on Summit has a buggy support for C++11 regex
+string (TOUPPER "${CMAKE_CXX_COMPILER_ID}" CMAKE_CXX_COMPILER_NAME)
+cmake_host_system_information (RESULT FQDN_SITENAME QUERY FQDN)
+if (FQDN_SITENAME MATCHES "^.*summit[.]olcf")
+  if (CMAKE_CXX_COMPILER_NAME STREQUAL "XL")
+    add_definitions(-DSPIO_NO_CXX_REGEX)
+  endif()
+endif()
+
 if (WITH_ADIOS2)
   find_package (ADIOS2 ${ADIOS_MIN_VER_REQD})
   if (ADIOS2_FOUND)

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -2,25 +2,6 @@
 ### CMakeList.txt for examples using pio
 ###-------------------------------------------------------------------------###
 
-# Disable C++11 regex usage for IBM XL and PGI compilers on Summit
-# The IBM XL compiler (16.1.1-8) and the PGI compiler (20.1) on Summit
-# have a buggy support for C++11 regex
-string (TOUPPER "${CMAKE_CXX_COMPILER_ID}" CMAKE_CXX_COMPILER_NAME)
-cmake_host_system_information (RESULT FQDN_SITENAME QUERY FQDN)
-if (FQDN_SITENAME MATCHES "^.*summit[.]olcf")
-  if ((CMAKE_CXX_COMPILER_NAME STREQUAL "XL") OR
-      (CMAKE_CXX_COMPILER_NAME STREQUAL "PGI"))
-    add_definitions(-DSPIO_NO_CXX_REGEX)
-  endif()
-endif()
-
-# GNU implemented a working version of C++11 regex
-# in version >= 4.9
-if ((CMAKE_CXX_COMPILER_NAME STREQUAL "GNU") AND
-    (CMAKE_CXX_COMPILER_VERSION VERSION_LESS "4.9"))
-  add_definitions(-DSPIO_NO_CXX_REGEX)
-endif()
-
 if (WITH_ADIOS2)
   find_package (ADIOS2 ${ADIOS_MIN_VER_REQD})
   if (ADIOS2_FOUND)

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -2,12 +2,14 @@
 ### CMakeList.txt for examples using pio
 ###-------------------------------------------------------------------------###
 
-# Disable C++11 regex usage for IBM XL compiler (16.*) on Summit
-# The IBM XL compiler on Summit has a buggy support for C++11 regex
+# Disable C++11 regex usage for IBM XL and PGI compilers on Summit
+# The IBM XL compiler (16.1.1-8) and the PGI compiler (20.1) on Summit
+# have a buggy support for C++11 regex
 string (TOUPPER "${CMAKE_CXX_COMPILER_ID}" CMAKE_CXX_COMPILER_NAME)
 cmake_host_system_information (RESULT FQDN_SITENAME QUERY FQDN)
 if (FQDN_SITENAME MATCHES "^.*summit[.]olcf")
-  if (CMAKE_CXX_COMPILER_NAME STREQUAL "XL")
+  if ((CMAKE_CXX_COMPILER_NAME STREQUAL "XL") OR
+      (CMAKE_CXX_COMPILER_NAME STREQUAL "PGI"))
     add_definitions(-DSPIO_NO_CXX_REGEX)
   endif()
 endif()

--- a/tools/adios2pio-nm/adios2pio-nm.cxx
+++ b/tools/adios2pio-nm/adios2pio-nm.cxx
@@ -30,7 +30,11 @@ static int get_user_options(
     mem_opt = 0;
     debug_lvl = 0;
 
+#ifdef SPIO_NO_CXX_REGEX
+    ap.no_regex_parse(argc, argv);
+#else
     ap.parse(argc, argv);
+#endif
     if (!ap.has_arg("bp-file") && !ap.has_arg("idir"))
     {
         ap.print_usage(std::cerr);

--- a/tools/adios2pio-nm/adios2pio-nm.cxx
+++ b/tools/adios2pio-nm/adios2pio-nm.cxx
@@ -119,9 +119,11 @@ int main(int argc, char *argv[])
     }
 
 #ifdef TIMING
+#ifndef TIMING_INTERNAL
     /* Initialize the GPTL timing library. */
     if ((ret = GPTLinitialize()))
         return ret;
+#endif
 #endif
 
     SetDebugOutput(debug_lvl);
@@ -137,9 +139,11 @@ int main(int argc, char *argv[])
     MPI_Barrier(comm_in);
 
 #ifdef TIMING
+#ifndef TIMING_INTERNAL
     /* Finalize the GPTL timing library. */
     if ((ret = GPTLfinalize()))
         return ret;
+#endif
 #endif
 
     MPI_Finalize();

--- a/tools/adios2pio-nm/adios2pio-nm.cxx
+++ b/tools/adios2pio-nm/adios2pio-nm.cxx
@@ -17,45 +17,32 @@ static void init_user_options(spio_tool_utils::ArgParser &ap)
       .add_opt("verbose", "Turn on verbose info messages");
 }
 
-/* Convert BP dir name (that contains the ADIOS BP data)
- * to the corresponding NetCDF file name by stripping
- * off the file type extensions at the end of the BP dir name.
+/* Convert BP file name (<BP_FILE_NAME>.dir contains the ADIOS BP data)
+ * to the corresponding NetCDF file name by stripping off the BP
+ * file type extension at the end of the BP file name.
  *
- * BP dir names are of the form "^.*([.]nc)?[.]bp$"
- * The returned string is the BP dir name stripped off the
- * ".nc" and ".bp" extensions
+ * BP file names are of the form "^.*([.]nc)?[.]bp$"
+ * The returned string is the BP file name stripped off the
+ * ".bp" extension
  */
-static std::string strip_ftype_ext(const std::string &bp_dname)
+static std::string strip_bp_ext(const std::string &bp_fname)
 {
 #ifdef SPIO_NO_CXX_REGEX
     const std::string bp_ext(".bp");
-    const std::string nc_opt_ext(".nc");
     std::size_t ext_sz = bp_ext.size();
-    if (bp_dname.size() > ext_sz)
+    if (bp_fname.size() > ext_sz)
     {
-        std::size_t chars_to_trim = 0;
-        if (bp_dname.substr(bp_dname.size() - ext_sz, ext_sz) ==  bp_ext)
+        if (bp_fname.substr(bp_fname.size() - ext_sz, ext_sz) ==  bp_ext)
         {
-            chars_to_trim += ext_sz;
-            ext_sz = nc_opt_ext.size();
-            if (bp_dname.size() > chars_to_trim + ext_sz)
-            {
-                if (bp_dname.substr(bp_dname.size() - chars_to_trim - ext_sz, ext_sz)
-                      == nc_opt_ext)
-                {
-                    chars_to_trim += ext_sz;
-                }
-            }
-
-            return bp_dname.substr(0, bp_dname.size() - chars_to_trim);
+            return bp_fname.substr(0, bp_fname.size() - ext_sz);
         }
     }
 #else
-    const std::string BP_DIR_RGX_STR("(.*)([.]nc)?[.]bp");
-    std::regex bp_dir_rgx(BP_DIR_RGX_STR.c_str());
+    const std::string BP_FILE_RGX_STR("(.*)[.]bp");
+    std::regex bp_file_rgx(BP_FILE_RGX_STR.c_str());
     std::smatch match;
-    if (std::regex_search(bp_dname, match, bp_dir_rgx) &&
-        match.size() >= 2)
+    if (std::regex_search(bp_fname, match, bp_file_rgx) &&
+        match.size() == 2)
     {
         return match.str(1);
     }
@@ -95,7 +82,7 @@ static int get_user_options(
         }
         else
         {
-            ofile = strip_ftype_ext(ifile);
+            ofile = strip_bp_ext(ifile);
         }
         if (ofile.size() == 0)
         {

--- a/tools/spio_finfo/spio_finfo_tool.cxx
+++ b/tools/spio_finfo/spio_finfo_tool.cxx
@@ -41,7 +41,11 @@ static int get_user_options(
   MPI_Comm_size(comm_in, &sz);
   verbose = false;
 
+#ifdef SPIO_NO_CXX_REGEX
+  ap.no_regex_parse(argc, argv);
+#else
   ap.parse(argc, argv);
+#endif
 
   if (ap.has_arg("verbose")){
     verbose = true;    

--- a/tools/util/argparser.cxx
+++ b/tools/util/argparser.cxx
@@ -10,7 +10,8 @@
 
 namespace spio_tool_utils{
 
-ArgParser::ArgParser(MPI_Comm comm):comm_(comm), is_root_(false),
+ArgParser::ArgParser(MPI_Comm comm):NOVAL_OPT_STR("noval"),
+                                    comm_(comm), is_root_(false),
                                     printed_usage_(false) 
 {
   int rank;
@@ -67,7 +68,6 @@ void ArgParser::parse(int argc, char *argv[])
       }
       else if (std::regex_search(argvi, noval_match, noval_opt_rgx) &&
           (noval_match.size() == 2)){
-        const std::string NOVAL_STR("noval");
         /* No value arguments like "--verbose" */
         if (opts_map_.count(noval_match.str(1)) != 1){
           if (is_root_){
@@ -76,7 +76,7 @@ void ArgParser::parse(int argc, char *argv[])
           }
           throw std::runtime_error("Invalid option");
         }
-        arg_map_[noval_match.str(1)] = NOVAL_STR;
+        arg_map_[noval_match.str(1)] = NOVAL_OPT_STR;
       }
       else{
         if (is_root_){
@@ -85,6 +85,64 @@ void ArgParser::parse(int argc, char *argv[])
         }
         throw std::runtime_error("Invalid option");
       }
+    }
+  }
+}
+
+/* Parse the command line arguments in argv[] without using
+ * C++11 regex expressions. This support is for compatibility
+ * with compilers (e.g. IBM XL 16.x on Summit) that do not
+ * support regex.
+ * Note: Valid options should already be set using add_opt()
+ * before calling parse()
+ */
+void ArgParser::no_regex_parse(int argc, char *argv[])
+{
+  assert(argv);
+  prog_name_ = std::string(argv[0]);
+  for (int i = 1; i < argc; i++){
+    std::string argvi(argv[i]);
+    std::vector<std::string> tokens;
+
+    tokenize_cmd_line_args(argvi, tokens);
+    if (tokens.size() == 2){
+      if (opts_map_.count(tokens[0]) != 1){
+        if (is_root_){
+          std::cerr << "Error: Invalid option, "
+                    << argvi << "\n";
+        }
+        throw std::runtime_error("Invalid option");
+      }
+      /* FIXME: No validation performed on the option value
+       * We could ask the user to specify option type when defining an
+       * option
+       */
+      arg_map_[tokens[0]] = tokens[1];
+    }
+    else if (tokens.size() == 1){
+      /* The "--help" option is provided by default */
+      if ((argvi == "--help") || (argvi == "-h")){
+        print_usage(std::cout);
+        return;
+      }
+      else{
+        /* No value arguments like "--verbose" */
+        if (opts_map_.count(tokens[0]) != 1){
+          if (is_root_){
+            std::cerr << "Error: Invalid option, "
+                      << argvi << "\n";
+          }
+          throw std::runtime_error("Invalid option");
+        }
+        arg_map_[tokens[0]] = NOVAL_OPT_STR;
+      }
+    }
+    else{
+      if (is_root_){
+        std::cerr << "Error: Unable to parse option : "
+                  << argvi << "\n";
+      }
+      throw std::runtime_error("Invalid option");
     }
   }
 }
@@ -107,6 +165,73 @@ void ArgParser::print_usage(std::ostream &ostr) const
         citer = opts_map_.cbegin();
         citer != opts_map_.cend(); ++citer){
     ostr << "--" << (*citer).first << ":\t" << (*citer).second << "\n";
+  }
+}
+
+/* Tokenize command line arguments to tokens
+ * Command line arguments are of the form,
+ * 1) "--opt=val", tokens are "opt", "val"
+ * 2) "--noval_opt", tokens are "noval_opt"
+ */
+void ArgParser::tokenize_cmd_line_args(const std::string &str, std::vector<std::string> &tokens) const
+{
+  if(str.size() < 3){
+    std::cerr << "Unable to tokenize command line arg (too small) : "
+              << str.c_str() << "\n";
+    return;
+  }
+
+  /* All options start with "--" */
+  if((str[0] != '-') || (str[1] != '-')){
+    std::cerr << "Unable to tokenize command line arg (option does not start with '--') : "
+              << str.c_str() << "\n";
+    return;
+  }
+
+  std::stringstream tok_ostr;
+  bool has_val = false;
+  std::size_t idx = 2;
+
+  /* Write the option name to the token stream */
+  for(idx = 2; idx < str.size(); idx++){
+    if(str[idx] == '='){
+      if(tok_ostr.str().size() == 0){
+        std::cerr << "Unable to tokenize command line arg (option does not have expected fmt) : "
+                  << str.c_str() << "\n";
+        return;
+      }
+
+      has_val = true;
+
+      /* Add option name to token list */
+      tokens.push_back(tok_ostr.str());
+
+      /* Reset stream to read optional value */
+      tok_ostr.str("");
+
+      idx++;
+      break;
+    }
+    else{
+      tok_ostr.put(str[idx]);
+    }
+  }
+
+  /* Write the optional value to the token stream */
+  for(; idx < str.size(); idx++){
+    tok_ostr.put(str[idx]);
+  }
+
+  if(tok_ostr.str().size() > 0){
+    /* Add optional value to token list */
+    tokens.push_back(tok_ostr.str());
+  }
+  else{
+    /* Extra sanity check to ensure that "--opt=" is followed by a value */
+    if(has_val){
+      std::cerr << "Warning: possibly corrupted command line arg (missing value for option) : "
+                << str.c_str() << "\n";
+    }
   }
 }
 

--- a/tools/util/argparser.h
+++ b/tools/util/argparser.h
@@ -19,6 +19,12 @@ class ArgParser{
                         const std::string &help_str);
     /* Parse the command line arguments in argv[] */
     void parse(int argc, char *argv[]);
+    /* Parse the command line arguments in argv[]
+     * without using regex
+     * This func supports compilers that do not have
+     * adequate support for regex
+     */
+    void no_regex_parse(int argc, char *argv[]);
     /* Returns true if option, opt, specified via command
      * line arguments and is parsed by the parser
      */
@@ -39,6 +45,7 @@ class ArgParser{
      * line via parse()
      */
     std::map<std::string, std::string> arg_map_;
+    const std::string NOVAL_OPT_STR;
     /* Executable name */
     std::string prog_name_;
     MPI_Comm comm_;
@@ -46,6 +53,10 @@ class ArgParser{
     bool is_root_;
     /* To prevent printing usage/help multiple times */ 
     mutable bool printed_usage_;
+
+    /* Tokenize user command line args */
+    void tokenize_cmd_line_args(const std::string &arg,
+      std::vector<std::string> &tokens) const;
 };
 
 template<typename T>


### PR DESCRIPTION
The IBM (16.1.1-8) and PGI (20.1/19.10) compilers on Summit/Compy
have buggy implementations of C++11 regex.

This change disables regex usage for these compilers and old
versions (< 4.9) of GNU compilers.

Fixes #356 