### PR TITLE
Build scorpio tools for nightly tests

### DIFF
--- a/CTestScript.cmake
+++ b/CTestScript.cmake
@@ -171,6 +171,8 @@ ctest_configure ()
 
 ## -- BUILD
 message (" -- Build - ${CTEST_BUILD_NAME} --")
+set (CTEST_BUILD_COMMAND "${MAKE}")
+ctest_build ()
 set (CTEST_BUILD_COMMAND "${MAKE} tests")
 ctest_build ()
 


### PR DESCRIPTION
It is confirmed that running "make tests" command only does not
build adios2pio-nm.exe or spio_finfo.exe.

For nightly builds, we need run "make" command first to build
ADIOS conversion and file information tools for testing.

This change is a prerequisite for issue #359