### PR TITLE
Handle multi-dimensional temporal variables for ADIOS type

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -203,7 +203,7 @@ set (MPE_MIN_VER_REQD "2.4.8")
 set (NETCDF_C_MIN_VER_REQD "4.3.3")
 set (NETCDF_FORTRAN_MIN_VER_REQD "4.3.3")
 set (PNETCDF_MIN_VER_REQD "1.8.1")
-set (ADIOS_MIN_VER_REQD "2.2.0")
+set (ADIOS_MIN_VER_REQD "2.6.0")
 
 #==============================================================================
 #  SET CODE COVERAGE COMPILER FLAGS

--- a/src/clib/pio.h
+++ b/src/clib/pio.h
@@ -808,6 +808,10 @@ typedef struct adios_var_desc_t
     adios2_variable* decomp_varid;
     adios2_variable* frame_varid;
     adios2_variable* fillval_varid;
+
+    /* to handle multi-dimensional temporal variables */
+    adios2_variable* start_varid;
+    adios2_variable* count_varid;
 } adios_var_desc_t;
 
 /* Track attributes */

--- a/src/clib/pio_file.c
+++ b/src/clib/pio_file.c
@@ -477,6 +477,10 @@ int PIOc_closefile(int ncid)
             file->adios_vars[i].decomp_varid = NULL;
             file->adios_vars[i].frame_varid = NULL;
             file->adios_vars[i].fillval_varid = NULL;
+
+            /* to handle multi-dimensional temporal variables */
+            file->adios_vars[i].start_varid = NULL;
+            file->adios_vars[i].count_varid = NULL;
         }
 
         file->num_vars = 0;

--- a/src/clib/pio_nc.c
+++ b/src/clib/pio_nc.c
@@ -2550,6 +2550,11 @@ int PIOc_def_var(int ncid, const char *name, nc_type xtype, int ndims,
         file->adios_vars[file->num_vars].decomp_varid = 0;
         file->adios_vars[file->num_vars].frame_varid = 0;
         file->adios_vars[file->num_vars].fillval_varid = 0;
+
+        /* to handle multi-dimensional temporal variables */
+        file->adios_vars[file->num_vars].start_varid = 0;
+        file->adios_vars[file->num_vars].count_varid = 0;
+
         file->adios_vars[file->num_vars].gdimids = (int*) malloc(ndims * sizeof(int));
         if (file->adios_vars[file->num_vars].gdimids == NULL)
         {

--- a/tests/general/ncdf_get_put.F90.in
+++ b/tests/general/ncdf_get_put.F90.in
@@ -653,6 +653,351 @@ PIO_TF_AUTO_TEST_SUB_BEGIN test_put_get_md2mdplus1_var
 
 PIO_TF_AUTO_TEST_SUB_END test_put_get_md2mdplus1_var
 
+! Similar to test_put_get_md2mdplus1_var, but uses an unlimited time dimension instead
+PIO_TF_TEMPLATE<PIO_TF_PREDEF_TYPENAME PIO_TF_DATA_TYPE, PIO_TF_PREDEF_TYPENAME PIO_TF_FC_DATA_TYPE>
+PIO_TF_AUTO_TEST_SUB_BEGIN test_put_get_md2mdplus1_rec
+  Implicit none
+  type(file_desc_t) :: pio_file
+  character(len=PIO_TF_MAX_STR_LEN) :: filename
+  character(len=*), parameter :: PIO_2DVAR_NAME = '2d_val'
+  character(len=*), parameter :: PIO_3DVAR_NAME = '3d_val'
+  character(len=*), parameter :: PIO_4DVAR_NAME = '4d_val'
+  integer, parameter :: MAX_DIMS = 4
+  integer, parameter :: MAX_ROWS = 10
+  integer, parameter :: MAX_COLS = 10
+  integer, parameter :: MAX_LEVS = 3
+  integer, parameter :: MAX_TIMES = 3
+  integer, dimension(MAX_DIMS) :: pio_dims
+  type(var_desc_t)  :: pio_2dvar, pio_3dvar, pio_4dvar
+  PIO_TF_FC_DATA_TYPE, dimension(MAX_ROWS,MAX_TIMES) :: gval_2d, exp_val_2d
+  PIO_TF_FC_DATA_TYPE, dimension(MAX_ROWS,MAX_COLS,MAX_TIMES) :: gval_3d, exp_val_3d
+  PIO_TF_FC_DATA_TYPE, dimension(MAX_ROWS,MAX_COLS,MAX_LEVS,MAX_TIMES) ::&
+                                                      gval_4d, exp_val_4d
+  ! Only one slice is written out at a time
+  ! pval_1d is a 1d slice of gval_2d ...
+  PIO_TF_FC_DATA_TYPE, dimension(MAX_ROWS) :: pval_1d
+  PIO_TF_FC_DATA_TYPE, dimension(MAX_ROWS, MAX_COLS) :: pval_2d
+  PIO_TF_FC_DATA_TYPE, dimension(MAX_ROWS, MAX_COLS, MAX_LEVS) :: pval_3d
+  integer, dimension(:) :: start(MAX_DIMS), count(MAX_DIMS)
+  integer :: pval_start
+  integer, dimension(:), allocatable :: iotypes
+  character(len=PIO_TF_MAX_STR_LEN), dimension(:), allocatable :: iotype_descs
+  integer :: num_iotypes
+  integer :: i, k, l, m, tstep, ret
+
+  num_iotypes = 0
+  call PIO_TF_Get_nc_iotypes(iotypes, iotype_descs, num_iotypes)
+  filename = "test_pio_ncdf_get_put_md_slice_rec.testfile"
+  do i=1,num_iotypes
+    PIO_TF_LOG(0,*) "Testing type :", iotype_descs(i)
+    ret = PIO_createfile(pio_tf_iosystem_, pio_file, iotypes(i), filename, PIO_CLOBBER)
+    PIO_TF_CHECK_ERR(ret, "Failed to open:" // trim(filename))
+
+    ! Since file is just created no need to enter redef
+    ret = PIO_def_dim(pio_file, 'nrows', MAX_ROWS, pio_dims(1))
+    PIO_TF_CHECK_ERR(ret, "Failed to define dim:" // trim(filename))
+
+    ret = PIO_def_dim(pio_file, 'ncols', MAX_COLS, pio_dims(2))
+    PIO_TF_CHECK_ERR(ret, "Failed to define dim:" // trim(filename))
+
+    ret = PIO_def_dim(pio_file, 'nlevs', MAX_LEVS, pio_dims(3))
+    PIO_TF_CHECK_ERR(ret, "Failed to define dim:" // trim(filename))
+
+    ret = PIO_def_dim(pio_file, 'timesteps', pio_unlimited, pio_dims(4))
+    PIO_TF_CHECK_ERR(ret, "Failed to define dim:" // trim(filename))
+
+    ret = PIO_def_var(pio_file, PIO_2DVAR_NAME, PIO_TF_DATA_TYPE,&
+              (/pio_dims(1),pio_dims(4)/), pio_2dvar)
+    PIO_TF_CHECK_ERR(ret, "Failed to define var:" // trim(filename))
+
+    ret = PIO_def_var(pio_file, PIO_3DVAR_NAME, PIO_TF_DATA_TYPE,&
+              (/pio_dims(1),pio_dims(2),pio_dims(4)/), pio_3dvar)
+    PIO_TF_CHECK_ERR(ret, "Failed to define var:" // trim(filename))
+
+    ret = PIO_def_var(pio_file, PIO_4DVAR_NAME, PIO_TF_DATA_TYPE,&
+              pio_dims, pio_4dvar)
+    PIO_TF_CHECK_ERR(ret, "Failed to define var:" // trim(filename))
+
+    ret = PIO_enddef(pio_file)
+    PIO_TF_CHECK_ERR(ret, "Failed to enddef:" // trim(filename))
+
+    ! Put vals are for each timestep &
+    ! expected vals are combined for all timesteps
+    do k=1,MAX_ROWS
+      pval_1d(k) = k
+    end do
+    do tstep=1,MAX_TIMES
+      pval_start = (tstep - 1) * MAX_ROWS
+      exp_val_2d(:,tstep) = pval_1d + pval_start
+    end do
+    do l=1,MAX_COLS
+      do k=1,MAX_ROWS
+        pval_2d(k,l) = (l - 1)*MAX_ROWS + k
+      end do
+    end do
+    do tstep=1,MAX_TIMES
+      do l=1,MAX_COLS
+        do k=1,MAX_ROWS
+          pval_start = (tstep - 1) * (MAX_ROWS * MAX_COLS)
+          exp_val_3d(:,:,tstep) = pval_2d + pval_start
+        end do
+      end do
+    end do
+    do m=1,MAX_LEVS
+      do l=1,MAX_COLS
+        do k=1,MAX_ROWS
+          pval_3d(k,l,m) = ((m-1)*(MAX_COLS*MAX_ROWS)+(l - 1)*MAX_ROWS + k)
+        end do
+      end do
+    end do
+    do tstep=1,MAX_TIMES
+      do m=1,MAX_LEVS
+        do l=1,MAX_COLS
+          do k=1,MAX_ROWS
+            pval_start = (tstep - 1) * (MAX_ROWS * MAX_COLS * MAX_LEVS)
+            exp_val_4d(:,:,:,tstep) = pval_3d + pval_start
+          end do
+        end do
+      end do
+    end do
+    ! Put 2d/3d/4d vals, one timestep at a time
+    do tstep=1,MAX_TIMES
+      start = 0
+      count = 0
+
+      start(1) = 1
+      count(1) = MAX_ROWS
+      start(2) = tstep
+      count(2) = 1
+      pval_start = (tstep - 1) * MAX_ROWS
+      ret = PIO_put_var(pio_file, pio_2dvar, start, count,&
+              pval_1d(:)+pval_start)
+      PIO_TF_CHECK_ERR(ret, "Failed to put 2d var:" // trim(filename))
+
+      start(1) = 1
+      count(1) = MAX_ROWS
+      start(2) = 1
+      count(2) = MAX_COLS
+      start(3) = tstep
+      count(3) = 1
+      pval_start = (tstep - 1) * (MAX_ROWS * MAX_COLS)
+      ret = PIO_put_var(pio_file, pio_3dvar, start, count,&
+              pval_2d(:,:)+pval_start)
+      PIO_TF_CHECK_ERR(ret, "Failed to put 3d var:" // trim(filename))
+
+      start(1) = 1
+      count(1) = MAX_ROWS
+      start(2) = 1
+      count(2) = MAX_COLS
+      start(3) = 1
+      count(3) = MAX_LEVS
+      start(4) = tstep
+      count(4) = 1
+      pval_start = (tstep - 1) * (MAX_ROWS * MAX_COLS * MAX_LEVS)
+      ret = PIO_put_var(pio_file, pio_4dvar, start, count,&
+              pval_3d(:,:,:)+pval_start)
+      PIO_TF_CHECK_ERR(ret, "Failed to put 4d var:" // trim(filename))
+    end do
+
+#ifdef PIO_TEST_CLOSE_OPEN_FOR_SYNC
+    call PIO_closefile(pio_file)
+
+    ret = PIO_openfile(pio_tf_iosystem_, pio_file, iotypes(i), filename, PIO_nowrite)
+    PIO_TF_CHECK_ERR(ret, "Failed to reopen:" // trim(filename))
+
+    ret = PIO_inq_varid(pio_file, PIO_2DVAR_NAME, pio_2dvar)
+    PIO_TF_CHECK_ERR(ret, "Failed to inq 2d var" // trim(filename))
+
+    ret = PIO_inq_varid(pio_file, PIO_3DVAR_NAME, pio_3dvar)
+    PIO_TF_CHECK_ERR(ret, "Failed to inq 3d var" // trim(filename))
+
+    ret = PIO_inq_varid(pio_file, PIO_4DVAR_NAME, pio_4dvar)
+    PIO_TF_CHECK_ERR(ret, "Failed to inq 4d var" // trim(filename))
+#else
+    call PIO_syncfile(pio_file)
+#endif
+
+    ret = PIO_get_var(pio_file, pio_2dvar, gval_2d)
+    PIO_TF_CHECK_ERR(ret, "Failed to get 2d var:" // trim(filename))
+
+    PIO_TF_CHECK_VAL((gval_2d, exp_val_2d), "Got wrong value (2d var)")
+
+    ret = PIO_get_var(pio_file, pio_3dvar, gval_3d)
+    PIO_TF_CHECK_ERR(ret, "Failed to get 3d var:" // trim(filename))
+
+    PIO_TF_CHECK_VAL((gval_3d, exp_val_3d), "Got wrong value (3d var)")
+
+    ret = PIO_get_var(pio_file, pio_4dvar, gval_4d)
+    PIO_TF_CHECK_ERR(ret, "Failed to get 4d var:" // trim(filename))
+
+    ! Special code to handle 4d vals is required since the framework
+    ! currently does not support comparing 4d arrays
+    do tstep=1,MAX_TIMES
+      PIO_TF_CHECK_VAL((gval_4d(:,:,:,tstep), exp_val_4d(:,:,:,tstep)), "Got wrong value (4d var)")
+    end do
+
+    call PIO_closefile(pio_file)
+    call PIO_deletefile(pio_tf_iosystem_, filename);
+  end do
+  if(allocated(iotypes)) then
+    deallocate(iotypes)
+    deallocate(iotype_descs)
+  end if
+
+PIO_TF_AUTO_TEST_SUB_END test_put_get_md2mdplus1_rec
+
+! Write out a scalar variable over time
+PIO_TF_TEMPLATE<PIO_TF_PREDEF_TYPENAME PIO_TF_DATA_TYPE, PIO_TF_PREDEF_TYPENAME PIO_TF_FC_DATA_TYPE>
+PIO_TF_AUTO_TEST_SUB_BEGIN test_put_get_time_scalar
+  Implicit none
+  type(file_desc_t) :: pio_file
+  character(len=PIO_TF_MAX_STR_LEN) :: filename
+  character(len=*), parameter :: PIO_VAR_NAME = 'dummy_scalar_var_over_time'
+  integer, parameter :: MAX_TIMES = 3
+  integer :: pio_dim
+  type(var_desc_t)  :: pio_var
+  PIO_TF_FC_DATA_TYPE, dimension(MAX_TIMES) :: gval, exp_val
+
+  ! Only one slice is written out at a time
+  PIO_TF_FC_DATA_TYPE, dimension(1) :: pval
+  integer, dimension(:) :: start(1), count(1)
+  integer, dimension(:), allocatable :: iotypes
+  character(len=PIO_TF_MAX_STR_LEN), dimension(:), allocatable :: iotype_descs
+  integer :: num_iotypes
+  integer :: i, tstep, ret
+
+  num_iotypes = 0
+  call PIO_TF_Get_nc_iotypes(iotypes, iotype_descs, num_iotypes)
+  filename = "test_pio_ncdf_get_put_time_scalar.testfile"
+  do i=1,num_iotypes
+    PIO_TF_LOG(0,*) "Testing type :", iotype_descs(i)
+    ret = PIO_createfile(pio_tf_iosystem_, pio_file, iotypes(i), filename, PIO_CLOBBER)
+    PIO_TF_CHECK_ERR(ret, "Failed to open:" // trim(filename))
+
+    ! Since file is just created no need to enter redef
+    ret = PIO_def_dim(pio_file, 'timesteps', MAX_TIMES, pio_dim)
+    PIO_TF_CHECK_ERR(ret, "Failed to define dim:" // trim(filename))
+
+    ret = PIO_def_var(pio_file, PIO_VAR_NAME, PIO_TF_DATA_TYPE, (/pio_dim/), pio_var)
+    PIO_TF_CHECK_ERR(ret, "Failed to define var:" // trim(filename))
+
+    ret = PIO_enddef(pio_file)
+    PIO_TF_CHECK_ERR(ret, "Failed to enddef:" // trim(filename))
+
+    ! Put scalar vals, one timestep at a time
+    do tstep=1,MAX_TIMES
+      start(1) = tstep
+      count(1) = 1
+      exp_val(tstep) = tstep - 1
+      pval = tstep - 1
+      ret = PIO_put_var(pio_file, pio_var, start, count, pval)
+      PIO_TF_CHECK_ERR(ret, "Failed to put scalar var over time:" // trim(filename))
+    end do
+
+#ifdef PIO_TEST_CLOSE_OPEN_FOR_SYNC
+    call PIO_closefile(pio_file)
+
+    ret = PIO_openfile(pio_tf_iosystem_, pio_file, iotypes(i), filename, PIO_nowrite)
+    PIO_TF_CHECK_ERR(ret, "Failed to reopen:" // trim(filename))
+
+    ret = PIO_inq_varid(pio_file, PIO_VAR_NAME, pio_var)
+    PIO_TF_CHECK_ERR(ret, "Failed to inq scalar var over time" // trim(filename))
+#else
+    call PIO_syncfile(pio_file)
+#endif
+
+    ret = PIO_get_var(pio_file, pio_var, gval)
+    PIO_TF_CHECK_ERR(ret, "Failed to get scalar var over time:" // trim(filename))
+
+    PIO_TF_CHECK_VAL((gval, exp_val), "Got wrong value (scalar var over time)")
+
+    call PIO_closefile(pio_file)
+    call PIO_deletefile(pio_tf_iosystem_, filename);
+  end do
+
+  if(allocated(iotypes)) then
+    deallocate(iotypes)
+    deallocate(iotype_descs)
+  end if
+
+PIO_TF_AUTO_TEST_SUB_END test_put_get_time_scalar
+
+! Similar to test_put_get_time_scalar, but uses an unlimited time dimension instead
+PIO_TF_TEMPLATE<PIO_TF_PREDEF_TYPENAME PIO_TF_DATA_TYPE, PIO_TF_PREDEF_TYPENAME PIO_TF_FC_DATA_TYPE>
+PIO_TF_AUTO_TEST_SUB_BEGIN test_put_get_time_scalar_rec
+  Implicit none
+  type(file_desc_t) :: pio_file
+  character(len=PIO_TF_MAX_STR_LEN) :: filename
+  character(len=*), parameter :: PIO_VAR_NAME = 'dummy_scalar_var_over_time'
+  integer, parameter :: MAX_TIMES = 3
+  integer :: pio_dim
+  type(var_desc_t)  :: pio_var
+  PIO_TF_FC_DATA_TYPE, dimension(MAX_TIMES) :: gval, exp_val
+
+  ! Only one slice is written out at a time
+  PIO_TF_FC_DATA_TYPE, dimension(1) :: pval
+  integer, dimension(:) :: start(1), count(1)
+  integer, dimension(:), allocatable :: iotypes
+  character(len=PIO_TF_MAX_STR_LEN), dimension(:), allocatable :: iotype_descs
+  integer :: num_iotypes
+  integer :: i, tstep, ret
+
+  num_iotypes = 0
+  call PIO_TF_Get_nc_iotypes(iotypes, iotype_descs, num_iotypes)
+  filename = "test_pio_ncdf_get_put_time_scalar_rec.testfile"
+  do i=1,num_iotypes
+    PIO_TF_LOG(0,*) "Testing type :", iotype_descs(i)
+    ret = PIO_createfile(pio_tf_iosystem_, pio_file, iotypes(i), filename, PIO_CLOBBER)
+    PIO_TF_CHECK_ERR(ret, "Failed to open:" // trim(filename))
+
+    ! Since file is just created no need to enter redef
+    ret = PIO_def_dim(pio_file, 'timesteps', pio_unlimited, pio_dim)
+    PIO_TF_CHECK_ERR(ret, "Failed to define dim:" // trim(filename))
+
+    ret = PIO_def_var(pio_file, PIO_VAR_NAME, PIO_TF_DATA_TYPE, (/pio_dim/), pio_var)
+    PIO_TF_CHECK_ERR(ret, "Failed to define var:" // trim(filename))
+
+    ret = PIO_enddef(pio_file)
+    PIO_TF_CHECK_ERR(ret, "Failed to enddef:" // trim(filename))
+
+    ! Put scalar vals, one timestep at a time
+    do tstep=1,MAX_TIMES
+      start(1) = tstep
+      count(1) = 1
+      exp_val(tstep) = tstep - 1
+      pval = tstep - 1
+      ret = PIO_put_var(pio_file, pio_var, start, count, pval)
+      PIO_TF_CHECK_ERR(ret, "Failed to put scalar var over time:" // trim(filename))
+    end do
+
+#ifdef PIO_TEST_CLOSE_OPEN_FOR_SYNC
+    call PIO_closefile(pio_file)
+
+    ret = PIO_openfile(pio_tf_iosystem_, pio_file, iotypes(i), filename, PIO_nowrite)
+    PIO_TF_CHECK_ERR(ret, "Failed to reopen:" // trim(filename))
+
+    ret = PIO_inq_varid(pio_file, PIO_VAR_NAME, pio_var)
+    PIO_TF_CHECK_ERR(ret, "Failed to inq scalar var over time" // trim(filename))
+#else
+    call PIO_syncfile(pio_file)
+#endif
+
+    ret = PIO_get_var(pio_file, pio_var, gval)
+    PIO_TF_CHECK_ERR(ret, "Failed to get scalar var over time:" // trim(filename))
+
+    PIO_TF_CHECK_VAL((gval, exp_val), "Got wrong value (scalar var over time)")
+
+    call PIO_closefile(pio_file)
+    call PIO_deletefile(pio_tf_iosystem_, filename);
+  end do
+
+  if(allocated(iotypes)) then
+    deallocate(iotypes)
+    deallocate(iotype_descs)
+  end if
+
+PIO_TF_AUTO_TEST_SUB_END test_put_get_time_scalar_rec
+
 PIO_TF_AUTO_TEST_SUB_BEGIN test_put_get_1d_str_arr
   Implicit none
   type(file_desc_t) :: pio_file


### PR DESCRIPTION
PIOc_put_vars() on multi-dimensional temporal variables now works
as expected with ADIOS type. The values for previous time steps
were being overwritten with values of the last time step.
    
Use snprintf instead of sprintf throughout tools/adios2pio-nm.
  
This patch is provided by Tahsin Kurc, and requires SCORPIO to
use ADIOS 2.6.0 or higher versions. Data to be written out by
PIOc_put_vars() is treated as local arrays. ADIOS 2.5.0 does
not allow for NULL as the value of the "start" parameter in
adios2_set_selection for local arrays.

Fixes #346