### PR TITLE
Support user-defined PnetCDF installation paths with mpi-serial (no MPI)

### DIFF
--- a/cmake/FindPnetCDF.cmake
+++ b/cmake/FindPnetCDF.cmake
@@ -47,11 +47,9 @@ foreach (PNCDFcomp IN LISTS PnetCDF_FIND_VALID_COMPONENTS)
             initialize_paths (PnetCDF_${PNCDFcomp}_PATHS
                               INCLUDE_DIRECTORIES ${MPI_${PNCDFcomp}_INCLUDE_PATH}
                               LIBRARIES ${MPI_${PNCDFcomp}_LIBRARIES})
-            find_package_component(PnetCDF COMPONENT ${PNCDFcomp}
-                                   PATHS ${PnetCDF_${PNCDFcomp}_PATHS})
-        else ()
-            find_package_component(PnetCDF COMPONENT ${PNCDFcomp})
         endif ()
+        find_package_component(PnetCDF COMPONENT ${PNCDFcomp}
+                               PATHS ${PnetCDF_${PNCDFcomp}_PATHS})
 
         # Continue only if component found
         if (PnetCDF_${PNCDFcomp}_FOUND)


### PR DESCRIPTION
Ensure that we use user-specified PnetCDF installation paths when
searching for the PnetCDF library, while building Scorpio with the
mpi-serial library.

Without this change PnetCDF installation paths specified by the user
is used only when an MPI library is detected successfully (when the
mpi-serial library is used the MPI library detection fails and the user
specified PnetCDF installation paths are ignored).

Also see PR #335 for a similar change for supporting user-specified
NetCDF library installation paths for the mpi-serial case.