### PR TITLE
Combine two separate ctest_build calls for nightly tests

### DIFF
--- a/CTestScript.cmake
+++ b/CTestScript.cmake
@@ -171,9 +171,7 @@ ctest_configure ()
 
 ## -- BUILD
 message (" -- Build - ${CTEST_BUILD_NAME} --")
-set (CTEST_BUILD_COMMAND "${MAKE}")
-ctest_build ()
-set (CTEST_BUILD_COMMAND "${MAKE} tests")
+set (CTEST_BUILD_COMMAND "${MAKE} all tests")
 ctest_build ()
 
 ## -- TEST


### PR DESCRIPTION
With two separate ctest_build calls, the build results of the
first call stored in Build.xml will be overwritten.

This fix is an enhancement of PR #361.