### PR TITLE
Fix truncation while reading strings with spaces

### DIFF
--- a/src/flib/pionfput_mod.F90.in
+++ b/src/flib/pionfput_mod.F90.in
@@ -136,13 +136,16 @@ contains
     allocate(count(ndims))
     count = 1
     ! Write the entire string starting from [index(1), clen]
-    count(1) = clen - index(1) + 1
+    count(1) = min(clen - index(1) + 1, len(ival))
 
     ! Convert string to a 1d character array
-    allocate(cval(count(1)))
+    allocate(cval(count(1) + 1))
     cval = ''
     do i=1,min(count(1),len_trim(ival))
        cval(i) = ival(i:i)
+    end do
+    do i=min(count(1),len_trim(ival))+1,size(cval)
+      cval(i) = C_NULL_CHAR
     end do
 
     ierr = put_vara_1d_text(File,varid, index, count, cval)

--- a/src/flib/pionfput_mod.F90.in
+++ b/src/flib/pionfput_mod.F90.in
@@ -517,7 +517,7 @@ contains
     cstr = C_NULL_CHAR
     cstr_idx = 0
 #if {DIMS} == 0
-    max_flen = len_trim(fstr)
+    max_flen = len(fstr)
     do i=1,min(max_clen, max_flen)
       cstr(i) = fstr(i:i)
     end do
@@ -533,7 +533,7 @@ contains
 #endif
 #if {DIMS} == 1
     do j=1,fstr_dim_sz(1)
-      max_flen = len_trim(fstr(j))
+      max_flen = len(fstr(j))
       do i=1,min(max_clen, max_flen)
         cstr(cstr_idx * max_clen + i) = fstr(j)(i:i)
       end do
@@ -552,7 +552,7 @@ contains
 #if {DIMS} == 2
     do k=1,fstr_dim_sz(2)
       do j=1,fstr_dim_sz(1)
-        max_flen = len_trim(fstr(j,k))
+        max_flen = len(fstr(j,k))
         do i=1,min(max_clen, max_flen)
           cstr(cstr_idx * max_clen + i) = fstr(j,k)(i:i)
         end do
@@ -573,7 +573,7 @@ contains
     do m=1,fstr_dim_sz(3)
       do k=1,fstr_dim_sz(2)
         do j=1,fstr_dim_sz(1)
-          max_flen = len_trim(fstr(j,k,m))
+          max_flen = len(fstr(j,k,m))
           do i=1,min(max_clen, max_flen)
             cstr(cstr_idx * max_clen + i) = fstr(j,k,m)(i:i)
           end do
@@ -596,7 +596,7 @@ contains
       do m=1,fstr_dim_sz(3)
         do k=1,fstr_dim_sz(2)
           do j=1,fstr_dim_sz(1)
-            max_flen = len_trim(fstr(j,k,m,n))
+            max_flen = len(fstr(j,k,m,n))
             do i=1,min(max_clen, max_flen)
               cstr(cstr_idx * max_clen + i) = fstr(j,k,m,n)(i:i)
             end do
@@ -621,7 +621,7 @@ contains
         do m=1,fstr_dim_sz(3)
           do k=1,fstr_dim_sz(2)
             do j=1,fstr_dim_sz(1)
-              max_flen = len_trim(fstr(j,k,m,n,q))
+              max_flen = len(fstr(j,k,m,n,q))
               do i=1,min(max_clen, max_flen)
                 cstr(cstr_idx * max_clen + i) = fstr(j,k,m,n,q)(i:i)
               end do

--- a/src/flib/pionfput_mod.F90.in
+++ b/src/flib/pionfput_mod.F90.in
@@ -111,22 +111,45 @@ contains
     character, allocatable :: cval(:)
     integer :: i
     integer, allocatable :: count(:)
-    integer :: ndims
+    integer :: ndims, clen
+
+    if(len(ival) == 0) then
+      print *, "PIO: WARNING: Empty string passed to PIO_put_var,",&
+                " function put_var1_text, a collective C API call will",&
+                " be skipped on this process. ", __PIO_FILE__, __LINE__
+    end if
+
+    ierr = get_text_var_sz(File, varid, clen)
+    if(ierr /= PIO_NOERR) then
+      call piodie(__PIO_FILE__, __LINE__, "Getting text variable size failed")
+    end if
+
+    if(clen < len_trim(ival)) then
+      print *, "PIO: WARNING: The length of the string in the user buffer,",&
+                len_trim(ival),&
+                " chars, is greater than the size of the variable",&
+                " being written to, ", clen, " chars. The string",&
+                " may be truncated. ", __PIO_FILE__, __LINE__
+    end if
 
     ndims = size(index)
     allocate(count(ndims))
     count = 1
-    count(1) = len(ival)
-    allocate(cval(count(1)+1))
-    cval = C_NULL_CHAR
-    do i=1,len_trim(ival)
+    ! Write the entire string starting from [index(1), clen]
+    count(1) = clen - index(1) + 1
+
+    ! Convert string to a 1d character array
+    allocate(cval(count(1)))
+    cval = ''
+    do i=1,min(count(1),len_trim(ival))
        cval(i) = ival(i:i)
     end do
 
-!print *,__FILE__,__LINE__,index,count,ival
-     ierr = put_vara_1d_text(File,varid, index, count, cval)
-    deallocate(count)
+    ierr = put_vara_1d_text(File,varid, index, count, cval)
+
+    deallocate(count, cval)
   end function put_var1_text
+
 ! TYPE int,real,double
 !>
 !! @public

--- a/tests/general/ncdf_get_put.F90.in
+++ b/tests/general/ncdf_get_put.F90.in
@@ -1849,7 +1849,6 @@ PIO_TF_AUTO_TEST_SUB_BEGIN test_put_get_str_idx
 
   character(len=STR_LEN) :: exp_midx_str1d(NUM_ROWS)
   character(len=LONG_STR_LEN) :: frame1_midx_str1d(NUM_ROWS)
-  character(len=LONG_STR_LEN) :: frame2_midx_str1d(NUM_ROWS)
 
   integer, dimension(NDIMS) :: strt
 
@@ -1898,7 +1897,6 @@ PIO_TF_AUTO_TEST_SUB_BEGIN test_put_get_str_idx
 
       write(exp_midx_str1d(row), VNAME_WITH_1D_IDX_FMT2) var1d_midx_name, row
       write(frame1_midx_str1d(row), VNAME_WITH_1D_IDX_FMT2) var1d_tmpl_name, row
-      frame2_midx_str1d(row) = exp_midx_str1d(row)(VNAME_IDX_IN_VNAME_WITH_1D_IDX_FMT2:len_trim(exp_midx_str1d(row)))
     end do
 
     PIO_TF_LOG(0,*) "Testing type :", iotype_descs(i)
@@ -2029,7 +2027,7 @@ PIO_TF_AUTO_TEST_SUB_BEGIN test_put_get_str_idx
       strt(2) = row
 
       ! This calls put_vara_1d_text()
-      ret = PIO_put_var(pio_file, var1d_midx, strt, frame2_midx_str1d(row));
+      ret = PIO_put_var(pio_file, var1d_midx, strt, var1d_midx_name);
       PIO_TF_CHECK_ERR(ret, "Failed to put 1d array of long strings 1 string at a time to file " // trim(filename))
     end do
 

--- a/tests/general/ncdf_get_put.F90.in
+++ b/tests/general/ncdf_get_put.F90.in
@@ -1812,10 +1812,14 @@ PIO_TF_AUTO_TEST_SUB_BEGIN test_put_get_str_idx
   Implicit none
   type(file_desc_t) :: pio_file
   character(len=*), parameter :: filename = "test_pio_ncdf_get_str_idx.testfile"
-  type(var_desc_t)  :: var1d
+  type(var_desc_t)  :: var1d, var1d_long, var1d_shrt
   character(len=*), parameter :: var1d_name = "var1d"
+  character(len=*), parameter :: var1d_long_name = "var1d_long"
+  character(len=*), parameter :: var1d_shrt_name = "var1d_shrt"
 
+  integer, parameter :: SHORT_STR_LEN = 32
   integer, parameter :: STR_LEN = 64
+  integer, parameter :: LONG_STR_LEN = 128
 
   integer, parameter :: NDIMS = 2
   integer, dimension(NDIMS) :: pio_dims
@@ -1828,6 +1832,12 @@ PIO_TF_AUTO_TEST_SUB_BEGIN test_put_get_str_idx
   character(len=STR_LEN) :: frame_str1d
   character(len=STR_LEN) :: gstr1d(NUM_ROWS)
 
+  character(len=STR_LEN) :: exp_shrt_str1d(NUM_ROWS)
+  character(len=SHORT_STR_LEN) :: frame_shrt_str1d
+
+  character(len=STR_LEN) :: exp_long_str1d(NUM_ROWS)
+  character(len=LONG_STR_LEN) :: frame_long_str1d
+
   integer, dimension(NDIMS) :: strt
 
   integer, dimension(:), allocatable :: iotypes
@@ -1839,6 +1849,7 @@ PIO_TF_AUTO_TEST_SUB_BEGIN test_put_get_str_idx
   ! "Index is: VAR_NAME(VAR_IDX)"
   ! e.g. var1d(i) = "Index is: var1d(i)"
   character(len=*), parameter :: VNAME_WITH_1D_IDX_FMT1 = '("Index is: ",A5,"(",I5,")")'
+  character(len=*), parameter :: VNAME_WITH_1D_IDX_FMT2 = '("Index is: ",A10,"(",I5,")")'
 
   integer :: i, row, ret
 
@@ -1848,6 +1859,8 @@ PIO_TF_AUTO_TEST_SUB_BEGIN test_put_get_str_idx
     ! Init buffers to be written out to the variables
     do row=1,NUM_ROWS
       write(exp_str1d(row), VNAME_WITH_1D_IDX_FMT1) var1d_name, row
+      write(exp_shrt_str1d(row), VNAME_WITH_1D_IDX_FMT2) var1d_shrt_name, row
+      write(exp_long_str1d(row), VNAME_WITH_1D_IDX_FMT2) var1d_long_name, row
     end do
 
     PIO_TF_LOG(0,*) "Testing type :", iotype_descs(i)
@@ -1863,6 +1876,12 @@ PIO_TF_AUTO_TEST_SUB_BEGIN test_put_get_str_idx
     ret = PIO_def_var(pio_file, var1d_name, PIO_char, (/pio_dims(1), pio_dims(2)/), var1d)
     PIO_TF_CHECK_ERR(ret, "Failed to define 1 dim char array or 1d array of strings in file " // trim(filename))
 
+    ret = PIO_def_var(pio_file, var1d_shrt_name, PIO_char, (/pio_dims(1), pio_dims(2)/), var1d_shrt)
+    PIO_TF_CHECK_ERR(ret, "Failed to define 1 dim char array or 1d array of short strings in file " // trim(filename))
+
+    ret = PIO_def_var(pio_file, var1d_long_name, PIO_char, (/pio_dims(1), pio_dims(2)/), var1d_long)
+    PIO_TF_CHECK_ERR(ret, "Failed to define 1 dim char array or 1d array of long strings in file " // trim(filename))
+
     ret = PIO_enddef(pio_file)
     PIO_TF_CHECK_ERR(ret, "Failed to enddef:" // trim(filename))
 
@@ -1876,6 +1895,32 @@ PIO_TF_AUTO_TEST_SUB_BEGIN test_put_get_str_idx
       ! This calls put_vara_1d_text()
       ret = PIO_put_var(pio_file, var1d, strt, frame_str1d);
       PIO_TF_CHECK_ERR(ret, "Failed to put 1d array of strings 1 string at a time to file " // trim(filename))
+    end do
+
+    ! Write the 1d text variable, 1 string at a time
+    ! The string written out is shorter than the size of the 1 dim, string length, of the variable
+    do row=1,NUM_ROWS
+      strt = 1
+      strt(1) = 1
+      strt(2) = row
+
+      frame_shrt_str1d = exp_shrt_str1d(row)
+      ! This calls put_vara_1d_text()
+      ret = PIO_put_var(pio_file, var1d_shrt, strt, frame_shrt_str1d);
+      PIO_TF_CHECK_ERR(ret, "Failed to put 1d array of short strings 1 string at a time to file " // trim(filename))
+    end do
+
+    ! Write the 1d text variable, 1 string at a time
+    ! The string written out is longer than the size of the 1 dim, string length, of the variable
+    do row=1,NUM_ROWS
+      strt = 1
+      strt(1) = 1
+      strt(2) = row
+
+      frame_long_str1d = exp_long_str1d(row)
+      ! This calls put_vara_1d_text()
+      ret = PIO_put_var(pio_file, var1d_long, strt, frame_long_str1d);
+      PIO_TF_CHECK_ERR(ret, "Failed to put 1d array of long strings 1 string at a time to file " // trim(filename))
     end do
 
     ! Sync data to disk
@@ -1896,6 +1941,18 @@ PIO_TF_AUTO_TEST_SUB_BEGIN test_put_get_str_idx
     PIO_TF_CHECK_ERR(ret, "Failed to get 1d char var in file " // trim(filename))
 
     PIO_TF_CHECK_VAL((gstr1d, exp_str1d), "Got wrong value for 1d char var")
+
+    gstr1d = ''
+    ret = PIO_get_var(pio_file, var1d_shrt, gstr1d);
+    PIO_TF_CHECK_ERR(ret, "Failed to get 1d char var in file " // trim(filename))
+
+    PIO_TF_CHECK_VAL((gstr1d, exp_shrt_str1d), "Got wrong value for short 1d char var")
+
+    gstr1d = ''
+    ret = PIO_get_var(pio_file, var1d_long, gstr1d);
+    PIO_TF_CHECK_ERR(ret, "Failed to get 1d char var in file " // trim(filename))
+
+    PIO_TF_CHECK_VAL((gstr1d, exp_long_str1d), "Got wrong value for long 1d char var")
 
     call PIO_closefile(pio_file)
     call PIO_deletefile(pio_tf_iosystem_, filename);

--- a/tests/general/ncdf_get_put.F90.in
+++ b/tests/general/ncdf_get_put.F90.in
@@ -1812,11 +1812,16 @@ PIO_TF_AUTO_TEST_SUB_BEGIN test_put_get_str_idx
   Implicit none
   type(file_desc_t) :: pio_file
   character(len=*), parameter :: filename = "test_pio_ncdf_get_str_idx.testfile"
-  type(var_desc_t)  :: var1d, var1d_long, var1d_shrt, var1d_trnc
+  type(var_desc_t)  :: var1d, var1d_long, var1d_shrt, var1d_trnc, var1d_midx
+  ! Variable names of length 5 chars
   character(len=*), parameter :: var1d_name = "var1d"
+  ! Variable names of length 10 chars
   character(len=*), parameter :: var1d_long_name = "var1d_long"
   character(len=*), parameter :: var1d_shrt_name = "var1d_shrt"
   character(len=*), parameter :: var1d_trnc_name = "var1d_trnc"
+  character(len=*), parameter :: var1d_midx_name = "var1d_midx"
+
+  character(len=*), parameter :: var1d_tmpl_name = "var1d_____"
 
   integer, parameter :: SHORT_STR_LEN = 32
   integer, parameter :: STR_LEN = 64
@@ -1842,6 +1847,10 @@ PIO_TF_AUTO_TEST_SUB_BEGIN test_put_get_str_idx
   character(len=LONG_STR_LEN) :: exp_trnc_str1d(NUM_ROWS)
   character(len=LONG_STR_LEN) :: frame_trnc_str1d(NUM_ROWS)
 
+  character(len=STR_LEN) :: exp_midx_str1d(NUM_ROWS)
+  character(len=LONG_STR_LEN) :: frame1_midx_str1d(NUM_ROWS)
+  character(len=LONG_STR_LEN) :: frame2_midx_str1d(NUM_ROWS)
+
   integer, dimension(NDIMS) :: strt
 
   integer, dimension(:), allocatable :: iotypes
@@ -1854,6 +1863,8 @@ PIO_TF_AUTO_TEST_SUB_BEGIN test_put_get_str_idx
   ! e.g. var1d(i) = "Index is: var1d(i)"
   character(len=*), parameter :: VNAME_WITH_1D_IDX_FMT1 = '("Index is: ",A5,"(",I5,")")'
   character(len=*), parameter :: VNAME_WITH_1D_IDX_FMT2 = '("Index is: ",A10,"(",I5,")")'
+
+  integer, parameter :: VNAME_IDX_IN_VNAME_WITH_1D_IDX_FMT2 = 11
 
   integer :: strt_idx, end_idx
   integer :: i, j, row, ret
@@ -1884,6 +1895,10 @@ PIO_TF_AUTO_TEST_SUB_BEGIN test_put_get_str_idx
       do j=strt_idx,end_idx
         write(frame_trnc_str1d(row)(j:j), '(I1)') mod(j,10)
       end do
+
+      write(exp_midx_str1d(row), VNAME_WITH_1D_IDX_FMT2) var1d_midx_name, row
+      write(frame1_midx_str1d(row), VNAME_WITH_1D_IDX_FMT2) var1d_tmpl_name, row
+      frame2_midx_str1d(row) = exp_midx_str1d(row)(VNAME_IDX_IN_VNAME_WITH_1D_IDX_FMT2:len_trim(exp_midx_str1d(row)))
     end do
 
     PIO_TF_LOG(0,*) "Testing type :", iotype_descs(i)
@@ -1906,6 +1921,9 @@ PIO_TF_AUTO_TEST_SUB_BEGIN test_put_get_str_idx
     PIO_TF_CHECK_ERR(ret, "Failed to define 1 dim char array or 1d array of long strings in file " // trim(filename))
 
     ret = PIO_def_var(pio_file, var1d_trnc_name, PIO_char, (/pio_dims(1), pio_dims(2)/), var1d_trnc)
+    PIO_TF_CHECK_ERR(ret, "Failed to define 1 dim char array or 1d array of truncatable strings in file " // trim(filename))
+
+    ret = PIO_def_var(pio_file, var1d_midx_name, PIO_char, (/pio_dims(1), pio_dims(2)/), var1d_midx)
     PIO_TF_CHECK_ERR(ret, "Failed to define 1 dim char array or 1d array of truncatable strings in file " // trim(filename))
 
     ret = PIO_enddef(pio_file)
@@ -1961,6 +1979,48 @@ PIO_TF_AUTO_TEST_SUB_BEGIN test_put_get_str_idx
       ret = PIO_put_var(pio_file, var1d_trnc, strt, frame_trnc_str1d(row));
       PIO_TF_CHECK_ERR(ret, "Failed to put 1d array of truncatable strings 1 string at a time to file " // trim(filename))
     end do
+
+    ! Write the 1d text variable, 1 string at a time
+    ! The string written out is longer than the size of the 1 dim, string length, of the variable
+    ! However the trim length of the string is <= the size of the 1st dim
+    ! The string is modified again by writing out contents at an index
+    do row=1,NUM_ROWS
+      ! Write out the string with variable template name
+      ! vname_midx(i) = "Index is: vname_____(i)"
+      strt = 1
+      strt(1) = 1
+      strt(2) = row
+
+      ! This calls put_vara_1d_text()
+      ret = PIO_put_var(pio_file, var1d_midx, strt, frame1_midx_str1d(row));
+      PIO_TF_CHECK_ERR(ret, "Failed to put 1d array of long strings 1 string at a time to file " // trim(filename))
+    end do
+
+    ! Sync data to disk
+#ifdef PIO_TEST_CLOSE_OPEN_FOR_SYNC
+    call PIO_closefile(pio_file)
+
+    ret = PIO_openfile(pio_tf_iosystem_, pio_file, iotypes(i), filename, PIO_nowrite)
+    PIO_TF_CHECK_ERR(ret, "Failed to reopen:" // trim(filename))
+
+    ret = PIO_inq_varid(pio_file, var1d_name, var1d)
+    PIO_TF_CHECK_ERR(ret, "Failed to inquire 1d array of strings var in file " // trim(filename))
+#else
+    call PIO_syncfile(pio_file)
+#endif
+
+    do row=1,NUM_ROWS
+      ! Change the variable name to "vname_mdix" by writing at the index for the variable name
+      ! vname_midx(i) = "Index is: vname_midx(i)"
+      strt = 1
+      strt(1) = VNAME_IDX_IN_VNAME_WITH_1D_IDX_FMT2
+      strt(2) = row
+
+      ! This calls put_vara_1d_text()
+      ret = PIO_put_var(pio_file, var1d_midx, strt, frame2_midx_str1d(row));
+      PIO_TF_CHECK_ERR(ret, "Failed to put 1d array of long strings 1 string at a time to file " // trim(filename))
+    end do
+
     ! Sync data to disk
 #ifdef PIO_TEST_CLOSE_OPEN_FOR_SYNC
     call PIO_closefile(pio_file)
@@ -1997,6 +2057,12 @@ PIO_TF_AUTO_TEST_SUB_BEGIN test_put_get_str_idx
     PIO_TF_CHECK_ERR(ret, "Failed to get 1d char var in file " // trim(filename))
 
     PIO_TF_CHECK_VAL((gstr1d, exp_trnc_str1d), "Got wrong value for truncatable 1d char var")
+
+    gstr1d = ''
+    ret = PIO_get_var(pio_file, var1d_midx, gstr1d);
+    PIO_TF_CHECK_ERR(ret, "Failed to get 1d char var in file " // trim(filename))
+
+    PIO_TF_CHECK_VAL((gstr1d, exp_midx_str1d), "Got wrong value for index write of 1d char var")
 
     call PIO_closefile(pio_file)
     call PIO_deletefile(pio_tf_iosystem_, filename);

--- a/tests/general/ncdf_get_put.F90.in
+++ b/tests/general/ncdf_get_put.F90.in
@@ -1332,14 +1332,14 @@ PIO_TF_AUTO_TEST_SUB_BEGIN test_put_get_misc_str
 
   ! Formats for the data written out in the text variable
   ! Each string in the variable is of the form
-  ! "VAR_NAME(VAR_IDX,...)"
-  ! e.g. For 2D var, var2d, var2d(j,i) = "var2d(j,i)"
-  character(len=*), parameter :: VNAME_WITH_1D_IDX_FMT1 = '(A5,"(",I5,")")'
-  character(len=*), parameter :: VNAME_WITH_2D_IDX_FMT1 = '(A5,"(",I5,",",I5,")")'
-  character(len=*), parameter :: VNAME_WITH_3D_IDX_FMT1 = '(A5,"(",I5,",",I5,",",I5,")")'
-  character(len=*), parameter :: VNAME_WITH_1D_IDX_FMT2 = '(A5,"[",I5,"]")'
-  character(len=*), parameter :: VNAME_WITH_2D_IDX_FMT2 = '(A5,"[",I5,",",I5,"]")'
-  character(len=*), parameter :: VNAME_WITH_3D_IDX_FMT2 = '(A5,"[",I5,",",I5,",",I5,"]")'
+  ! "Index is: VAR_NAME(VAR_IDX,...)"
+  ! e.g. For 2D var, var2d, var2d(j,i) = "Index is: var2d(j,i)"
+  character(len=*), parameter :: VNAME_WITH_1D_IDX_FMT1 = '("Index is: ",A5,"(",I5,")")'
+  character(len=*), parameter :: VNAME_WITH_2D_IDX_FMT1 = '("Index is: ",A5,"(",I5,",",I5,")")'
+  character(len=*), parameter :: VNAME_WITH_3D_IDX_FMT1 = '("Index is: ",A5,"(",I5,",",I5,",",I5,")")'
+  character(len=*), parameter :: VNAME_WITH_1D_IDX_FMT2 = '("Index is: ",A5,"[",I5,"]")'
+  character(len=*), parameter :: VNAME_WITH_2D_IDX_FMT2 = '("Index is: ",A5,"[",I5,",",I5,"]")'
+  character(len=*), parameter :: VNAME_WITH_3D_IDX_FMT2 = '("Index is: ",A5,"[",I5,",",I5,",",I5,"]")'
 
   integer :: i, row, col, step, ret
 
@@ -1652,14 +1652,14 @@ PIO_TF_AUTO_TEST_SUB_BEGIN test_put_get_str_frames
 
   ! Formats for the data written out in the text variable
   ! Each string in the variable is of the form
-  ! "VAR_NAME(VAR_IDX,...)"
-  ! e.g. For 2D var, var2d, var2d(j,i) = "var2d(j,i)"
-  character(len=*), parameter :: VNAME_WITH_1D_IDX_FMT1 = '(A5,"(",I5,")")'
-  character(len=*), parameter :: VNAME_WITH_2D_IDX_FMT1 = '(A5,"(",I5,",",I5,")")'
-  character(len=*), parameter :: VNAME_WITH_3D_IDX_FMT1 = '(A5,"(",I5,",",I5,",",I5,")")'
-  character(len=*), parameter :: VNAME_WITH_1D_IDX_FMT2 = '(A5,"[",I5,"]")'
-  character(len=*), parameter :: VNAME_WITH_2D_IDX_FMT2 = '(A5,"[",I5,",",I5,"]")'
-  character(len=*), parameter :: VNAME_WITH_3D_IDX_FMT2 = '(A5,"[",I5,",",I5,",",I5,"]")'
+  ! "Index is: VAR_NAME(VAR_IDX,...)"
+  ! e.g. For 2D var, var2d, var2d(j,i) = "Index is: var2d(j,i)"
+  character(len=*), parameter :: VNAME_WITH_1D_IDX_FMT1 = '("Index is: ",A5,"(",I5,")")'
+  character(len=*), parameter :: VNAME_WITH_2D_IDX_FMT1 = '("Index is: ",A5,"(",I5,",",I5,")")'
+  character(len=*), parameter :: VNAME_WITH_3D_IDX_FMT1 = '("Index is: ",A5,"(",I5,",",I5,",",I5,")")'
+  character(len=*), parameter :: VNAME_WITH_1D_IDX_FMT2 = '("Index is: ",A5,"[",I5,"]")'
+  character(len=*), parameter :: VNAME_WITH_2D_IDX_FMT2 = '("Index is: ",A5,"[",I5,",",I5,"]")'
+  character(len=*), parameter :: VNAME_WITH_3D_IDX_FMT2 = '("Index is: ",A5,"[",I5,",",I5,",",I5,"]")'
 
   integer :: i, row, col, step, ret
 

--- a/tests/general/ncdf_get_put.F90.in
+++ b/tests/general/ncdf_get_put.F90.in
@@ -1812,10 +1812,11 @@ PIO_TF_AUTO_TEST_SUB_BEGIN test_put_get_str_idx
   Implicit none
   type(file_desc_t) :: pio_file
   character(len=*), parameter :: filename = "test_pio_ncdf_get_str_idx.testfile"
-  type(var_desc_t)  :: var1d, var1d_long, var1d_shrt
+  type(var_desc_t)  :: var1d, var1d_long, var1d_shrt, var1d_trnc
   character(len=*), parameter :: var1d_name = "var1d"
   character(len=*), parameter :: var1d_long_name = "var1d_long"
   character(len=*), parameter :: var1d_shrt_name = "var1d_shrt"
+  character(len=*), parameter :: var1d_trnc_name = "var1d_trnc"
 
   integer, parameter :: SHORT_STR_LEN = 32
   integer, parameter :: STR_LEN = 64
@@ -1838,6 +1839,9 @@ PIO_TF_AUTO_TEST_SUB_BEGIN test_put_get_str_idx
   character(len=STR_LEN) :: exp_long_str1d(NUM_ROWS)
   character(len=LONG_STR_LEN) :: frame_long_str1d
 
+  character(len=LONG_STR_LEN) :: exp_trnc_str1d(NUM_ROWS)
+  character(len=LONG_STR_LEN) :: frame_trnc_str1d(NUM_ROWS)
+
   integer, dimension(NDIMS) :: strt
 
   integer, dimension(:), allocatable :: iotypes
@@ -1851,7 +1855,8 @@ PIO_TF_AUTO_TEST_SUB_BEGIN test_put_get_str_idx
   character(len=*), parameter :: VNAME_WITH_1D_IDX_FMT1 = '("Index is: ",A5,"(",I5,")")'
   character(len=*), parameter :: VNAME_WITH_1D_IDX_FMT2 = '("Index is: ",A10,"(",I5,")")'
 
-  integer :: i, row, ret
+  integer :: strt_idx, end_idx
+  integer :: i, j, row, ret
 
   num_iotypes = 0
   call PIO_TF_Get_nc_iotypes(iotypes, iotype_descs, num_iotypes)
@@ -1861,6 +1866,24 @@ PIO_TF_AUTO_TEST_SUB_BEGIN test_put_get_str_idx
       write(exp_str1d(row), VNAME_WITH_1D_IDX_FMT1) var1d_name, row
       write(exp_shrt_str1d(row), VNAME_WITH_1D_IDX_FMT2) var1d_shrt_name, row
       write(exp_long_str1d(row), VNAME_WITH_1D_IDX_FMT2) var1d_long_name, row
+      write(exp_trnc_str1d(row), VNAME_WITH_1D_IDX_FMT2) var1d_trnc_name, row
+      write(frame_trnc_str1d(row), VNAME_WITH_1D_IDX_FMT2) var1d_trnc_name, row
+      ! The expected string, exp_trnc_str1d(row), is the same length as the
+      ! variable, STR_LEN
+      ! exp_trnc_str1d(i) = "Index is: var1d_trnc(i)8901234567890..."
+      ! The frames written out, frame_trnc_str1d(row), is larger and contains
+      ! non-space characters that will be truncated while written out
+      ! frame_trnc_str1d(i) = "Index is: var1d_trnc(i)8901234567890..."
+      strt_idx = len_trim(exp_trnc_str1d(row)) + 1
+      end_idx = min(STR_LEN,len(exp_trnc_str1d(row)))
+      do j=strt_idx,end_idx
+        write(exp_trnc_str1d(row)(j:j), '(I1)') mod(j,10)
+      end do
+      strt_idx = len_trim(frame_trnc_str1d(row)) + 1
+      end_idx = len(frame_trnc_str1d(row))
+      do j=strt_idx,end_idx
+        write(frame_trnc_str1d(row)(j:j), '(I1)') mod(j,10)
+      end do
     end do
 
     PIO_TF_LOG(0,*) "Testing type :", iotype_descs(i)
@@ -1881,6 +1904,9 @@ PIO_TF_AUTO_TEST_SUB_BEGIN test_put_get_str_idx
 
     ret = PIO_def_var(pio_file, var1d_long_name, PIO_char, (/pio_dims(1), pio_dims(2)/), var1d_long)
     PIO_TF_CHECK_ERR(ret, "Failed to define 1 dim char array or 1d array of long strings in file " // trim(filename))
+
+    ret = PIO_def_var(pio_file, var1d_trnc_name, PIO_char, (/pio_dims(1), pio_dims(2)/), var1d_trnc)
+    PIO_TF_CHECK_ERR(ret, "Failed to define 1 dim char array or 1d array of truncatable strings in file " // trim(filename))
 
     ret = PIO_enddef(pio_file)
     PIO_TF_CHECK_ERR(ret, "Failed to enddef:" // trim(filename))
@@ -1923,6 +1949,18 @@ PIO_TF_AUTO_TEST_SUB_BEGIN test_put_get_str_idx
       PIO_TF_CHECK_ERR(ret, "Failed to put 1d array of long strings 1 string at a time to file " // trim(filename))
     end do
 
+    ! Write the 1d text variable, 1 string at a time
+    ! The string written out is longer than the size of the 1 dim, string length, of the variable
+    ! (and the contents of the string will be truncated)
+    do row=1,NUM_ROWS
+      strt = 1
+      strt(1) = 1
+      strt(2) = row
+
+      ! This calls put_vara_1d_text()
+      ret = PIO_put_var(pio_file, var1d_trnc, strt, frame_trnc_str1d(row));
+      PIO_TF_CHECK_ERR(ret, "Failed to put 1d array of truncatable strings 1 string at a time to file " // trim(filename))
+    end do
     ! Sync data to disk
 #ifdef PIO_TEST_CLOSE_OPEN_FOR_SYNC
     call PIO_closefile(pio_file)
@@ -1953,6 +1991,12 @@ PIO_TF_AUTO_TEST_SUB_BEGIN test_put_get_str_idx
     PIO_TF_CHECK_ERR(ret, "Failed to get 1d char var in file " // trim(filename))
 
     PIO_TF_CHECK_VAL((gstr1d, exp_long_str1d), "Got wrong value for long 1d char var")
+
+    gstr1d = ''
+    ret = PIO_get_var(pio_file, var1d_trnc, gstr1d);
+    PIO_TF_CHECK_ERR(ret, "Failed to get 1d char var in file " // trim(filename))
+
+    PIO_TF_CHECK_VAL((gstr1d, exp_trnc_str1d), "Got wrong value for truncatable 1d char var")
 
     call PIO_closefile(pio_file)
     call PIO_deletefile(pio_tf_iosystem_, filename);

--- a/tests/general/ncdf_get_put.F90.in
+++ b/tests/general/ncdf_get_put.F90.in
@@ -1805,6 +1805,108 @@ PIO_TF_AUTO_TEST_SUB_BEGIN test_put_get_str_frames
 
 PIO_TF_AUTO_TEST_SUB_END test_put_get_str_frames
 
+! Test puts of text variables, varying the index of the output var written out.
+! Although index/starts of the output variable is specified the counts are
+! not provided.
+PIO_TF_AUTO_TEST_SUB_BEGIN test_put_get_str_idx
+  Implicit none
+  type(file_desc_t) :: pio_file
+  character(len=*), parameter :: filename = "test_pio_ncdf_get_str_idx.testfile"
+  type(var_desc_t)  :: var1d
+  character(len=*), parameter :: var1d_name = "var1d"
+
+  integer, parameter :: STR_LEN = 64
+
+  integer, parameter :: NDIMS = 2
+  integer, dimension(NDIMS) :: pio_dims
+  integer, parameter :: NUM_ROWS = 10
+
+  character(len=*), parameter :: dim0_name = "slen"
+  character(len=*), parameter :: dim1_name = "row"
+
+  character(len=STR_LEN) :: exp_str1d(NUM_ROWS)
+  character(len=STR_LEN) :: frame_str1d
+  character(len=STR_LEN) :: gstr1d(NUM_ROWS)
+
+  integer, dimension(NDIMS) :: strt
+
+  integer, dimension(:), allocatable :: iotypes
+  character(len=PIO_TF_MAX_STR_LEN), dimension(:), allocatable :: iotype_descs
+  integer :: num_iotypes
+
+  ! Formats for the data written out in the text variable
+  ! Each string in the variable is of the form
+  ! "Index is: VAR_NAME(VAR_IDX)"
+  ! e.g. var1d(i) = "Index is: var1d(i)"
+  character(len=*), parameter :: VNAME_WITH_1D_IDX_FMT1 = '("Index is: ",A5,"(",I5,")")'
+
+  integer :: i, row, ret
+
+  num_iotypes = 0
+  call PIO_TF_Get_nc_iotypes(iotypes, iotype_descs, num_iotypes)
+  do i=1,num_iotypes
+    ! Init buffers to be written out to the variables
+    do row=1,NUM_ROWS
+      write(exp_str1d(row), VNAME_WITH_1D_IDX_FMT1) var1d_name, row
+    end do
+
+    PIO_TF_LOG(0,*) "Testing type :", iotype_descs(i)
+    ret = PIO_createfile(pio_tf_iosystem_, pio_file, iotypes(i), filename, PIO_CLOBBER)
+    PIO_TF_CHECK_ERR(ret, "Failed to open:" // trim(filename))
+
+    ret = PIO_def_dim(pio_file, dim0_name, STR_LEN, pio_dims(1))
+    PIO_TF_CHECK_ERR(ret, "Failed to define dim 0:" // trim(filename))
+
+    ret = PIO_def_dim(pio_file, dim1_name, NUM_ROWS, pio_dims(2))
+    PIO_TF_CHECK_ERR(ret, "Failed to define dim 1:" // trim(filename))
+
+    ret = PIO_def_var(pio_file, var1d_name, PIO_char, (/pio_dims(1), pio_dims(2)/), var1d)
+    PIO_TF_CHECK_ERR(ret, "Failed to define 1 dim char array or 1d array of strings in file " // trim(filename))
+
+    ret = PIO_enddef(pio_file)
+    PIO_TF_CHECK_ERR(ret, "Failed to enddef:" // trim(filename))
+
+    ! Write the 1d text variable, 1 string at a time
+    do row=1,NUM_ROWS
+      strt = 1
+      strt(1) = 1
+      strt(2) = row
+
+      frame_str1d = exp_str1d(row)
+      ! This calls put_vara_1d_text()
+      ret = PIO_put_var(pio_file, var1d, strt, frame_str1d);
+      PIO_TF_CHECK_ERR(ret, "Failed to put 1d array of strings 1 string at a time to file " // trim(filename))
+    end do
+
+    ! Sync data to disk
+#ifdef PIO_TEST_CLOSE_OPEN_FOR_SYNC
+    call PIO_closefile(pio_file)
+
+    ret = PIO_openfile(pio_tf_iosystem_, pio_file, iotypes(i), filename, PIO_nowrite)
+    PIO_TF_CHECK_ERR(ret, "Failed to reopen:" // trim(filename))
+
+    ret = PIO_inq_varid(pio_file, var1d_name, var1d)
+    PIO_TF_CHECK_ERR(ret, "Failed to inquire 1d array of strings var in file " // trim(filename))
+#else
+    call PIO_syncfile(pio_file)
+#endif
+
+    ! This calls get_var_1d_text()
+    ret = PIO_get_var(pio_file, var1d, gstr1d);
+    PIO_TF_CHECK_ERR(ret, "Failed to get 1d char var in file " // trim(filename))
+
+    PIO_TF_CHECK_VAL((gstr1d, exp_str1d), "Got wrong value for 1d char var")
+
+    call PIO_closefile(pio_file)
+    call PIO_deletefile(pio_tf_iosystem_, filename);
+  end do
+  if(allocated(iotypes)) then
+    deallocate(iotypes)
+    deallocate(iotype_descs)
+  end if
+
+PIO_TF_AUTO_TEST_SUB_END test_put_get_str_idx
+
 ! Testing put/get of hyperslabs of a text variable
 ! Each string in the text variable is initialized with the variable name and
 ! index

--- a/tests/general/ncdf_get_put.F90.in
+++ b/tests/general/ncdf_get_put.F90.in
@@ -2000,10 +2000,22 @@ PIO_TF_AUTO_TEST_SUB_BEGIN test_put_get_str_idx
 #ifdef PIO_TEST_CLOSE_OPEN_FOR_SYNC
     call PIO_closefile(pio_file)
 
-    ret = PIO_openfile(pio_tf_iosystem_, pio_file, iotypes(i), filename, PIO_nowrite)
+    ret = PIO_openfile(pio_tf_iosystem_, pio_file, iotypes(i), filename, PIO_write)
     PIO_TF_CHECK_ERR(ret, "Failed to reopen:" // trim(filename))
 
     ret = PIO_inq_varid(pio_file, var1d_name, var1d)
+    PIO_TF_CHECK_ERR(ret, "Failed to inquire 1d array of strings var in file " // trim(filename))
+
+    ret = PIO_inq_varid(pio_file, var1d_shrt_name, var1d_shrt)
+    PIO_TF_CHECK_ERR(ret, "Failed to inquire 1d array of strings var in file " // trim(filename))
+
+    ret = PIO_inq_varid(pio_file, var1d_long_name, var1d_long)
+    PIO_TF_CHECK_ERR(ret, "Failed to inquire 1d array of strings var in file " // trim(filename))
+
+    ret = PIO_inq_varid(pio_file, var1d_trnc_name, var1d_trnc)
+    PIO_TF_CHECK_ERR(ret, "Failed to inquire 1d array of strings var in file " // trim(filename))
+
+    ret = PIO_inq_varid(pio_file, var1d_midx_name, var1d_midx)
     PIO_TF_CHECK_ERR(ret, "Failed to inquire 1d array of strings var in file " // trim(filename))
 #else
     call PIO_syncfile(pio_file)

--- a/tests/general/ncdf_get_put.F90.in
+++ b/tests/general/ncdf_get_put.F90.in
@@ -1641,8 +1641,6 @@ PIO_TF_AUTO_TEST_SUB_BEGIN test_put_get_str_frames
 
   character(len=SHORT_STR_LEN) :: exp_sstr1d(NUM_ROWS)
   character(len=SHORT_STR_LEN) :: exp_sstr2d(NUM_ROWS, NUM_COLS)
-  character(len=LONG_STR_LEN) :: glstr1d(NUM_ROWS)
-  character(len=LONG_STR_LEN) :: glstr2d(NUM_ROWS, NUM_COLS)
 
   integer, dimension(NDIMS) :: strt, cnt
 
@@ -1946,7 +1944,7 @@ PIO_TF_AUTO_TEST_SUB_BEGIN test_put_get_str_idx
       strt(1) = 1
       strt(2) = row
 
-      frame_shrt_str1d = exp_shrt_str1d(row)
+      frame_shrt_str1d = exp_shrt_str1d(row)(1:len(frame_shrt_str1d))
       ! This calls put_vara_1d_text()
       ret = PIO_put_var(pio_file, var1d_shrt, strt, frame_shrt_str1d);
       PIO_TF_CHECK_ERR(ret, "Failed to put 1d array of short strings 1 string at a time to file " // trim(filename))


### PR DESCRIPTION
Fixing issue with truncation while writing/reading strings with
spaces in a variable using pio_put/get_var.

Also modifying existing tests and adding some new tests that
show the issue with reading strings with spaces.

Also see E3SM-Project/E3SM#3966