### PR TITLE
Optimize the ADIOS conversion tool

### DIFF
--- a/src/clib/pio.h
+++ b/src/clib/pio.h
@@ -789,6 +789,7 @@ typedef struct adios_var_desc_t
 
     /** Type converted from NC type to adios type */
     adios2_type adios_type;
+    int adios_type_size;
 
     /** Number of dimensions */
     int ndims;

--- a/src/clib/pio_file.c
+++ b/src/clib/pio_file.c
@@ -501,6 +501,8 @@ int PIOc_closefile(int ncid)
         char conv_iotype[] = "netcdf";
 #endif
 
+        int rearr_type = PIO_REARR_SUBSET;
+
         /* Convert XXXX.nc.bp to XXXX.nc */
         len = strlen(file->filename);
         assert(len > 6 && len <= PIO_MAX_NAME);
@@ -508,7 +510,7 @@ int PIOc_closefile(int ncid)
         outfilename[len - 3] = '\0';
         LOG((1, "CONVERTING: %s", file->filename));
         MPI_Barrier(ios->union_comm);
-        ierr = C_API_ConvertBPToNC(file->filename, outfilename, conv_iotype, 0, ios->union_comm);
+        ierr = C_API_ConvertBPToNC(file->filename, outfilename, conv_iotype, rearr_type, ios->union_comm);
         MPI_Barrier(ios->union_comm);
         LOG((1, "DONE CONVERTING: %s", file->filename));
         if (ierr != PIO_NOERR)

--- a/src/clib/pio_nc.c
+++ b/src/clib/pio_nc.c
@@ -2544,6 +2544,7 @@ int PIOc_def_var(int ncid, const char *name, nc_type xtype, int ndims,
         file->adios_vars[file->num_vars].name = strdup(name);
         file->adios_vars[file->num_vars].nc_type = xtype;
         file->adios_vars[file->num_vars].adios_type = PIOc_get_adios_type(xtype);
+        file->adios_vars[file->num_vars].adios_type_size = adios2_type_size(file->adios_vars[file->num_vars].adios_type, NULL);
         file->adios_vars[file->num_vars].nattrs = 0;
         file->adios_vars[file->num_vars].ndims = ndims;
         file->adios_vars[file->num_vars].adios_varid = 0;

--- a/tools/adios2pio-nm/adios2pio-nm-lib-c.h
+++ b/tools/adios2pio-nm/adios2pio-nm-lib-c.h
@@ -7,7 +7,7 @@
 extern "C" {
 #endif
 
-extern int C_API_ConvertBPToNC(const char *infilepath, const char *outfilename, const char *piotype, int mem_opt, MPI_Comm comm_in);
+extern int C_API_ConvertBPToNC(const char *infilepath, const char *outfilename, const char *piotype, int rearr_type, MPI_Comm comm_in);
 
 #ifdef __cplusplus
 }

--- a/tools/adios2pio-nm/adios2pio-nm-lib.h
+++ b/tools/adios2pio-nm/adios2pio-nm-lib.h
@@ -8,8 +8,8 @@ using namespace std;
 
 int ConvertBPToNC(const string &infilepath,
                   const string &outfilename,
-                  const string &piotype, int mem_opt, MPI_Comm comm_in);
-int MConvertBPToNC(const string &bppdir, const string &piotype, int mem_opt,
+                  const string &piotype, const string &rearr, MPI_Comm comm_in);
+int MConvertBPToNC(const string &bppdir, const string &piotype, const string &rearr,
                     MPI_Comm comm);
 void SetDebugOutput(int val);
 

--- a/tools/adios2pio-nm/adios2pio-nm.cxx
+++ b/tools/adios2pio-nm/adios2pio-nm.cxx
@@ -13,7 +13,7 @@ static void init_user_options(spio_tool_utils::ArgParser &ap)
       .add_opt("idir", "Directory containing data output from PIO (in ADIOS format)")
       .add_opt("nc-file", "output file name after conversion")
       .add_opt("pio-format", "output PIO_IO_TYPE. Supported parameters: \"pnetcdf\",  \"netcdf\",  \"netcdf4c\",  \"netcdf4p\"")
-      .add_opt("reduce-memory-usage", "Reduce memory usage (execution time will likely increase)")
+      .add_opt("rearr", "PIO rearranger. Supported parameters: \"subset\", \"box\". Default \"subset\".")
       .add_opt("verbose", "Turn on verbose info messages");
 }
 
@@ -56,11 +56,11 @@ static int get_user_options(
               std::string &idir,
               std::string &ifile, std::string &ofile,
               std::string &otype,
-              int &mem_opt,
+              std::string &rearr,
               int &debug_lvl)
 {
     const std::string DEFAULT_PIO_FORMAT("pnetcdf");
-    mem_opt = 0;
+    const std::string DEFAULT_REARRANGER("subset");
     debug_lvl = 0;
 
 #ifdef SPIO_NO_CXX_REGEX
@@ -105,9 +105,13 @@ static int get_user_options(
         otype = DEFAULT_PIO_FORMAT;
     }
 
-    if (ap.has_arg("reduce-memory-usage"))
+    if (ap.has_arg("rearr"))
     {
-        mem_opt = 1;
+        rearr = ap.get_arg<std::string>("rearr");
+    }
+    else
+    {
+        rearr = DEFAULT_REARRANGER;
     }
 
     if (ap.has_arg("verbose"))
@@ -132,12 +136,11 @@ int main(int argc, char *argv[])
     init_user_options(ap);
 
     /* Parse the user options */
-    string idir, infilepath, outfilename, piotype;
-    int mem_opt = 0;
+    string idir, infilepath, outfilename, piotype, rearr;
     int debug_lvl = 0;
     ret = get_user_options(ap, argc, argv,
                             idir, infilepath, outfilename,
-                            piotype, mem_opt, debug_lvl);
+                            piotype, rearr, debug_lvl);
 
     if (ret != 0)
     {
@@ -156,11 +159,11 @@ int main(int argc, char *argv[])
     MPI_Barrier(comm_in);
     if (idir.size() == 0)
     {
-        ret = ConvertBPToNC(infilepath, outfilename, piotype, mem_opt, comm_in);
+        ret = ConvertBPToNC(infilepath, outfilename, piotype, rearr, comm_in);
     }
     else
     {
-        ret = MConvertBPToNC(idir, piotype, mem_opt, comm_in);
+        ret = MConvertBPToNC(idir, piotype, rearr, comm_in);
     }
     MPI_Barrier(comm_in);
 


### PR DESCRIPTION
This patch is provided by Tahsin Kurc, which further improves the
performance of the ADIOS conversion tool.

Major changes:
Use SUBSET rearranger by default.
Merge start/count/buffer to reduce costly I/O seeks.
Reorganize order to process variables to reduce decomposition
allocations.

Note the updated conversion tool will not work with the previously
generated BP files,  because it will expect merged start/count/buffer.