### PR TITLE
Signal pio_unit_test as failed when a Fortran function returns an error

### DIFF
--- a/tests/unit/basic_tests.F90
+++ b/tests/unit/basic_tests.F90
@@ -16,6 +16,8 @@ module basic_tests
   public :: test_create
   public :: test_open
 
+  integer, parameter :: ERR = 1
+
   Contains
 
     Subroutine test_create(test_id, err_msg)
@@ -51,7 +53,7 @@ module basic_tests
         ! Error in PIO_createfile
          print *,' ret_val = ', ret_val
         err_msg = "Could not create " // trim(filename)
-        call mpi_abort(MPI_COMM_WORLD, 0, ret_val2)
+        call mpi_abort(MPI_COMM_WORLD, ERR, ret_val2)
       end if
       
       call mpi_barrier(mpi_comm_world,ret_val)
@@ -62,7 +64,7 @@ module basic_tests
           ! Error in PIO_enddef
           err_msg = "Could not end define mode"
           call PIO_closefile(pio_file)
-          call mpi_abort(MPI_COMM_WORLD, 0, ret_val2)
+          call mpi_abort(MPI_COMM_WORLD, ERR, ret_val2)
         end if
       end if
       call PIO_closefile(pio_file)
@@ -73,7 +75,7 @@ module basic_tests
       if (ret_val .ne. PIO_NOERR) then
         ! Error in PIO_openfile
         err_msg = "Could not open " // trim(filename)
-        call mpi_abort(MPI_COMM_WORLD, 0, ret_val2)
+        call mpi_abort(MPI_COMM_WORLD, ERR, ret_val2)
       end if
 
       ! Close file
@@ -85,7 +87,7 @@ module basic_tests
         if (ret_val .ne. PIO_NOERR) then
           ! Error in PIO_createfile
           err_msg = "Could not clobber " // trim(filename)
-          call mpi_abort(MPI_COMM_WORLD, 0, ret_val2)
+          call mpi_abort(MPI_COMM_WORLD, ERR, ret_val2)
         end if
 
         ! Leave define mode
@@ -94,7 +96,7 @@ module basic_tests
           ! Error in PIO_enddef
           err_msg = "Could not end define mode in clobbered file"
           call PIO_closefile(pio_file)
-          call mpi_abort(MPI_COMM_WORLD, 0, ret_val2)
+          call mpi_abort(MPI_COMM_WORLD, ERR, ret_val2)
         end if
 
         ! Close file
@@ -113,7 +115,7 @@ module basic_tests
           err_msg = "Was able to clobber file despite PIO_NOCLOBBER"
           ret_val = PIO_enddef(pio_file)
           call PIO_closefile(pio_file)
-          call mpi_abort(MPI_COMM_WORLD, 0, ret_val2)
+          call mpi_abort(MPI_COMM_WORLD, ERR, ret_val2)
         end if
       end if
 
@@ -166,7 +168,7 @@ module basic_tests
         ! Error in PIO_openfile
         err_msg = "Successfully opened file that doesn't exist"
         call PIO_closefile(pio_file)
-        call mpi_abort(MPI_COMM_WORLD, 0, ret_val2)
+        call mpi_abort(MPI_COMM_WORLD, ERR, ret_val2)
       end if
 
       ! Open existing file, write data to it (for binary file, need to create new file)
@@ -178,7 +180,7 @@ module basic_tests
       if (ret_val .ne. PIO_NOERR) then
         ! Error in PIO_openfile (or PIO_createfile)
         err_msg = "Could not open " // trim(filename) // " in write mode"
-        call mpi_abort(MPI_COMM_WORLD, 0, ret_val2)
+        call mpi_abort(MPI_COMM_WORLD, ERR, ret_val2)
       end if
 
       ! Enter define mode for netcdf files
@@ -187,7 +189,7 @@ module basic_tests
         if (ret_val .ne. PIO_NOERR) then
           err_msg = "Could not enter redef mode"
           call PIO_closefile(pio_file)
-          call mpi_abort(MPI_COMM_WORLD, 0, ret_val2)
+          call mpi_abort(MPI_COMM_WORLD, ERR, ret_val2)
         end if
 
         ! Define a new dimension N
@@ -196,7 +198,7 @@ module basic_tests
           ! Error in PIO_def_dim
           err_msg = "Could not define dimension N"
           call PIO_closefile(pio_file)
-          call mpi_abort(MPI_COMM_WORLD, 0, ret_val2)
+          call mpi_abort(MPI_COMM_WORLD, ERR, ret_val2)
         end if
 
         ! Define a new variable foo
@@ -206,7 +208,7 @@ module basic_tests
           ! Error in PIO_def_var
           err_msg = "Could not define variable foo"
           call PIO_closefile(pio_file)
-          call mpi_abort(MPI_COMM_WORLD, 0, ret_val2)
+          call mpi_abort(MPI_COMM_WORLD, ERR, ret_val2)
         end if
 
         ! Leave define mode
@@ -216,7 +218,7 @@ module basic_tests
            print *,__FILE__,__LINE__,ret_val
           err_msg = "Could not end define mode"
           call PIO_closefile(pio_file)
-          call mpi_abort(MPI_COMM_WORLD, 0, ret_val2)
+          call mpi_abort(MPI_COMM_WORLD, ERR, ret_val2)
         end if
       end if
 
@@ -228,7 +230,7 @@ module basic_tests
         ! Error in PIO_write_darray
         err_msg = "Could not write data"
         call PIO_closefile(pio_file)
-        call mpi_abort(MPI_COMM_WORLD, 0, ret_val2)
+        call mpi_abort(MPI_COMM_WORLD, ERR, ret_val2)
       end if
 
       ! Close file
@@ -241,14 +243,14 @@ module basic_tests
         if (ret_val .ne. PIO_NOERR) then
           ! Error opening file
           err_msg = "Could not open file in NoWrite mode"
-          call mpi_abort(MPI_COMM_WORLD, 0, ret_val2)
+          call mpi_abort(MPI_COMM_WORLD, ERR, ret_val2)
         end if
 
         ret_val = PIO_inq_varid(pio_file, 'foo', pio_var)
         if (ret_val .ne. PIO_NOERR) then
           ! Error opening file
           err_msg = "Could not inquire about var 'foo' in file"
-          call mpi_abort(MPI_COMM_WORLD, 0, ret_val2)
+          call mpi_abort(MPI_COMM_WORLD, ERR, ret_val2)
         end if
 
         ! Try to write (should fail)
@@ -260,7 +262,7 @@ module basic_tests
           ! Error in PIO_write_darray
           err_msg = "Wrote to file opened in NoWrite mode"
           call PIO_closefile(pio_file)
-          call mpi_abort(MPI_COMM_WORLD, 0, ret_val2)
+          call mpi_abort(MPI_COMM_WORLD, ERR, ret_val2)
         end if
 
         call mpi_barrier(MPI_COMM_WORLD,ret_val)
@@ -273,13 +275,13 @@ module basic_tests
           err_msg = "Error in read_darray"
           call PIO_closefile(pio_file)
           print *,__FILE__,__LINE__,err_msg
-          call mpi_abort(MPI_COMM_WORLD, 0, ret_val2)
+          call mpi_abort(MPI_COMM_WORLD, ERR, ret_val2)
         end if
         if(any(data_buffer /= my_rank)) then
           err_msg = "Error reading data"
           call PIO_closefile(pio_file)
           print *,__FILE__,__LINE__,iotype, trim(err_msg), data_buffer
-          call mpi_abort(MPI_COMM_WORLD, 0, ret_val2)
+          call mpi_abort(MPI_COMM_WORLD, ERR, ret_val2)
         end if
 
         ret_val = PIO_set_log_level(3)
@@ -288,7 +290,7 @@ module basic_tests
            err_msg = "Error in inq_unlimdim"
            call PIO_closefile(pio_file)
            print *,__FILE__,__LINE__,iotype, trim(err_msg)
-           call mpi_abort(MPI_COMM_WORLD, 0, ret_val2)
+           call mpi_abort(MPI_COMM_WORLD, ERR, ret_val2)
         end if
         ret_val = PIO_set_log_level(0)
         
@@ -309,7 +311,7 @@ module basic_tests
           ! Error in PIO_openfile
           err_msg = "Opened a non-netcdf file as netcdf"
           call PIO_closefile(pio_file)
-          call mpi_abort(MPI_COMM_WORLD, 0, ret_val2)
+          call mpi_abort(MPI_COMM_WORLD, ERR, ret_val2)
         end if
       end if
 


### PR DESCRIPTION
When a Fortran function returns an error and mpi_abort() is called
in pio_unit_test, the input error code for mpi_abort() is set to 0
such that the test does not fail as expected.

To properly signal pio_unit_test as failed for the test framework
of SCORPIO, mpi_abort() should be called with a nonzero error
code as the second argument to return to invoking environment.