### PR TITLE
New ncdf_get_put test with expected data type conversion

### DIFF
--- a/tests/general/ncdf_get_put.F90.in
+++ b/tests/general/ncdf_get_put.F90.in
@@ -2547,3 +2547,107 @@ PIO_TF_AUTO_TEST_SUB_BEGIN test_put_get_str_hslabs
 
 PIO_TF_AUTO_TEST_SUB_END test_put_get_str_hslabs
 
+! This test puts and gets variables that can involve implicit type conversion
+PIO_TF_TEMPLATE<PIO_TF_PREDEF_TYPENAME PIO_TF_DATA_TYPE, PIO_TF_PREDEF_TYPENAME PIO_TF_FC_DATA_TYPE>
+PIO_TF_AUTO_TEST_SUB_BEGIN test_put_get_type_conversion
+  Implicit none
+  integer, parameter :: DIM_LEN = 100
+  type(var_desc_t)  :: pio_var_int, pio_var_real, pio_var_double
+  type(file_desc_t) :: pio_file
+  character(len=PIO_TF_MAX_STR_LEN) :: data_fname = "pio_test_put_get_type_conversion.nc"
+  character(len=*), parameter :: PIO_VAR_INT_NAME = 'PIO_TF_test_var_int'
+  character(len=*), parameter :: PIO_VAR_REAL_NAME = 'PIO_TF_test_var_real'
+  character(len=*), parameter :: PIO_VAR_DBL_NAME = 'PIO_TF_test_var_dbl'
+  PIO_TF_FC_DATA_TYPE, dimension(DIM_LEN) :: pval, gval
+  integer :: pio_dim
+  ! iotypes = valid io types
+  integer, dimension(:), allocatable :: iotypes
+  character(len=PIO_TF_MAX_STR_LEN), dimension(:), allocatable :: iotype_descs
+  integer :: num_iotypes
+  integer :: i, ierr
+
+  pval = pio_tf_world_sz_
+
+  num_iotypes = 0
+  call PIO_TF_Get_nc_iotypes(iotypes, iotype_descs, num_iotypes)
+  do i=1,num_iotypes
+    PIO_TF_LOG(0,*) "Testing : PIO_TF_DATA_TYPE : ", iotype_descs(i)
+
+    ierr = PIO_createfile(pio_tf_iosystem_, pio_file, iotypes(i), data_fname, PIO_CLOBBER)
+    PIO_TF_CHECK_ERR(ierr, "Could not create file " // trim(data_fname))
+
+    ierr = PIO_def_dim(pio_file, 'PIO_TF_test_dim', DIM_LEN, pio_dim)
+    PIO_TF_CHECK_ERR(ierr, "Failed to define a dim : " // trim(data_fname))
+
+    ierr = PIO_def_var(pio_file, PIO_VAR_INT_NAME, PIO_int, (/pio_dim/), pio_var_int)
+    PIO_TF_CHECK_ERR(ierr, "Failed to define a var of int type : " // trim(data_fname))
+
+    ierr = PIO_def_var(pio_file, PIO_VAR_REAL_NAME, PIO_real, (/pio_dim/), pio_var_real)
+    PIO_TF_CHECK_ERR(ierr, "Failed to define a var of real type : " // trim(data_fname))
+
+    ierr = PIO_def_var(pio_file, PIO_VAR_DBL_NAME, PIO_double, (/pio_dim/), pio_var_double)
+    PIO_TF_CHECK_ERR(ierr, "Failed to define a var of double type : " // trim(data_fname))
+
+    ierr = PIO_enddef(pio_file)
+    PIO_TF_CHECK_ERR(ierr, "Failed to end redef mode : " // trim(data_fname))
+
+    ! Put the int type variable out (data conversion might occur: real => int, double => int)
+    ierr = PIO_put_var(pio_file, pio_var_int, pval)
+    PIO_TF_CHECK_ERR(ierr, "Failed to put a var of int type : " // trim(data_fname))
+
+    ! Put the real type variable out (data conversion might occur: int => real, double => real)
+    ierr = PIO_put_var(pio_file, pio_var_real, pval)
+    PIO_TF_CHECK_ERR(ierr, "Failed to put a var of real type : " // trim(data_fname))
+
+    ! Put the double type variable out (data conversion might occur: int => double, real => double)
+    ierr = PIO_put_var(pio_file, pio_var_double, pval)
+    PIO_TF_CHECK_ERR(ierr, "Failed to put a var of double type : " // trim(data_fname))
+
+#ifdef PIO_TEST_CLOSE_OPEN_FOR_SYNC
+    call PIO_closefile(pio_file)
+
+    ierr = PIO_openfile(pio_tf_iosystem_, pio_file, iotypes(i), data_fname, PIO_nowrite)
+    PIO_TF_CHECK_ERR(ierr, "Could not reopen file " // trim(data_fname))
+
+    ierr = PIO_inq_varid(pio_file, PIO_VAR_INT_NAME, pio_var_int)
+    PIO_TF_CHECK_ERR(ierr, "Cannot inq int var " // trim(data_fname))
+
+    ierr = PIO_inq_varid(pio_file, PIO_VAR_REAL_NAME, pio_var_real)
+    PIO_TF_CHECK_ERR(ierr, "Cannot inq real var " // trim(data_fname))
+
+    ierr = PIO_inq_varid(pio_file, PIO_VAR_DBL_NAME, pio_var_double)
+    PIO_TF_CHECK_ERR(ierr, "Cannot inq double var " // trim(data_fname))
+#else
+    call PIO_syncfile(pio_file)
+#endif
+
+    ! Get the int type variable back (data conversion might occur: int => real, int => double)
+    gval = 0
+    ierr = PIO_get_var(pio_file, pio_var_int, gval)
+    PIO_TF_CHECK_ERR(ierr, "Failed to get a var of int type : " // trim(data_fname))
+
+    PIO_TF_CHECK_VAL((gval, pval), "Got wrong val")
+
+    ! Get the real type variable back (data conversion might occur: real => int, real => double)
+    gval = 0
+    ierr = PIO_get_var(pio_file, pio_var_real, gval)
+    PIO_TF_CHECK_ERR(ierr, "Failed to get a var of real type : " // trim(data_fname))
+
+    PIO_TF_CHECK_VAL((gval, pval), "Got wrong val")
+
+    ! Get the double type variable back (data conversion might occur: double => int, double => real)
+    gval = 0
+    ierr = PIO_get_var(pio_file, pio_var_double, gval)
+    PIO_TF_CHECK_ERR(ierr, "Failed to get a var of double type : " // trim(data_fname))
+
+    PIO_TF_CHECK_VAL((gval, pval), "Got wrong val")
+
+    call PIO_closefile(pio_file)
+    call PIO_deletefile(pio_tf_iosystem_, data_fname);
+  end do
+  if(allocated(iotypes)) then
+    deallocate(iotypes)
+    deallocate(iotype_descs)
+  end if
+
+PIO_TF_AUTO_TEST_SUB_END test_put_get_type_conversion


### PR DESCRIPTION
Unlike PIOc_write_darray, PIOc_put_vars does not have a unit test
on implicit data type conversion so far.

This new test can reproduce issue #385 for ADIOS type.