### PR TITLE
Reduce I/O volume for PIOc_put_vars using ADIOS type

### DIFF
--- a/src/clib/pio_nc.c
+++ b/src/clib/pio_nc.c
@@ -988,19 +988,12 @@ int PIOc_inq_var(int ncid, int varid, char *name, int namelen, nc_type *xtypep, 
             if (nattsp)
                 *nattsp = file->adios_vars[varid].nattrs;
 
+            strncpy(file->varlist[varid].vname, file->adios_vars[varid].name, PIO_MAX_NAME);
+
             ierr = PIO_NOERR;
         }
         else
             ierr = PIO_EBADID;
-
-        /* Copied and modified from MPI_Bcast lines */
-        if (name && namelen > 0)
-        {
-            assert(namelen <= PIO_MAX_NAME + 1);
-            strncpy(name, my_name, namelen);
-        }
-
-        strncpy(file->varlist[varid].vname, my_name, PIO_MAX_NAME);
 
         return ierr;
     }


### PR DESCRIPTION
This patch is provided by Tahsin Kurc, which performs ADIOS calls
only on the master task in PIOc_put_vars_tc().

It also fixes an issue in PIOc_inq_var() on copying variable name
with ADIOS type.