### PR TITLE
New GPTL timers on the write I/O throughput

### DIFF
--- a/src/clib/pio_darray.c
+++ b/src/clib/pio_darray.c
@@ -1276,6 +1276,7 @@ int PIOc_write_darray(int ncid, int varid, int ioid, PIO_Offset arraylen, void *
     int ierr = PIO_NOERR;  /* Return code. */
 
     GPTLstart("PIO:PIOc_write_darray");
+    GPTLstart("PIO:write_total");
     LOG((1, "PIOc_write_darray ncid = %d varid = %d ioid = %d arraylen = %d",
          ncid, varid, ioid, arraylen));
 
@@ -1283,13 +1284,17 @@ int PIOc_write_darray(int ncid, int varid, int ioid, PIO_Offset arraylen, void *
     if ((ierr = pio_get_file(ncid, &file)))
     {
         GPTLstop("PIO:PIOc_write_darray");
+        GPTLstop("PIO:write_total");
         return pio_err(NULL, NULL, PIO_EBADID, __FILE__, __LINE__,
                         "Writing variable (varid=%d) failed on file. Invalid file id (ncid=%d) provided", varid, ncid);
     }
     ios = file->iosystem;
 
     if (file->iotype == PIO_IOTYPE_ADIOS)
+    {
         GPTLstart("PIO:PIOc_write_darray_adios");
+        GPTLstart("PIO:write_total_adios");
+    }
 
     LOG((1, "PIOc_write_darray ncid=%d varid=%d wb_pend=%llu file_wb_pend=%llu",
           ncid, varid,
@@ -1301,8 +1306,12 @@ int PIOc_write_darray(int ncid, int varid, int ioid, PIO_Offset arraylen, void *
     if (!(file->mode & PIO_WRITE))
     {
         GPTLstop("PIO:PIOc_write_darray");
+        GPTLstop("PIO:write_total");
         if (file->iotype == PIO_IOTYPE_ADIOS)
+        {
             GPTLstop("PIO:PIOc_write_darray_adios");
+            GPTLstop("PIO:write_total_adios");
+        }
         return pio_err(ios, file, PIO_EPERM, __FILE__, __LINE__,
                         "Writing variable (%s, varid=%d) to file (%s, ncid=%d) failed. The file was not opened for writing, try reopening the file in write mode (use the PIO_WRITE flag)", pio_get_vname_from_file(file, varid), varid, pio_get_fname_from_file(file), file->pio_ncid);
     }
@@ -1311,8 +1320,12 @@ int PIOc_write_darray(int ncid, int varid, int ioid, PIO_Offset arraylen, void *
     if (!(iodesc = pio_get_iodesc_from_id(ioid)))
     {
         GPTLstop("PIO:PIOc_write_darray");
+        GPTLstop("PIO:write_total");
         if (file->iotype == PIO_IOTYPE_ADIOS)
+        {
             GPTLstop("PIO:PIOc_write_darray_adios");
+            GPTLstop("PIO:write_total_adios");
+        }
         return pio_err(ios, file, PIO_EBADID, __FILE__, __LINE__,
                         "Writing variable (%s, varid=%d) to file (%s, ncid=%d) failed. Invalid I/O descriptor id (ioid=%d) provided", pio_get_vname_from_file(file, varid), varid, pio_get_fname_from_file(file), file->pio_ncid, ioid);
     }
@@ -1324,8 +1337,12 @@ int PIOc_write_darray(int ncid, int varid, int ioid, PIO_Offset arraylen, void *
     if (arraylen < iodesc->ndof)
     {
         GPTLstop("PIO:PIOc_write_darray");
+        GPTLstop("PIO:write_total");
         if (file->iotype == PIO_IOTYPE_ADIOS)
+        {
             GPTLstop("PIO:PIOc_write_darray_adios");
+            GPTLstop("PIO:write_total_adios");
+        }
         return pio_err(ios, file, PIO_EINVAL, __FILE__, __LINE__,
                         "Writing variable (%s, varid=%d) to file (%s, ncid=%d) failed. The local array size (arraylen=%lld) is smaller than expected, the I/O decomposition (ioid=%d) requires a local array of size = %lld", pio_get_vname_from_file(file, varid), varid, pio_get_fname_from_file(file), file->pio_ncid, (long long int) arraylen, ioid, (long long int) iodesc->ndof);
     }
@@ -1348,8 +1365,12 @@ int PIOc_write_darray(int ncid, int varid, int ioid, PIO_Offset arraylen, void *
         if(ierr != PIO_NOERR)
         {
             GPTLstop("PIO:PIOc_write_darray");
+            GPTLstop("PIO:write_total");
             if (file->iotype == PIO_IOTYPE_ADIOS)
+            {
                 GPTLstop("PIO:PIOc_write_darray_adios");
+                GPTLstop("PIO:write_total_adios");
+            }
             return pio_err(ios, NULL, ierr, __FILE__, __LINE__,
                             "Writing variable (%s, varid=%d) to file (%s, ncid=%d) failed. Saving I/O decomposition (ioid=%d) failed. Unable to create a unique file name for saving the I/O decomposition", pio_get_vname_from_file(file, varid), varid, pio_get_fname_from_file(file), file->pio_ncid, ioid);
         }
@@ -1367,8 +1388,12 @@ int PIOc_write_darray(int ncid, int varid, int ioid, PIO_Offset arraylen, void *
         if ((ierr = find_var_fillvalue(file, varid, vdesc)))
         {
             GPTLstop("PIO:PIOc_write_darray");
+            GPTLstop("PIO:write_total");
             if (file->iotype == PIO_IOTYPE_ADIOS)
+            {
                 GPTLstop("PIO:PIOc_write_darray_adios");
+                GPTLstop("PIO:write_total_adios");
+            }
             return pio_err(ios, file, PIO_EBADID, __FILE__, __LINE__,
                             "Writing variable (%s, varid=%d) to file (%s, ncid=%d) failed. Finding fillvalue associated with the variable failed", pio_get_vname_from_file(file, varid), varid, pio_get_fname_from_file(file), file->pio_ncid);
         }
@@ -1390,7 +1415,9 @@ int PIOc_write_darray(int ncid, int varid, int ioid, PIO_Offset arraylen, void *
     {
         ierr = PIOc_write_darray_adios(file, varid, ioid, iodesc, arraylen, array, fillvalue);
         GPTLstop("PIO:PIOc_write_darray_adios");
+        GPTLstop("PIO:write_total_adios");
         GPTLstop("PIO:PIOc_write_darray");
+        GPTLstop("PIO:write_total");
         return ierr;
     }
 #endif
@@ -1403,6 +1430,7 @@ int PIOc_write_darray(int ncid, int varid, int ioid, PIO_Offset arraylen, void *
         if (!(wmb->next = calloc(1, sizeof(wmulti_buffer))))
         {
             GPTLstop("PIO:PIOc_write_darray");
+            GPTLstop("PIO:write_total");
             return pio_err(ios, file, PIO_ENOMEM, __FILE__, __LINE__,
                             "Writing variable (%s, varid=%d) to file (%s, ncid=%d) failed. Out of memory allocating %lld bytes for a write multi buffer to cache user data", pio_get_fname_from_file(file), varid, pio_get_fname_from_file(file), file->pio_ncid, (unsigned long long) sizeof(wmulti_buffer));
         }
@@ -1454,6 +1482,7 @@ int PIOc_write_darray(int ncid, int varid, int ioid, PIO_Offset arraylen, void *
                                 ios->comp_comm)))
     {
         GPTLstop("PIO:PIOc_write_darray");
+        GPTLstop("PIO:write_total");
         return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
     }
     LOG((2, "needsflush = %d", needsflush));
@@ -1488,6 +1517,7 @@ int PIOc_write_darray(int ncid, int varid, int ioid, PIO_Offset arraylen, void *
         if ((ierr = flush_buffer(ncid, wmb, (needsflush == 2))))
         {
             GPTLstop("PIO:PIOc_write_darray");
+            GPTLstop("PIO:write_total");
             return pio_err(ios, file, ierr, __FILE__, __LINE__,
                             "Writing variable (%s, varid=%d) to file (%s, ncid=%d) failed. Flushing data (multiple cached variables with the same decomposition) from compute processes to I/O processes %s failed", pio_get_vname_from_file(file, varid), varid, pio_get_fname_from_file(file), file->pio_ncid, (needsflush == 2) ? "and to disk" : "");
         }
@@ -1514,6 +1544,7 @@ int PIOc_write_darray(int ncid, int varid, int ioid, PIO_Offset arraylen, void *
         if (!(wmb->data = bgetr(wmb->data, (1 + wmb->num_arrays) * arraylen * iodesc->mpitype_size)))
         {
             GPTLstop("PIO:PIOc_write_darray");
+            GPTLstop("PIO:write_total");
             return pio_err(ios, file, PIO_ENOMEM, __FILE__, __LINE__,
                             "Writing variable (%s, varid=%d) to file (%s, ncid=%d) failed. Out of memory allocating space (realloc %lld bytes) to cache user data", pio_get_vname_from_file(file, varid), varid, pio_get_fname_from_file(file), file->pio_ncid, (long long int )((1 + wmb->num_arrays) * arraylen * iodesc->mpitype_size));
         }
@@ -1525,6 +1556,7 @@ int PIOc_write_darray(int ncid, int varid, int ioid, PIO_Offset arraylen, void *
     if (!(wmb->vid = realloc(wmb->vid, sizeof(int) * (1 + wmb->num_arrays))))
     {
         GPTLstop("PIO:PIOc_write_darray");
+        GPTLstop("PIO:write_total");
         return pio_err(ios, file, PIO_ENOMEM, __FILE__, __LINE__,
                         "Writing variable (%s, varid=%d) to file (%s, ncid=%d) failed. Out of memory allocating space (realloc %lld bytes) for array of variable ids in write multi buffer to cache user data", pio_get_vname_from_file(file, varid), varid, pio_get_fname_from_file(file), file->pio_ncid, (unsigned long long)(sizeof(int) * (1 + wmb->num_arrays)));
     }
@@ -1536,6 +1568,7 @@ int PIOc_write_darray(int ncid, int varid, int ioid, PIO_Offset arraylen, void *
         if (!(wmb->frame = realloc(wmb->frame, sizeof(int) * (1 + wmb->num_arrays))))
         {
             GPTLstop("PIO:PIOc_write_darray");
+            GPTLstop("PIO:write_total");
             return pio_err(ios, file, PIO_ENOMEM, __FILE__, __LINE__,
                             "Writing variable (%s, varid=%d) to file (%s, ncid=%d) failed. Out of memory allocating space (realloc %lld bytes) for array of frame numbers in write multi buffer to cache user data", pio_get_vname_from_file(file, varid), varid, pio_get_fname_from_file(file), file->pio_ncid, (unsigned long long)(sizeof(int) * (1 + wmb->num_arrays)));
         }
@@ -1549,6 +1582,7 @@ int PIOc_write_darray(int ncid, int varid, int ioid, PIO_Offset arraylen, void *
         if (!(wmb->fillvalue = bgetr(wmb->fillvalue, iodesc->mpitype_size * (1 + wmb->num_arrays))))
         {
             GPTLstop("PIO:PIOc_write_darray");
+            GPTLstop("PIO:write_total");
             return pio_err(ios, file, PIO_ENOMEM, __FILE__, __LINE__,
                             "Writing variable (%s, varid=%d) to file (%s, ncid=%d) failed. Out of memory allocating space (realloc %lld bytes) for variable fillvalues in write multi buffer to cache user data", pio_get_vname_from_file(file, varid), varid, pio_get_fname_from_file(file), file->pio_ncid, (unsigned long long)(iodesc->mpitype_size * (1 + wmb->num_arrays)));
         }
@@ -1611,6 +1645,7 @@ int PIOc_write_darray(int ncid, int varid, int ioid, PIO_Offset arraylen, void *
             else
             {
                 GPTLstop("PIO:PIOc_write_darray");
+                GPTLstop("PIO:write_total");
                 return pio_err(ios, file, PIO_EBADTYPE, __FILE__, __LINE__,
                                 "Writing variable (%s, varid=%d) to file (%s, ncid=%d) failed. Unable to find a default fillvalue for variable, unsupported variable type", pio_get_vname_from_file(file, varid), varid, pio_get_fname_from_file(file), file->pio_ncid);
             }
@@ -1654,6 +1689,7 @@ int PIOc_write_darray(int ncid, int varid, int ioid, PIO_Offset arraylen, void *
     mtimer_stop(file->varlist[varid].wr_mtimer, get_var_desc_str(ncid, varid, NULL));
 #endif
     GPTLstop("PIO:PIOc_write_darray");
+    GPTLstop("PIO:write_total");
     return PIO_NOERR;
 }
 

--- a/src/clib/pio_file.c
+++ b/src/clib/pio_file.c
@@ -133,15 +133,23 @@ int PIOc_createfile(int iosysid, int *ncidp, int *iotype, const char *filename,
     int ret;               /* Return code from function calls. */
 
     GPTLstart("PIO:PIOc_createfile");
+    GPTLstart("PIO:write_total");
     if (*iotype == PIO_IOTYPE_ADIOS)
+    {
         GPTLstart("PIO:PIOc_createfile_adios");
+        GPTLstart("PIO:write_total_adios");
+    }
 
     /* Get the IO system info from the id. */
     if (!(ios = pio_get_iosystem_from_id(iosysid)))
     {
         GPTLstop("PIO:PIOc_createfile");
+        GPTLstop("PIO:write_total");
         if (*iotype == PIO_IOTYPE_ADIOS)
+        {
             GPTLstop("PIO:PIOc_createfile_adios");
+            GPTLstop("PIO:write_total_adios");
+        }
         return pio_err(NULL, NULL, PIO_EBADID, __FILE__, __LINE__,
                         "Unable to create file (%s, mode = %d, iotype=%s). Invalid arguments provided, invalid iosystem id (iosysid = %d)", (filename) ? filename : "NULL", mode, (!iotype) ? "UNKNOWN" : pio_iotype_to_string(*iotype), iosysid);
     }
@@ -150,8 +158,12 @@ int PIOc_createfile(int iosysid, int *ncidp, int *iotype, const char *filename,
     if ((ret = PIOc_createfile_int(iosysid, ncidp, iotype, filename, mode)))
     {
         GPTLstop("PIO:PIOc_createfile");
+        GPTLstop("PIO:write_total");
         if (*iotype == PIO_IOTYPE_ADIOS)
+        {
             GPTLstop("PIO:PIOc_createfile_adios");
+            GPTLstop("PIO:write_total_adios");
+        }
 
         return pio_err(ios, NULL, ret, __FILE__, __LINE__,
                         "Unable to create file (%s, mode = %d, iotype=%s) on iosystem (iosystem id = %d). Internal error creating the file", (filename) ? filename : "NULL", mode, (!iotype) ? "UNKNOWN" : pio_iotype_to_string(*iotype), iosysid);
@@ -167,16 +179,24 @@ int PIOc_createfile(int iosysid, int *ncidp, int *iotype, const char *filename,
         if ((ret = PIOc_set_fill(*ncidp, NC_NOFILL, NULL)))
         {
             GPTLstop("PIO:PIOc_createfile");
+            GPTLstop("PIO:write_total");
             if (*iotype == PIO_IOTYPE_ADIOS)
+            {
                 GPTLstop("PIO:PIOc_createfile_adios");
+                GPTLstop("PIO:write_total_adios");
+            }
             return pio_err(ios, NULL, ret, __FILE__, __LINE__,
                             "Unable to create file (%s, mode = %d, iotype=%s) on iosystem (iosystem id = %d). Setting fill mode to NOFILL failed.", (filename) ? filename : "NULL", mode, (!iotype) ? "UNKNOWN" : pio_iotype_to_string(*iotype), iosysid);
         }
     }
 
     GPTLstop("PIO:PIOc_createfile");
+    GPTLstop("PIO:write_total");
     if (*iotype == PIO_IOTYPE_ADIOS)
+    {
         GPTLstop("PIO:PIOc_createfile_adios");
+        GPTLstop("PIO:write_total_adios");
+    }
 
     return ret;
 }
@@ -375,13 +395,22 @@ int PIOc_closefile(int ncid)
     ios = file->iosystem;
 
     if (file->iotype == PIO_IOTYPE_ADIOS)
+    {
         GPTLstart("PIO:PIOc_closefile_adios");
+        GPTLstart("PIO:write_total_adios");
+#ifndef _ADIOS_BP2NC_TEST
+        GPTLstart("PIO:write_total");
+#endif
+    }
     else
     {
         GPTLstart("PIO:PIOc_closefile");
 
         if (file->mode & PIO_WRITE)
+        {
             GPTLstart("PIO:PIOc_closefile_write_mode");
+            GPTLstart("PIO:write_total");
+        }
     }
 
     /* Sync changes before closing on all tasks if async is not in
@@ -402,13 +431,22 @@ int PIOc_closefile(int ncid)
         if(ierr != PIO_NOERR)
         {
             if (file->iotype == PIO_IOTYPE_ADIOS)
+            {
                 GPTLstop("PIO:PIOc_closefile_adios");
+                GPTLstop("PIO:write_total_adios");
+#ifndef _ADIOS_BP2NC_TEST
+                GPTLstop("PIO:write_total");
+#endif
+            }
             else
             {
                 GPTLstop("PIO:PIOc_closefile");
 
                 if (file->mode & PIO_WRITE)
+                {
                     GPTLstop("PIO:PIOc_closefile_write_mode");
+                    GPTLstop("PIO:write_total");
+                }
             }
             return pio_err(ios, file, ierr, __FILE__, __LINE__,
                             "Closing file (%s, ncid=%d) failed. Error sending async msg PIO_MSG_CLOSE_FILE", pio_get_fname_from_file(file), ncid);
@@ -430,13 +468,22 @@ int PIOc_closefile(int ncid)
                 if (attributeH == NULL)
                 {
                     if (file->iotype == PIO_IOTYPE_ADIOS)
+                    {
                         GPTLstop("PIO:PIOc_closefile_adios");
+                        GPTLstop("PIO:write_total_adios");
+#ifndef _ADIOS_BP2NC_TEST
+                        GPTLstop("PIO:write_total");
+#endif
+                    }
                     else
                     {
                         GPTLstop("PIO:PIOc_closefile");
 
                         if (file->mode & PIO_WRITE)
+                        {
                             GPTLstop("PIO:PIOc_closefile_write_mode");
+                            GPTLstop("PIO:write_total");
+                        }
                     }
                     return pio_err(ios, file, PIO_EADIOS2ERR, __FILE__, __LINE__, "Defining (ADIOS) attribute (name=/__pio__/fillmode) failed for file (%s, ncid=%d)", pio_get_fname_from_file(file), file->pio_ncid);
                 }
@@ -446,12 +493,21 @@ int PIOc_closefile(int ncid)
             if (adiosErr != adios2_error_none)
             {
                 if (file->iotype == PIO_IOTYPE_ADIOS)
+                {
                     GPTLstop("PIO:PIOc_closefile_adios");
+                    GPTLstop("PIO:write_total_adios");
+#ifndef _ADIOS_BP2NC_TEST
+                    GPTLstop("PIO:write_total");
+#endif
+                }
                 else
                 {
                     GPTLstop("PIO:PIOc_closefile");
                     if (file->mode & PIO_WRITE)
+                    {
                         GPTLstop("PIO:PIOc_closefile_write_mode");
+                        GPTLstop("PIO:write_total");
+                    }
                 }
                 return pio_err(ios, file, PIO_EADIOS2ERR, __FILE__, __LINE__, "Closing (ADIOS) file (%s, ncid=%d) failed (adios2_error=%s)", pio_get_fname_from_file(file), file->pio_ncid, adios2_error_to_string(adiosErr));
             }
@@ -516,13 +572,19 @@ int PIOc_closefile(int ncid)
         if (ierr != PIO_NOERR)
         {
             if (file->iotype == PIO_IOTYPE_ADIOS)
+            {
                 GPTLstop("PIO:PIOc_closefile_adios");
+                GPTLstop("PIO:write_total_adios");
+            }
             else
             {
                 GPTLstop("PIO:PIOc_closefile");
 
                 if (file->mode & PIO_WRITE)
+                {
                     GPTLstop("PIO:PIOc_closefile_write_mode");
+                    GPTLstop("PIO:write_total");
+                }
             }
             return pio_err(ios, file, ierr, __FILE__, __LINE__,
                             "C_API_ConvertBPToNC(infile = %s, outfile = %s, piotype = %s) failed", file->filename, outfilename, conv_iotype);
@@ -532,13 +594,22 @@ int PIOc_closefile(int ncid)
         free(file->filename);
 
         if (file->iotype == PIO_IOTYPE_ADIOS)
+        {
             GPTLstop("PIO:PIOc_closefile_adios");
+            GPTLstop("PIO:write_total_adios");
+#ifndef _ADIOS_BP2NC_TEST
+            GPTLstop("PIO:write_total");
+#endif
+        }
         else
         {
             GPTLstop("PIO:PIOc_closefile");
 
             if (file->mode & PIO_WRITE)
+            {
                 GPTLstop("PIO:PIOc_closefile_write_mode");
+                GPTLstop("PIO:write_total");
+            }
         }
 
         /* Delete file from our list of open files. */
@@ -578,7 +649,10 @@ int PIOc_closefile(int ncid)
         default:
             GPTLstop("PIO:PIOc_closefile");
             if (file->mode & PIO_WRITE)
+            {
                 GPTLstop("PIO:PIOc_closefile_write_mode");
+                GPTLstop("PIO:write_total");
+            }
             return pio_err(ios, file, PIO_EBADIOTYPE, __FILE__, __LINE__,
                             "Closing file (%s, ncid=%d) failed. Unsupported iotype (%d) specified", pio_get_fname_from_file(file), file->pio_ncid, file->iotype);
         }
@@ -589,13 +663,19 @@ int PIOc_closefile(int ncid)
         LOG((1, "nc*_close failed, ierr = %d", ierr));
         GPTLstop("PIO:PIOc_closefile");
         if (file->mode & PIO_WRITE)
+        {
             GPTLstop("PIO:PIOc_closefile_write_mode");
+            GPTLstop("PIO:write_total");
+        }
         return pio_err(NULL, file, ierr, __FILE__, __LINE__,
                         "Closing file (%s, ncid=%d) failed. Underlying I/O library (iotype=%s) call failed", pio_get_fname_from_file(file), file->pio_ncid, pio_iotype_to_string(file->iotype));
     }
 
     if (file->mode & PIO_WRITE)
+    {
         GPTLstop("PIO:PIOc_closefile_write_mode");
+        GPTLstop("PIO:write_total");
+    }
 
     /* Delete file from our list of open files. */
     pio_delete_file_from_list(ncid);
@@ -693,11 +773,13 @@ int PIOc_sync(int ncid)
     int ierr = PIO_NOERR;  /* Return code from function calls. */
 
     GPTLstart("PIO:PIOc_sync");
+    GPTLstart("PIO:write_total");
 
     LOG((1, "PIOc_sync ncid = %d", ncid));
 
     ierr = sync_file(ncid);
 
     GPTLstop("PIO:PIOc_sync");
+    GPTLstop("PIO:write_total");
     return ierr;
 }

--- a/src/clib/pio_getput_int.c
+++ b/src/clib/pio_getput_int.c
@@ -40,24 +40,33 @@ int PIOc_put_att_tc(int ncid, int varid, const char *name, nc_type atttype,
     int ierr = PIO_NOERR;           /* Return code from function calls. */
 
     GPTLstart("PIO:PIOc_put_att_tc");
+    GPTLstart("PIO:write_total");
     /* Find the info about this file. */
     if ((ierr = pio_get_file(ncid, &file)))
     {
         GPTLstop("PIO:PIOc_put_att_tc");
+        GPTLstop("PIO:write_total");
         return pio_err(NULL, NULL, ierr, __FILE__, __LINE__,
                         "Writing variable (varid=%d) attribute (%s) to file failed. Invalid file id (ncid=%d) provided", varid, (name) ? name : "NULL", ncid);
     }
     ios = file->iosystem;
 
     if (file->iotype == PIO_IOTYPE_ADIOS)
+    {
         GPTLstart("PIO:PIOc_put_att_tc_adios");
+        GPTLstart("PIO:write_total_adios");
+    }
 
     /* User must provide some valid parameters. */
     if (!name || !op || strlen(name) > PIO_MAX_NAME || len < 0)
     {
         GPTLstop("PIO:PIOc_put_att_tc");
+        GPTLstop("PIO:write_total");
         if (file->iotype == PIO_IOTYPE_ADIOS)
+        {
             GPTLstop("PIO:PIOc_put_att_tc_adios");
+            GPTLstop("PIO:write_total_adios");
+        }
         return pio_err(ios, file, PIO_EINVAL, __FILE__, __LINE__,
                         "Writing variable (%s, varid=%d) attribute (%s) to file (%s, ncid=%d) failed. Invalid arguments provided, Attribute name (name) is %s (expected not NULL), Attribute data pointer (op) is %s (expected not NULL), Attribute name length is %lld (expected <= %d), Attribute length is %lld (expected >= 0)", pio_get_vname_from_file(file, varid), varid, PIO_IS_NULL(name), pio_get_fname_from_file(file), file->pio_ncid, PIO_IS_NULL(name), PIO_IS_NULL(op), (name) ? ((unsigned long long )strlen(name)) : 0,  PIO_MAX_NAME, (unsigned long long ) len);
     }
@@ -74,8 +83,12 @@ int PIOc_put_att_tc(int ncid, int varid, const char *name, nc_type atttype,
         if(ierr != PIO_NOERR){
             LOG((1, "PIOc_inq_type failed, ierr = %d", ierr));
             GPTLstop("PIO:PIOc_put_att_tc");
+            GPTLstop("PIO:write_total");
             if (file->iotype == PIO_IOTYPE_ADIOS)
+            {
                 GPTLstop("PIO:PIOc_put_att_tc_adios");
+                GPTLstop("PIO:write_total_adios");
+            }
             return ierr;
         }
 
@@ -87,8 +100,12 @@ int PIOc_put_att_tc(int ncid, int varid, const char *name, nc_type atttype,
             ierr = PIOc_inq_type(ncid, memtype, NULL, &memtype_len);
             if(ierr != PIO_NOERR){
                 GPTLstop("PIO:PIOc_put_att_tc");
+                GPTLstop("PIO:write_total");
                 if (file->iotype == PIO_IOTYPE_ADIOS)
+                {
                     GPTLstop("PIO:PIOc_put_att_tc_adios");
+                    GPTLstop("PIO:write_total_adios");
+                }
                 LOG((1, "PIOc_inq_type failed, ierr = %d", ierr));
                 return ierr;
             }
@@ -108,8 +125,12 @@ int PIOc_put_att_tc(int ncid, int varid, const char *name, nc_type atttype,
         if(ierr != PIO_NOERR)
         {
             GPTLstop("PIO:PIOc_put_att_tc");
+            GPTLstop("PIO:write_total");
             if (file->iotype == PIO_IOTYPE_ADIOS)
+            {
                 GPTLstop("PIO:PIOc_put_att_tc_adios");
+                GPTLstop("PIO:write_total_adios");
+            }
             return pio_err(ios, NULL, ierr, __FILE__, __LINE__,
                             "Writing variable (%s, varid=%d) attribute (%s) to file (%s, ncid=%d) failed. Error sending asynchronous message, PIO_MSG_PUT_ATT",  pio_get_vname_from_file(file, varid), varid, name, pio_get_fname_from_file(file), file->pio_ncid);
         }
@@ -118,15 +139,23 @@ int PIOc_put_att_tc(int ncid, int varid, const char *name, nc_type atttype,
         if ((mpierr = MPI_Bcast(&atttype_len, 1, MPI_OFFSET, ios->comproot, ios->my_comm)))
         {
             GPTLstop("PIO:PIOc_put_att_tc");
+            GPTLstop("PIO:write_total");
             if (file->iotype == PIO_IOTYPE_ADIOS)
+            {
                 GPTLstop("PIO:PIOc_put_att_tc_adios");
+                GPTLstop("PIO:write_total_adios");
+            }
             return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
         }
         if ((mpierr = MPI_Bcast(&memtype_len, 1, MPI_OFFSET, ios->comproot, ios->my_comm)))
         {
             GPTLstop("PIO:PIOc_put_att_tc");
+            GPTLstop("PIO:write_total");
             if (file->iotype == PIO_IOTYPE_ADIOS)
+            {
                 GPTLstop("PIO:PIOc_put_att_tc_adios");
+                GPTLstop("PIO:write_total_adios");
+            }
             return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
         }
         LOG((2, "PIOc_put_att bcast from comproot = %d atttype_len = %d", ios->comproot,
@@ -160,7 +189,9 @@ int PIOc_put_att_tc(int ncid, int varid, const char *name, nc_type atttype,
         {
             fprintf(stderr, "ERROR: Num of attributes exceeds maximum (%d).\n", PIO_MAX_VARS);
             GPTLstop("PIO:PIOc_put_att_tc");
+            GPTLstop("PIO:write_total");
             GPTLstop("PIO:PIOc_put_att_tc_adios");
+            GPTLstop("PIO:write_total_adios");
             return PIO_EMAXATTS;
         }
         file->adios_attrs[num_attrs].att_name = strdup(name);
@@ -184,13 +215,17 @@ int PIOc_put_att_tc(int ncid, int varid, const char *name, nc_type atttype,
             if (attributeH == NULL)
             {
                 GPTLstop("PIO:PIOc_put_att_tc");
+                GPTLstop("PIO:write_total");
                 GPTLstop("PIO:PIOc_put_att_tc_adios");
+                GPTLstop("PIO:write_total_adios");
                 return pio_err(ios, file, PIO_EADIOS2ERR, __FILE__, __LINE__, "Defining (ADIOS) attribute (name=%s) failed for file (%s, ncid=%d)", att_name, pio_get_fname_from_file(file), file->pio_ncid);
             }
         }
 
         GPTLstop("PIO:PIOc_put_att_tc");
+        GPTLstop("PIO:write_total");
         GPTLstop("PIO:PIOc_put_att_tc_adios");
+        GPTLstop("PIO:write_total_adios");
 
         return PIO_NOERR;
     }
@@ -227,6 +262,7 @@ int PIOc_put_att_tc(int ncid, int varid, const char *name, nc_type atttype,
                 break;
             default:
                 GPTLstop("PIO:PIOc_put_att_tc");
+                GPTLstop("PIO:write_total");
                 return pio_err(ios, file, PIO_EBADTYPE, __FILE__, __LINE__,
                                 "Writing variable (%s, varid=%d) attribute (%s) to file (%s, ncid=%d) failed. Unsupported PnetCDF attribute type (memtype = %x)", pio_get_vname_from_file(file, varid), varid, name, pio_get_fname_from_file(file), file->pio_ncid, memtype);
             }
@@ -283,6 +319,7 @@ int PIOc_put_att_tc(int ncid, int varid, const char *name, nc_type atttype,
 #endif /* _NETCDF4 */
             default:
                 GPTLstop("PIO:PIOc_put_att_tc");
+                GPTLstop("PIO:write_total");
                 return pio_err(ios, file, PIO_EBADTYPE, __FILE__, __LINE__,
                                 "Writing variable (%s, varid=%d) attribute (%s) to file (%s, ncid=%d) failed. Unsupported attribute type (memtype = %x)", pio_get_vname_from_file(file, varid), varid, name, pio_get_fname_from_file(file), file->pio_ncid, memtype);
             }
@@ -293,11 +330,13 @@ int PIOc_put_att_tc(int ncid, int varid, const char *name, nc_type atttype,
     if(ierr != PIO_NOERR){
         LOG((1, "nc*_put_att_* failed, ierr = %d", ierr));
         GPTLstop("PIO:PIOc_put_att_tc");
+        GPTLstop("PIO:write_total");
         return pio_err(NULL, file, ierr, __FILE__, __LINE__,
                         "Writing variable (%s, varid=%d) attribute (%s) to file (%s, ncid=%d) failed. Internal I/O library (%s) call failed", pio_get_vname_from_file(file, varid), varid, name, pio_get_fname_from_file(file), file->pio_ncid, pio_iotype_to_string(file->iotype));
     }
 
     GPTLstop("PIO:PIOc_put_att_tc");
+    GPTLstop("PIO:write_total");
     return PIO_NOERR;
 }
 
@@ -1062,6 +1101,7 @@ int PIOc_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
     int ierr = PIO_NOERR;          /* Return code from function calls. */
 
     GPTLstart("PIO:PIOc_put_vars_tc");
+    GPTLstart("PIO:write_total");
     LOG((1, "PIOc_put_vars_tc ncid = %d varid = %d start_present = %d "
          "count_present = %d stride_present = %d xtype = %d", ncid, varid,
          start_present, count_present, stride_present, xtype));
@@ -1070,20 +1110,28 @@ int PIOc_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
     if ((ierr = pio_get_file(ncid, &file)))
     {
         GPTLstop("PIO:PIOc_put_vars_tc");
+        GPTLstop("PIO:write_total");
         return pio_err(NULL, NULL, ierr, __FILE__, __LINE__,
                         "Writing variable (varid=%d) to file failed. Invalid file id (ncid=%d) provided", varid, ncid);
     }
     ios = file->iosystem;
 
     if (file->iotype == PIO_IOTYPE_ADIOS)
+    {
         GPTLstart("PIO:PIOc_put_vars_tc_adios");
+        GPTLstart("PIO:write_total_adios");
+    }
 
     /* User must provide a place to put some data. */
     if (!buf)
     {
         GPTLstop("PIO:PIOc_put_vars_tc");
+        GPTLstop("PIO:write_total");
         if (file->iotype == PIO_IOTYPE_ADIOS)
+        {
             GPTLstop("PIO:PIOc_put_vars_tc_adios");
+            GPTLstop("PIO:write_total_adios");
+        }
         return pio_err(ios, file, PIO_EINVAL, __FILE__, __LINE__,
                         "Writing variable (%s, varid=%d) to file (%s, ncid=%d) failed. Invalid/NULL user buffer provided", pio_get_vname_from_file(file, varid), varid, pio_get_fname_from_file(file), ncid);
     }
@@ -1096,8 +1144,12 @@ int PIOc_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
         ierr = PIOc_inq_vartype(ncid, varid, &vartype);
         if(ierr != PIO_NOERR){
             GPTLstop("PIO:PIOc_put_vars_tc");
+            GPTLstop("PIO:write_total");
             if (file->iotype == PIO_IOTYPE_ADIOS)
+            {
                 GPTLstop("PIO:PIOc_put_vars_tc_adios");
+                GPTLstop("PIO:write_total_adios");
+            }
             return pio_err(NULL, NULL, ierr, __FILE__, __LINE__,
                             "Writing variable (%s, varid=%d) to file (%s, ncid=%d) failed. Inquiring variable type failed", pio_get_vname_from_file(file, varid), varid, pio_get_fname_from_file(file), ncid);
         }
@@ -1110,8 +1162,12 @@ int PIOc_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
         ierr = PIOc_inq_varndims(ncid, varid, &ndims);
         if(ierr != PIO_NOERR){
             GPTLstop("PIO:PIOc_put_vars_tc");
+            GPTLstop("PIO:write_total");
             if (file->iotype == PIO_IOTYPE_ADIOS)
+            {
                 GPTLstop("PIO:PIOc_put_vars_tc_adios");
+                GPTLstop("PIO:write_total_adios");
+            }
             return pio_err(NULL, NULL, ierr, __FILE__, __LINE__,
                             "Writing variable (%s, varid=%d) to file (%s, ncid=%d) failed. Inquiring number of dimensions of the variable failed", pio_get_vname_from_file(file, varid), varid, pio_get_fname_from_file(file), ncid);
         }
@@ -1124,8 +1180,12 @@ int PIOc_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
             ierr = PIOc_inq_type(ncid, xtype, NULL, &typelen);
             if(ierr != PIO_NOERR){
                 GPTLstop("PIO:PIOc_put_vars_tc");
+                GPTLstop("PIO:write_total");
                 if (file->iotype == PIO_IOTYPE_ADIOS)
+                {
                     GPTLstop("PIO:PIOc_put_vars_tc_adios");
+                    GPTLstop("PIO:write_total_adios");
+                }
                 return pio_err(NULL, NULL, ierr, __FILE__, __LINE__,
                                 "Writing variable (%s, varid=%d) to file (%s, ncid=%d) failed. Inquiring variable type length failed", pio_get_vname_from_file(file, varid), varid, pio_get_fname_from_file(file), ncid);
             }
@@ -1174,8 +1234,12 @@ int PIOc_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
         if(ierr != PIO_NOERR)
         {
             GPTLstop("PIO:PIOc_put_vars_tc");
+            GPTLstop("PIO:write_total");
             if (file->iotype == PIO_IOTYPE_ADIOS)
+            {
                 GPTLstop("PIO:PIOc_put_vars_tc_adios");
+                GPTLstop("PIO:write_total_adios");
+            }
             return pio_err(ios, NULL, ierr, __FILE__, __LINE__,
                             "Writing variable (%s, varid=%d) to file (%s, ncid=%d) failed. Error sending asynchronous message, PIO_MSG_PUT_VARS", pio_get_vname_from_file(file, varid), varid, pio_get_fname_from_file(file), ncid);
         }
@@ -1198,15 +1262,23 @@ int PIOc_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
         if ((mpierr = MPI_Bcast(&ndims, 1, MPI_INT, ios->comproot, ios->my_comm)))
         {
             GPTLstop("PIO:PIOc_put_vars_tc");
+            GPTLstop("PIO:write_total");
             if (file->iotype == PIO_IOTYPE_ADIOS)
+            {
                 GPTLstop("PIO:PIOc_put_vars_tc_adios");
+                GPTLstop("PIO:write_total_adios");
+            }
             return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
         }
         if ((mpierr = MPI_Bcast(&xtype, 1, MPI_INT, ios->comproot, ios->my_comm)))
         {
             GPTLstop("PIO:PIOc_put_vars_tc");
+            GPTLstop("PIO:write_total");
             if (file->iotype == PIO_IOTYPE_ADIOS)
+            {
                 GPTLstop("PIO:PIOc_put_vars_tc_adios");
+                GPTLstop("PIO:write_total_adios");
+            }
             return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
         }
         LOG((2, "PIOc_put_vars_tc complete bcast from comproot ndims = %d", ndims));
@@ -1219,7 +1291,9 @@ int PIOc_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
         if (varid < 0 || varid >= file->num_vars)
         {
             GPTLstop("PIO:PIOc_put_vars_tc");
+            GPTLstop("PIO:write_total");
             GPTLstop("PIO:PIOc_put_vars_tc_adios");
+            GPTLstop("PIO:write_total_adios");
             return pio_err(ios, file, PIO_EBADID, __FILE__, __LINE__,
                             "Writing variable to file (%s, ncid=%d) failed. Invalid variable id (varid=%d, expected >=0 and < number of variables in the file, %d) provided", pio_get_fname_from_file(file), ncid, varid, file->num_vars);
         }
@@ -1289,7 +1363,9 @@ int PIOc_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
                     if (av->adios_varid == NULL)
                     {
                         GPTLstop("PIO:PIOc_put_vars_tc");
+                        GPTLstop("PIO:write_total");
                         GPTLstop("PIO:PIOc_put_vars_tc_adios");
+                        GPTLstop("PIO:write_total_adios");
                         return pio_err(NULL, file, PIO_EADIOS2ERR, __FILE__, __LINE__, "Defining (ADIOS) variable (name=%s) failed for file (%s, ncid=%d)", av->name, pio_get_fname_from_file(file), file->pio_ncid);
                     }
                 }
@@ -1298,7 +1374,9 @@ int PIOc_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
                 if (adiosErr != adios2_error_none)
                 {
                     GPTLstop("PIO:PIOc_put_vars_tc");
+                    GPTLstop("PIO:write_total");
                     GPTLstop("PIO:PIOc_put_vars_tc_adios");
+                    GPTLstop("PIO:write_total_adios");
                     return pio_err(ios, file, PIO_EADIOS2ERR, __FILE__, __LINE__, "Putting (ADIOS) variable (name=%s) failed (adios2_error=%s) for file (%s, ncid=%d)", av->name, adios2_error_to_string(adiosErr), pio_get_fname_from_file(file), file->pio_ncid);
                 }
             }
@@ -1389,7 +1467,9 @@ int PIOc_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
                     if (av->adios_varid == NULL)
                     {
                         GPTLstop("PIO:PIOc_put_vars_tc");
+                        GPTLstop("PIO:write_total");
                         GPTLstop("PIO:PIOc_put_vars_tc_adios");
+                        GPTLstop("PIO:write_total_adios");
                         return pio_err(ios, file, PIO_EADIOS2ERR, __FILE__, __LINE__, "Defining (ADIOS) variable (name=%s) failed for file (%s, ncid=%d)", av->name, pio_get_fname_from_file(file), file->pio_ncid);
                     }
                 }
@@ -1399,7 +1479,9 @@ int PIOc_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
                     if (adiosErr != adios2_error_none)
                     {
                         GPTLstop("PIO:PIOc_put_vars_tc");
+                        GPTLstop("PIO:write_total");
                         GPTLstop("PIO:PIOc_put_vars_tc_adios");
+                        GPTLstop("PIO:write_total_adios");
                         return pio_err(ios, file, PIO_EADIOS2ERR, __FILE__, __LINE__, "Setting (ADIOS) selection to variable (name=%s) failed (adios2_error=%s) for file (%s, ncid=%d)", av->name, adios2_error_to_string(adiosErr), pio_get_fname_from_file(file), file->pio_ncid);
                     }
                 }
@@ -1408,7 +1490,9 @@ int PIOc_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
                 if (mem_buffer == NULL)
                 {
                     GPTLstop("PIO:PIOc_put_vars_tc");
+                    GPTLstop("PIO:write_total");
                     GPTLstop("PIO:PIOc_put_vars_tc_adios");
+                    GPTLstop("PIO:write_total_adios");
                     return pio_err(ios, file, PIO_ENOMEM, __FILE__, __LINE__,
                                     "Writing variable (%s, varid=%d) to file (%s, ncid=%d) failed. Out of memory, allocating memory (%lld bytes) for putting ADIOS variable (name = %s)", pio_get_vname_from_file(file, varid), varid, pio_get_fname_from_file(file), ncid, (long long int) (av_size * sizeof(unsigned char)), av->name);
                 }
@@ -1424,7 +1508,9 @@ int PIOc_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
                 if (adiosErr != adios2_error_none)
                 {
                     GPTLstop("PIO:PIOc_put_vars_tc");
+                    GPTLstop("PIO:write_total");
                     GPTLstop("PIO:PIOc_put_vars_tc_adios");
+                    GPTLstop("PIO:write_total_adios");
                     return pio_err(ios, file, PIO_EADIOS2ERR, __FILE__, __LINE__, "Putting (ADIOS) variable (name=%s) failed (adios2_error=%s) for file (%s, ncid=%d)", av->name, adios2_error_to_string(adiosErr), pio_get_fname_from_file(file), file->pio_ncid);
                 }
 
@@ -1446,7 +1532,9 @@ int PIOc_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
                     if (attributeH == NULL)
                     {
                         GPTLstop("PIO:PIOc_put_vars_tc");
+                        GPTLstop("PIO:write_total");
                         GPTLstop("PIO:PIOc_put_vars_tc_adios");
+                        GPTLstop("PIO:write_total_adios");
                         return pio_err(ios, file, PIO_EADIOS2ERR, __FILE__, __LINE__, "Defining (ADIOS) attribute array (name=%s, size=%d) failed for file (%s, ncid=%d)", att_name, av->ndims, pio_get_fname_from_file(file), file->pio_ncid);
                     }
                 }
@@ -1465,7 +1553,9 @@ int PIOc_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
                 if (attributeH == NULL)
                 {
                     GPTLstop("PIO:PIOc_put_vars_tc");
+                    GPTLstop("PIO:write_total");
                     GPTLstop("PIO:PIOc_put_vars_tc_adios");
+                    GPTLstop("PIO:write_total_adios");
                     return pio_err(ios, file, PIO_EADIOS2ERR, __FILE__, __LINE__, "Defining (ADIOS) attribute (name=%s) failed for file (%s, ncid=%d)", att_name, pio_get_fname_from_file(file), file->pio_ncid);
                 }
             }
@@ -1478,7 +1568,9 @@ int PIOc_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
                 if (attributeH == NULL)
                 {
                     GPTLstop("PIO:PIOc_put_vars_tc");
+                    GPTLstop("PIO:write_total");
                     GPTLstop("PIO:PIOc_put_vars_tc_adios");
+                    GPTLstop("PIO:write_total_adios");
                     return pio_err(ios, file, PIO_EADIOS2ERR, __FILE__, __LINE__, "Defining (ADIOS) attribute (name=%s) failed for file (%s, ncid=%d)", att_name, pio_get_fname_from_file(file), file->pio_ncid);
                 }
             }
@@ -1493,7 +1585,9 @@ int PIOc_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
                 if (attributeH == NULL)
                 {
                     GPTLstop("PIO:PIOc_put_vars_tc");
+                    GPTLstop("PIO:write_total");
                     GPTLstop("PIO:PIOc_put_vars_tc_adios");
+                    GPTLstop("PIO:write_total_adios");
                     return pio_err(ios, file, PIO_EADIOS2ERR, __FILE__, __LINE__, "Defining (ADIOS) attribute (name=%s) failed for file (%s, ncid=%d)", att_name, pio_get_fname_from_file(file), file->pio_ncid);
                 }
             }
@@ -1506,14 +1600,18 @@ int PIOc_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
                 if (attributeH == NULL)
                 {
                     GPTLstop("PIO:PIOc_put_vars_tc");
+                    GPTLstop("PIO:write_total");
                     GPTLstop("PIO:PIOc_put_vars_tc_adios");
+                    GPTLstop("PIO:write_total_adios");
                     return pio_err(ios, file, PIO_EADIOS2ERR, __FILE__, __LINE__, "Defining (ADIOS) attribute (name=%s) failed for file (%s, ncid=%d)", att_name, pio_get_fname_from_file(file), file->pio_ncid);
                 }
             }
         }
 
         GPTLstop("PIO:PIOc_put_vars_tc");
+        GPTLstop("PIO:write_total");
         GPTLstop("PIO:PIOc_put_vars_tc_adios");
+        GPTLstop("PIO:write_total_adios");
 
         return PIO_NOERR;
     }
@@ -1533,6 +1631,7 @@ int PIOc_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
                                                sizeof(int) * (vdesc->nreqs + PIO_REQUEST_ALLOC_CHUNK))))
                 {
                     GPTLstop("PIO:PIOc_put_vars_tc");
+                    GPTLstop("PIO:write_total");
                     return pio_err(ios, file, PIO_ENOMEM, __FILE__, __LINE__,
                                     "Writing variable (%s, varid=%d) to file (%s, ncid=%d) failed. Out of memory, reallocating memory (%lld bytes) for array to store PnetCDF request handles", pio_get_vname_from_file(file, varid), varid, pio_get_fname_from_file(file), ncid, (long long int) (sizeof(int) * (vdesc->nreqs + PIO_REQUEST_ALLOC_CHUNK)));
                 }
@@ -1544,6 +1643,7 @@ int PIOc_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
                 if(!(vdesc->request_sz))
                 {
                     GPTLstop("PIO:PIOc_put_vars_tc");
+                    GPTLstop("PIO:write_total");
                     return pio_err(ios, file, PIO_ENOMEM, __FILE__, __LINE__,
                                     "Writing variable (%s, varid=%d) to file (%s, ncid=%d) failed. Out of memory, reallocating memory (%lld bytes) for array to store PnetCDF request handles", pio_get_vname_from_file(file, varid), varid, pio_get_fname_from_file(file), ncid, (long long int) (sizeof(int) * (vdesc->nreqs + PIO_REQUEST_ALLOC_CHUNK)));
                 }
@@ -1612,6 +1712,7 @@ int PIOc_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
                         break;
                     default:
                         GPTLstop("PIO:PIOc_put_vars_tc");
+                        GPTLstop("PIO:write_total");
                         return pio_err(ios, file, PIO_EBADIOTYPE, __FILE__, __LINE__,
                                         "Writing variable (%s, varid=%d) to file (%s, ncid=%d) failed. Unsupported PnetCDF variable type (type=%x)", pio_get_vname_from_file(file, varid), varid, pio_get_fname_from_file(file), ncid, xtype);
                     }
@@ -1642,6 +1743,7 @@ int PIOc_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
                     if (!(fake_stride = malloc(ndims * sizeof(PIO_Offset))))
                     {
                         GPTLstop("PIO:PIOc_put_vars_tc");
+                        GPTLstop("PIO:write_total");
                         return pio_err(ios, file, PIO_ENOMEM, __FILE__, __LINE__,
                                         "Writing variable (%s, varid=%d) to file (%s, ncid=%d) failed. Out of memory, allocating memory (%lld bytes) for default variable stride", pio_get_vname_from_file(file, varid), varid, pio_get_fname_from_file(file), ncid, (long long int) (ndims * sizeof(PIO_Offset)));
                     }
@@ -1679,6 +1781,7 @@ int PIOc_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
                         break;
                     default:
                         GPTLstop("PIO:PIOc_put_vars_tc");
+                        GPTLstop("PIO:write_total");
                         return pio_err(ios, file, PIO_EBADTYPE, __FILE__, __LINE__,
                                         "Writing variable (%s, varid=%d) to file (%s, ncid=%d) failed. Unsupported PnetCDF variable type (%x)", pio_get_vname_from_file(file, varid), varid, pio_get_fname_from_file(file), ncid, xtype);
                     }
@@ -1769,6 +1872,7 @@ int PIOc_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
 #endif /* _NETCDF4 */
             default:
                 GPTLstop("PIO:PIOc_put_vars_tc");
+                GPTLstop("PIO:write_total");
                 return pio_err(ios, file, PIO_EBADTYPE, __FILE__, __LINE__,
                                 "Writing variable (%s, varid=%d) to file (%s, ncid=%d) failed. Unsupported variable type (%x) for iotype=%s", pio_get_vname_from_file(file, varid), varid, pio_get_fname_from_file(file), ncid, xtype, pio_iotype_to_string(file->iotype));
             }
@@ -1780,6 +1884,7 @@ int PIOc_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
     if(ierr != PIO_NOERR){
         LOG((1, "nc*_put_vars_* failed, ierr = %d", ierr));
         GPTLstop("PIO:PIOc_put_vars_tc");
+        GPTLstop("PIO:write_total");
         return pio_err(NULL, file, ierr, __FILE__, __LINE__,
                         "Writing variable (%s, varid=%d) to file (%s, ncid=%d) failed. Underlying I/O library call failed(iotype=%x:%s) ", pio_get_vname_from_file(file, varid), varid, pio_get_fname_from_file(file), ncid, xtype, pio_iotype_to_string(file->iotype));
                     
@@ -1788,6 +1893,7 @@ int PIOc_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
     LOG((2, "PIOc_put_vars_tc bcast netcdf return code %d complete", ierr));
 
     GPTLstop("PIO:PIOc_put_vars_tc");
+    GPTLstop("PIO:write_total");
     return PIO_NOERR;
 }
 

--- a/src/clib/pioc_support.c
+++ b/src/clib/pioc_support.c
@@ -2203,16 +2203,9 @@ int PIOc_createfile_int(int iosysid, int *ncidp, int *iotype, const char *filena
     int mpierr = MPI_SUCCESS;  /* Return code from MPI function codes. */
     int ierr = PIO_NOERR;              /* Return code from function calls. */
 
-    GPTLstart("PIO:PIOc_createfile_int");
-    if (*iotype == PIO_IOTYPE_ADIOS)
-        GPTLstart("PIO:PIOc_createfile_int_adios");
-
     /* Get the IO system info from the iosysid. */
     if (!(ios = pio_get_iosystem_from_id(iosysid)))
     {
-        GPTLstop("PIO:PIOc_createfile_int");
-        if (*iotype == PIO_IOTYPE_ADIOS)
-            GPTLstop("PIO:PIOc_createfile_int_adios");
         return pio_err(NULL, NULL, PIO_EBADID, __FILE__, __LINE__,
                         "Creating file (%s) failed. Invalid iosystem id (%d) provided", (filename) ? filename : "UNKNOWN", iosysid);
     }
@@ -2220,9 +2213,6 @@ int PIOc_createfile_int(int iosysid, int *ncidp, int *iotype, const char *filena
     /* User must provide valid input for these parameters. */
     if (!ncidp || !iotype || !filename || strlen(filename) > PIO_MAX_NAME)
     {
-        GPTLstop("PIO:PIOc_createfile_int");
-        if (*iotype == PIO_IOTYPE_ADIOS)
-            GPTLstop("PIO:PIOc_createfile_int_adios");
         return pio_err(ios, NULL, PIO_EINVAL, __FILE__, __LINE__,
                         "Creating file failed. Invalid arguments provided, ncidp is %s (expected not NULL), iotype is %s (expected not NULL), filename is %s (expected not NULL), filename length = %lld (expected <= %d)", PIO_IS_NULL(ncidp), PIO_IS_NULL(iotype), PIO_IS_NULL(filename), (filename) ? ((unsigned long long )strlen(filename)) : 0, (int )PIO_MAX_NAME);
     }
@@ -2232,9 +2222,6 @@ int PIOc_createfile_int(int iosysid, int *ncidp, int *iotype, const char *filena
     {
         char avail_iotypes[PIO_MAX_NAME + 1];
         PIO_get_avail_iotypes(avail_iotypes, PIO_MAX_NAME);
-        GPTLstop("PIO:PIOc_createfile_int");
-        if (*iotype == PIO_IOTYPE_ADIOS)
-            GPTLstop("PIO:PIOc_createfile_int_adios");
         return pio_err(ios, NULL, PIO_EBADIOTYPE, __FILE__, __LINE__,
                         "Creating file (%s) failed. Invalid iotype (%s:%d) specified. Available iotypes are : %s", filename, pio_iotype_to_string(*iotype), *iotype, avail_iotypes);
     }
@@ -2245,9 +2232,6 @@ int PIOc_createfile_int(int iosysid, int *ncidp, int *iotype, const char *filena
     /* Allocate space for the file info. */
     if (!(file = calloc(sizeof(file_desc_t), 1)))
     {
-        GPTLstop("PIO:PIOc_createfile_int");
-        if (*iotype == PIO_IOTYPE_ADIOS)
-            GPTLstop("PIO:PIOc_createfile_int_adios");
         return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__,
                         "Creating file (%s) failed. Out of memory allocating %lld bytes for the file descriptor", filename, (unsigned long long) (sizeof(file_desc_t)));
     }
@@ -2297,9 +2281,6 @@ int PIOc_createfile_int(int iosysid, int *ncidp, int *iotype, const char *filena
         PIO_SEND_ASYNC_MSG(ios, msg, &ierr, len, filename, file->iotype, file->mode);
         if(ierr != PIO_NOERR)
         {
-            GPTLstop("PIO:PIOc_createfile_int");
-            if (*iotype == PIO_IOTYPE_ADIOS)
-                GPTLstop("PIO:PIOc_createfile_int_adios");
             return pio_err(ios, NULL, ierr, __FILE__, __LINE__,
                             "Creating file (%s) failed. Error sending asynchronous message, PIO_MSG_CREATE_FILE, to create the file on iosystem (iosysid=%d)", filename, ios->iosysid);
         }
@@ -2316,9 +2297,6 @@ int PIOc_createfile_int(int iosysid, int *ncidp, int *iotype, const char *filena
         file->filename = malloc(len + 4);
         if (file->filename == NULL)
         {
-            GPTLstop("PIO:PIOc_createfile_int");
-            if (*iotype == PIO_IOTYPE_ADIOS)
-                GPTLstop("PIO:PIOc_createfile_int_adios");
             return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__,
                             "Creating file (%s) using ADIOS iotype failed. Out of memory allocating %lld bytes for the file name", filename, (unsigned long long) (len + 4));
         }
@@ -2349,9 +2327,6 @@ int PIOc_createfile_int(int iosysid, int *ncidp, int *iotype, const char *filena
              * directory while it is being deleted */
             if ((mpierr = MPI_Barrier(ios->union_comm)))
             {
-                GPTLstop("PIO:PIOc_createfile_int");
-                if (*iotype == PIO_IOTYPE_ADIOS)
-                    GPTLstop("PIO:PIOc_createfile_int_adios");
                 return check_mpi(ios, file, mpierr, __FILE__, __LINE__);
             }
         }
@@ -2365,18 +2340,12 @@ int PIOc_createfile_int(int iosysid, int *ncidp, int *iotype, const char *filena
             file->ioH = adios2_declare_io(ios->adiosH, (const char*)(declare_name));
             if (file->ioH == NULL)
             {
-                GPTLstop("PIO:PIOc_createfile_int");
-                if (*iotype == PIO_IOTYPE_ADIOS)
-                    GPTLstop("PIO:PIOc_createfile_int_adios");
                 return pio_err(ios, NULL, PIO_EADIOS2ERR, __FILE__, __LINE__, "Declaring (ADIOS) IO (name=%s) failed for file (%s)", declare_name, pio_get_fname_from_file(file));
             }
 
             adios2_error adiosErr = adios2_set_engine(file->ioH, "BP3");
             if (adiosErr != adios2_error_none)
             {
-                GPTLstop("PIO:PIOc_createfile_int");
-                if (*iotype == PIO_IOTYPE_ADIOS)
-                    GPTLstop("PIO:PIOc_createfile_int_adios");
                 return pio_err(ios, NULL, PIO_EADIOS2ERR, __FILE__, __LINE__, "Setting (ADIOS) engine (type=BP3) failed (adios2_error=%s) for file (%s)", adios2_error_to_string(adiosErr), pio_get_fname_from_file(file));
             }
 
@@ -2396,27 +2365,18 @@ int PIOc_createfile_int(int iosysid, int *ncidp, int *iotype, const char *filena
             adiosErr = adios2_set_parameter(file->ioH, "substreams", file->params);
             if (adiosErr != adios2_error_none)
             {
-                GPTLstop("PIO:PIOc_createfile_int");
-                if (*iotype == PIO_IOTYPE_ADIOS)
-                    GPTLstop("PIO:PIOc_createfile_int_adios");
                 return pio_err(ios, NULL, PIO_EADIOS2ERR, __FILE__, __LINE__, "Setting (ADIOS) parameter (substreams=%s) failed (adios2_error=%s) for file (%s)", file->params, adios2_error_to_string(adiosErr), pio_get_fname_from_file(file));
             }
 
             adiosErr = adios2_set_parameter(file->ioH, "CollectiveMetadata", "OFF");
             if (adiosErr != adios2_error_none)
             {
-                GPTLstop("PIO:PIOc_createfile_int");
-                if (*iotype == PIO_IOTYPE_ADIOS)
-                    GPTLstop("PIO:PIOc_createfile_int_adios");
                 return pio_err(ios, NULL, PIO_EADIOS2ERR, __FILE__, __LINE__, "Setting (ADIOS) parameter (CollectiveMetadata=OFF) failed (adios2_error=%s) for file (%s)", adios2_error_to_string(adiosErr), pio_get_fname_from_file(file));
             }
 
             file->engineH = adios2_open(file->ioH, file->filename, adios2_mode_write);
             if (file->engineH == NULL)
             {
-                GPTLstop("PIO:PIOc_createfile_int");
-                if (*iotype == PIO_IOTYPE_ADIOS)
-                    GPTLstop("PIO:PIOc_createfile_int_adios");
                 return pio_err(NULL, file, PIO_EADIOS2ERR, __FILE__, __LINE__, "Opening (ADIOS) file (%s) failed", pio_get_fname_from_file(file));
             }
 
@@ -2447,9 +2407,6 @@ int PIOc_createfile_int(int iosysid, int *ncidp, int *iotype, const char *filena
                                                        adios2_constant_dims_true);
                     if (variableH == NULL)
                     {
-                        GPTLstop("PIO:PIOc_createfile_int");
-                        if (*iotype == PIO_IOTYPE_ADIOS)
-                            GPTLstop("PIO:PIOc_createfile_int_adios");
                         return pio_err(ios, NULL, PIO_EADIOS2ERR, __FILE__, __LINE__, "Defining (ADIOS) variable (name=/__pio__/info/nproc) failed for file (%s)", pio_get_fname_from_file(file));
                     }
                 }
@@ -2457,9 +2414,6 @@ int PIOc_createfile_int(int iosysid, int *ncidp, int *iotype, const char *filena
                 adios2_error adiosErr = adios2_put(file->engineH, variableH, &ios->num_uniontasks, adios2_mode_sync);
                 if (adiosErr != adios2_error_none)
                 {
-                    GPTLstop("PIO:PIOc_createfile_int");
-                    if (*iotype == PIO_IOTYPE_ADIOS)
-                        GPTLstop("PIO:PIOc_createfile_int_adios");
                     return pio_err(ios, NULL, PIO_EADIOS2ERR, __FILE__, __LINE__, "Putting (ADIOS) variable (name=/__pio__/info/nproc) failed (adios2_error=%s) for file (%s)", adios2_error_to_string(adiosErr), pio_get_fname_from_file(file));
                 }
             }
@@ -2628,15 +2582,11 @@ int PIOc_createfile_int(int iosysid, int *ncidp, int *iotype, const char *filena
     ierr = check_netcdf(ios, NULL, ierr, __FILE__, __LINE__);
     /* If there was an error, free the memory we allocated and handle error. */
     if(ierr != PIO_NOERR){
-        if (file->iotype == PIO_IOTYPE_ADIOS)
-            GPTLstop("PIO:PIOc_createfile_int_adios");
-
 #ifdef _ADIOS2
         free(file->filename);
 #endif
 
         free(file);
-        GPTLstop("PIO:PIOc_createfile_int");
         return pio_err(ios, NULL, ierr, __FILE__, __LINE__,
                         "Creating file (%s) failed. Internal error", filename);
     }
@@ -2644,9 +2594,6 @@ int PIOc_createfile_int(int iosysid, int *ncidp, int *iotype, const char *filena
     /* Broadcast mode to all tasks. */
     if ((mpierr = MPI_Bcast(&file->mode, 1, MPI_INT, ios->ioroot, ios->union_comm)))
     {
-        GPTLstop("PIO:PIOc_createfile_int");
-        if (*iotype == PIO_IOTYPE_ADIOS)
-            GPTLstop("PIO:PIOc_createfile_int_adios");
         return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
     }
 
@@ -2668,10 +2615,6 @@ int PIOc_createfile_int(int iosysid, int *ncidp, int *iotype, const char *filena
 
     LOG((2, "Created file %s file->fh = %d file->pio_ncid = %d", filename,
          file->fh, file->pio_ncid));
-
-    GPTLstop("PIO:PIOc_createfile_int");
-    if (file->iotype == PIO_IOTYPE_ADIOS)
-        GPTLstop("PIO:PIOc_createfile_int_adios");
 
     return ierr;
 }


### PR DESCRIPTION
Add two GPTL timers to calculate the write I/O throughput, one for
all I/O types and one for ADIOS type only.

Also remove timer for internal function PIOc_createfile_int().

Fixes (partially) issue #224 (Cleanup GPTL timers)