### PR TITLE
Adding XML serializer and fixing remaining issues in the serializer

### DIFF
--- a/src/clib/io_perf_summary.schema.json
+++ b/src/clib/io_perf_summary.schema.json
@@ -34,7 +34,7 @@
         },
         "tot_wtime": {
           "description": "Total elapsed wallclock time (seconds)",
-          "type": "integer",
+          "type": "number",
           "minimum": 0
         }
       },
@@ -48,7 +48,7 @@
     "ScorpioIOSummaryStatistics" : {
       "type": "object",
       "properties": {
-        "OverallModelIOStatistics": {
+        "OverallIOStatistics": {
           "$ref": "#/definitions/io_stats"
         },
         "ModelComponentIOStatistics": {
@@ -64,7 +64,7 @@
           }
         }
       },
-      "required": ["OverallModelIOStatistics", "ModelComponentIOStatistics", "FileIOStatistics"] 
+      "required": ["OverallIOStatistics", "ModelComponentIOStatistics", "FileIOStatistics"]
     }
   },
   "required": ["ScorpioIOSummaryStatistics"]

--- a/src/clib/spio_io_summary.cpp
+++ b/src/clib/spio_io_summary.cpp
@@ -402,6 +402,7 @@ static int cache_or_print_stats(iosystem_desc_t *ios, int root_proc,
     std::string sfname = std::string("io_perf_summary_") + std::to_string(pid);
     const std::string sfname_txt_suffix(".txt");
     const std::string sfname_json_suffix(".json");
+    const std::string sfname_xml_suffix(".xml");
 
     assert(cached_ios_gio_sstats.size() == cached_ios_names.size());
 
@@ -412,9 +413,13 @@ static int cache_or_print_stats(iosystem_desc_t *ios, int root_proc,
     std::unique_ptr<PIO_Util::SPIO_serializer> spio_json_ser =
       PIO_Util::Serializer_Utils::create_serializer(PIO_Util::Serializer_type::JSON_SERIALIZER,
         sfname + sfname_json_suffix);
+    std::unique_ptr<PIO_Util::SPIO_serializer> spio_xml_ser =
+      PIO_Util::Serializer_Utils::create_serializer(PIO_Util::Serializer_type::XML_SERIALIZER,
+        sfname + sfname_xml_suffix);
     std::vector<std::pair<std::string, std::string> > vals;
     int id = spio_ser->serialize("ScorpioIOSummaryStatistics", vals);
     int json_id = spio_json_ser->serialize("ScorpioIOSummaryStatistics", vals);
+    int xml_id = spio_xml_ser->serialize("ScorpioIOSummaryStatistics", vals);
 
     /* Add Overall I/O performance statistics */
     std::vector<std::pair<std::string, std::string> > overall_comp_vals;
@@ -440,10 +445,11 @@ static int cache_or_print_stats(iosystem_desc_t *ios, int root_proc,
 
     spio_ser->serialize(id, "OverallIOStatistics", overall_comp_vals);
     spio_json_ser->serialize(json_id, "OverallIOStatistics", overall_comp_vals);
+    spio_xml_ser->serialize(xml_id, "OverallIOStatistics", overall_comp_vals);
 
     /* Add Model Component I/O performance statistics */
     std::vector<std::vector<std::pair<std::string, std::string> > > comp_vvals;
-    std::vector<int> comp_vvals_ids, json_comp_vvals_ids;
+    std::vector<int> comp_vvals_ids, json_comp_vvals_ids, xml_comp_vvals_ids;
 
     for(std::size_t i = 0; i < cached_ios_gio_sstats.size(); i++){
       std::vector<std::pair<std::string, std::string> > comp_vals;
@@ -487,10 +493,11 @@ static int cache_or_print_stats(iosystem_desc_t *ios, int root_proc,
     }
     spio_ser->serialize(id, "ModelComponentIOStatistics", comp_vvals, comp_vvals_ids);
     spio_json_ser->serialize(json_id, "ModelComponentIOStatistics", comp_vvals, json_comp_vvals_ids);
+    spio_xml_ser->serialize(xml_id, "ModelComponentIOStatistics", comp_vvals, xml_comp_vvals_ids);
 
     /* Add File I/O statistics */
     std::vector<std::vector<std::pair<std::string, std::string> > > file_vvals;
-    std::vector<int> file_vvals_ids, json_file_vvals_ids;
+    std::vector<int> file_vvals_ids, json_file_vvals_ids, xml_file_vvals_ids;
     assert(cached_file_gio_sstats.size() == cached_ios_gio_sstats.size());
     for(std::size_t i = 0; i < cached_file_gio_sstats.size(); i++){
       for(std::size_t j = 0; j < cached_file_gio_sstats[i].size(); j++){
@@ -538,10 +545,12 @@ static int cache_or_print_stats(iosystem_desc_t *ios, int root_proc,
     }
     spio_ser->serialize(id, "FileIOStatistics", file_vvals, file_vvals_ids);
     spio_json_ser->serialize(json_id, "FileIOStatistics", file_vvals, json_file_vvals_ids);
+    spio_xml_ser->serialize(xml_id, "FileIOStatistics", file_vvals, xml_file_vvals_ids);
 
     /* Sync/flush I/O performance statistics to the files */
     spio_ser->sync();
     spio_json_ser->sync();
+    spio_xml_ser->sync();
   }
 
   return PIO_NOERR;

--- a/src/clib/spio_io_summary.cpp
+++ b/src/clib/spio_io_summary.cpp
@@ -402,7 +402,6 @@ static int cache_or_print_stats(iosystem_desc_t *ios, int root_proc,
     std::string sfname = std::string("io_perf_summary_") + std::to_string(pid);
     const std::string sfname_txt_suffix(".txt");
     const std::string sfname_json_suffix(".json");
-    const std::string sfname_xml_suffix(".xml");
 
     assert(cached_ios_gio_sstats.size() == cached_ios_names.size());
 
@@ -413,13 +412,9 @@ static int cache_or_print_stats(iosystem_desc_t *ios, int root_proc,
     std::unique_ptr<PIO_Util::SPIO_serializer> spio_json_ser =
       PIO_Util::Serializer_Utils::create_serializer(PIO_Util::Serializer_type::JSON_SERIALIZER,
         sfname + sfname_json_suffix);
-    std::unique_ptr<PIO_Util::SPIO_serializer> spio_xml_ser =
-      PIO_Util::Serializer_Utils::create_serializer(PIO_Util::Serializer_type::XML_SERIALIZER,
-        sfname + sfname_xml_suffix);
     std::vector<std::pair<std::string, std::string> > vals;
     int id = spio_ser->serialize("ScorpioIOSummaryStatistics", vals);
     int json_id = spio_json_ser->serialize("ScorpioIOSummaryStatistics", vals);
-    int xml_id = spio_xml_ser->serialize("ScorpioIOSummaryStatistics", vals);
 
     /* Add Overall I/O performance statistics */
     std::vector<std::pair<std::string, std::string> > overall_comp_vals;
@@ -445,11 +440,10 @@ static int cache_or_print_stats(iosystem_desc_t *ios, int root_proc,
 
     spio_ser->serialize(id, "OverallIOStatistics", overall_comp_vals);
     spio_json_ser->serialize(json_id, "OverallIOStatistics", overall_comp_vals);
-    spio_xml_ser->serialize(xml_id, "OverallIOStatistics", overall_comp_vals);
 
     /* Add Model Component I/O performance statistics */
     std::vector<std::vector<std::pair<std::string, std::string> > > comp_vvals;
-    std::vector<int> comp_vvals_ids, json_comp_vvals_ids, xml_comp_vvals_ids;
+    std::vector<int> comp_vvals_ids, json_comp_vvals_ids;
 
     for(std::size_t i = 0; i < cached_ios_gio_sstats.size(); i++){
       std::vector<std::pair<std::string, std::string> > comp_vals;
@@ -493,11 +487,10 @@ static int cache_or_print_stats(iosystem_desc_t *ios, int root_proc,
     }
     spio_ser->serialize(id, "ModelComponentIOStatistics", comp_vvals, comp_vvals_ids);
     spio_json_ser->serialize(json_id, "ModelComponentIOStatistics", comp_vvals, json_comp_vvals_ids);
-    spio_xml_ser->serialize(xml_id, "ModelComponentIOStatistics", comp_vvals, xml_comp_vvals_ids);
 
     /* Add File I/O statistics */
     std::vector<std::vector<std::pair<std::string, std::string> > > file_vvals;
-    std::vector<int> file_vvals_ids, json_file_vvals_ids, xml_file_vvals_ids;
+    std::vector<int> file_vvals_ids, json_file_vvals_ids;
     assert(cached_file_gio_sstats.size() == cached_ios_gio_sstats.size());
     for(std::size_t i = 0; i < cached_file_gio_sstats.size(); i++){
       for(std::size_t j = 0; j < cached_file_gio_sstats[i].size(); j++){
@@ -545,12 +538,10 @@ static int cache_or_print_stats(iosystem_desc_t *ios, int root_proc,
     }
     spio_ser->serialize(id, "FileIOStatistics", file_vvals, file_vvals_ids);
     spio_json_ser->serialize(json_id, "FileIOStatistics", file_vvals, json_file_vvals_ids);
-    spio_xml_ser->serialize(xml_id, "FileIOStatistics", file_vvals, xml_file_vvals_ids);
 
     /* Sync/flush I/O performance statistics to the files */
     spio_ser->sync();
     spio_json_ser->sync();
-    spio_xml_ser->sync();
   }
 
   return PIO_NOERR;

--- a/src/clib/spio_serializer.cpp
+++ b/src/clib/spio_serializer.cpp
@@ -368,7 +368,7 @@ std::string PIO_Util::Json_serializer::get_serialized_data(void )
   return sdata_;
 }
 
-/* Text serializer visitor functions */
+/* Json serializer visitor functions */
 
 void PIO_Util::Json_serializer::Json_serializer_visitor::begin(void)
 {
@@ -400,7 +400,11 @@ void PIO_Util::Json_serializer::Json_serializer_visitor::enter_node(
   /* Serialize all (name, value) pairs on this node */
   for(std::vector<std::pair<std::string, std::string> >::const_iterator citer = val.vals.cbegin();
       citer != val.vals.cend(); ++citer){
-    sdata_ += val_spaces + (*citer).first + SPACE + ID_SEP + SPACE + (*citer).second + NEWLINE;
+    sdata_ += val_spaces + (*citer).first + SPACE + ID_SEP + SPACE + (*citer).second;
+    if(citer + 1 != val.vals.cend()){
+      sdata_ += ELEM_SEP;
+    }
+    sdata_ += NEWLINE;
   }
 }
 
@@ -417,8 +421,8 @@ void PIO_Util::Json_serializer::Json_serializer_visitor::on_node(
   int id_nspaces = id2spaces_[val_id] + inc_spaces_;
   std::string id_spaces(id_nspaces, SPACE);
 
-  /* Separate out the JSON objects in this aggregate object using AGG_SEP */
-  sdata_ += id_spaces + AGG_SEP + NEWLINE;
+  /* Separate out the JSON objects in this aggregate object using ELEM_SEP */
+  sdata_ += id_spaces + ELEM_SEP + NEWLINE;
 }
 
 void PIO_Util::Json_serializer::Json_serializer_visitor::on_node(

--- a/src/clib/spio_serializer.cpp
+++ b/src/clib/spio_serializer.cpp
@@ -106,6 +106,166 @@ void PIO_Util::Text_serializer::Text_serializer_visitor::enter_node(
   Text_serializer_visitor::enter_node(val, val_id);
 }
 
+/* XML Serializer function definitions */
+
+int PIO_Util::XML_serializer::serialize(const std::string &name,
+      const std::vector<std::pair<std::string, std::string> > &vals)
+{
+  /* Add the user data to the internal tree */
+  XML_serializer_val sval = {name, vals};
+  int val_id = dom_tree_.add(sval);
+
+  /* Since this val has no parent, 0 spaces required for this tag */
+  id2spaces_[val_id] = 0;
+
+  return val_id;
+}
+
+int PIO_Util::XML_serializer::serialize(int parent_id,
+      const std::string &name,
+      const std::vector<std::pair<std::string, std::string> > &vals)
+{
+  /* Add the user data to the internal tree */
+  XML_serializer_val sval = {name, vals};
+  int val_id = dom_tree_.add(sval, parent_id);
+
+  /* Number of spaces is INC_SPACES more than the parent tag */
+  id2spaces_[val_id] = id2spaces_[parent_id] + INC_SPACES;
+
+  return val_id;
+}
+
+void PIO_Util::XML_serializer::serialize(const std::string &name,
+      const std::vector< std::vector<std::pair<std::string, std::string> > > &vvals,
+      std::vector<int> &val_ids)
+{
+  for(std::vector<std::vector<std::pair<std::string, std::string> > >::const_iterator
+      citer = vvals.cbegin(); citer != vvals.cend(); ++citer){
+    val_ids.push_back(serialize(name, *citer));
+  }
+}
+
+void PIO_Util::XML_serializer::serialize(int parent_id, const std::string &name,
+      const std::vector< std::vector<std::pair<std::string, std::string> > > &vvals,
+      std::vector<int> &val_ids)
+{
+  for(std::vector<std::vector<std::pair<std::string, std::string> > >::const_iterator
+      citer = vvals.cbegin(); citer != vvals.cend(); ++citer){
+    val_ids.push_back(serialize(parent_id, name, *citer));
+  }
+}
+
+void PIO_Util::XML_serializer::sync(void )
+{
+  /* Create an XML serializer */
+  XML_serializer_visitor vis(id2spaces_, INC_SPACES);
+
+  /* Traverse the tree using the XML serializer. The XML serializer
+   * serializes the data in the tree to text and caches it
+   */
+  dom_tree_.dfs(vis);
+
+  /* Get the cached serialized data from the XML serializer */
+  sdata_ = vis.get_serialized_data();
+
+  /* Write the data out to the XML file */
+  std::ofstream fstr;
+  fstr.open(pname_.c_str(), std::ofstream::out | std::ofstream::trunc);
+  fstr << sdata_.c_str();
+  fstr.close();
+}
+
+std::string PIO_Util::XML_serializer::get_serialized_data(void )
+{
+  return sdata_;
+}
+
+/* XML serializer visitor functions */
+void PIO_Util::XML_serializer::XML_serializer_visitor::enter_node(
+  XML_serializer_val &val, int val_id)
+{
+  int id_nspaces = id2spaces_[val_id];
+  std::string id_spaces(id_nspaces, SPACE);
+
+  std::string tname = get_start_tag(val.name);
+  sdata_ += id_spaces + tname + NEWLINE;
+
+  int val_nspaces = id_nspaces + inc_spaces_;
+  std::string val_spaces(val_nspaces, SPACE);
+
+  /* Serialize and cache the (name, value) pairs on the node */
+  for(std::vector<std::pair<std::string, std::string> >::const_iterator citer = val.vals.cbegin();
+      citer != val.vals.cend(); ++citer){
+    std::string stag_name = get_start_tag(citer->first);
+    std::string etag_name = get_end_tag(citer->first);
+    sdata_ += val_spaces + stag_name + SPACE + citer->second + SPACE + etag_name + NEWLINE;
+  }
+}
+
+void PIO_Util::XML_serializer::XML_serializer_visitor::enter_node(
+  XML_serializer_val &val, int val_id,
+  XML_serializer_val &parent_val, int parent_id)
+{
+  /* XML serializer does not use the parent info */
+  XML_serializer_visitor::enter_node(val, val_id);
+}
+
+void PIO_Util::XML_serializer::XML_serializer_visitor::exit_node(
+  XML_serializer_val &val, int val_id)
+{
+  int id_nspaces = id2spaces_[val_id];
+  std::string id_spaces(id_nspaces, SPACE);
+
+  std::string tname = get_end_tag(val.name);
+  sdata_ += id_spaces + tname + NEWLINE;
+}
+
+void PIO_Util::XML_serializer::XML_serializer_visitor::exit_node(
+  XML_serializer_val &val, int val_id,
+  XML_serializer_val &parent_val, int parent_id)
+{
+  /* XML serializer does not use the parent info */
+  XML_serializer_visitor::exit_node(val, val_id);
+}
+
+/* XML tagify the tag names */
+std::string PIO_Util::XML_serializer::XML_serializer_visitor::get_start_tag(
+  const std::string &tag_name)
+{
+  return std::string("<") +
+          get_unquoted_str(tag_name) +
+          std::string(">");
+}
+
+std::string PIO_Util::XML_serializer::XML_serializer_visitor::get_end_tag(
+  const std::string &tag_name)
+{
+  return std::string("</") +
+          get_unquoted_str(tag_name) +
+          std::string(">");
+}
+
+/* Remove double quotes around a string
+ * The function only removes double quotes if its present at the beginning
+ * and the end of a string
+ * e.g.
+ *  "helloworld" --> helloworld
+ *  'helloworld' --> 'helloworld'
+ *  helloworld --> helloworld
+ *  hello"world" --> hello"world"
+ */
+std::string PIO_Util::XML_serializer::XML_serializer_visitor::get_unquoted_str(
+  const std::string &str)
+{
+  const char DQUOTE = '"';
+  if(str.size() >= 2){
+    if((str[0] == DQUOTE) && (str[str.size() - 1] == DQUOTE)){
+      return str.substr(1, str.size() - 2);
+    }
+  }
+  return str;
+}
+
 /* JSON Serializer functions */
 int PIO_Util::Json_serializer::serialize(const std::string &name,
       const std::vector<std::pair<std::string, std::string> > &vals)
@@ -329,7 +489,7 @@ std::unique_ptr<PIO_Util::SPIO_serializer> PIO_Util::Serializer_Utils::create_se
     return std::unique_ptr<Json_serializer>(new Json_serializer(persistent_name));
   }
   else if(type == Serializer_type::XML_SERIALIZER){
-    throw std::runtime_error("XML serializer is currently not supported");
+    return std::unique_ptr<XML_serializer>(new XML_serializer(persistent_name));
   }
   else if(type == Serializer_type::TEXT_SERIALIZER){
     return std::unique_ptr<Text_serializer>(new Text_serializer(persistent_name));

--- a/src/clib/spio_serializer.hpp
+++ b/src/clib/spio_serializer.hpp
@@ -235,7 +235,7 @@ class Json_serializer : public SPIO_serializer{
         const char ARRAY_END = ']';
         const char OBJECT_START = '{';
         const char OBJECT_END = '}';
-        const char AGG_SEP = ',';
+        const char ELEM_SEP = ',';
         std::string sdata_;
         std::map<int, int> id2spaces_;
         int inc_spaces_;

--- a/src/clib/spio_serializer.hpp
+++ b/src/clib/spio_serializer.hpp
@@ -110,6 +110,66 @@ class Text_serializer : public SPIO_serializer{
     SPIO_tree<Text_serializer_val> dom_tree_;
 };
 
+/* Class to serialize (name, value) pairs and tags in to an XML file */
+class XML_serializer : public SPIO_serializer{
+  public:
+    XML_serializer(const std::string &fname) : SPIO_serializer(fname) {};
+    int serialize(const std::string &name,
+                  const std::vector<std::pair<std::string, std::string> > &vals) override;
+    int serialize(int parent_id, const std::string &name,
+                  const std::vector<std::pair<std::string, std::string> > &vals) override;
+    void serialize(const std::string &name,
+                  const std::vector<std::vector<std::pair<std::string, std::string> > > &vvals,
+                  std::vector<int> &val_ids) override;
+    void serialize(int parent_id, const std::string &name,
+                  const std::vector<std::vector<std::pair<std::string, std::string> > > &vvals,
+                  std::vector<int> &val_ids) override;
+    void sync(void ) override;
+    std::string get_serialized_data(void ) override;
+    ~XML_serializer() {};
+  private:
+    /* Cache of the serialized data */
+    std::string sdata_;
+    const int START_ID_SPACES = 0;
+    const int INC_SPACES = 2;
+    /* Store the number of spaces to output for each tag/id */
+    std::map<int, int> id2spaces_;
+
+    /* The internal tree stores the tag name and the associated (name, value) pair
+     * in this struct
+     */
+    struct XML_serializer_val{
+      std::string name;
+      std::vector<std::pair<std::string, std::string> > vals;
+    };
+
+    /* Visitor class used to serialize the contents of the internal tree to text */
+    class XML_serializer_visitor : public SPIO_tree_visitor<XML_serializer_val>{
+      public:
+        XML_serializer_visitor(const std::map<int, int> &id2spaces,
+          int inc_spaces) : id2spaces_(id2spaces), inc_spaces_(inc_spaces) {};
+        void enter_node(XML_serializer_val &val, int val_id) override;
+        void enter_node(XML_serializer_val &val, int val_id,
+              XML_serializer_val &parent_val, int parent_id) override;
+        void exit_node(XML_serializer_val &val, int val_id) override;
+        void exit_node(XML_serializer_val &val, int val_id,
+              XML_serializer_val &parent_val, int parent_id) override;
+        std::string get_serialized_data(void ) { return sdata_; };
+      private:
+        const char SPACE = ' ';
+        const char NEWLINE = '\n';
+        std::string sdata_;
+        std::map<int, int> id2spaces_;
+        int inc_spaces_;
+
+        std::string get_start_tag(const std::string &tag_name);
+        std::string get_end_tag(const std::string &tag_name);
+        std::string get_unquoted_str(const std::string &str);
+    };
+
+    SPIO_tree<XML_serializer_val> dom_tree_;
+};
+
 /* Class to serialize (name, value) pairs and tags in to a json file */
 class Json_serializer : public SPIO_serializer{
   public:

--- a/tests/cunit/test_spio_serializer.cpp
+++ b/tests/cunit/test_spio_serializer.cpp
@@ -155,19 +155,20 @@ int test_simple_types(int wrank)
    * ============ Expected Serialized JSON ===========
    *{
    * "SerializedVals":{
-   *    "name" : "helloworld"
-   *    "ival" : 3
+   *    "name" : "helloworld",
+   *    "ival" : 3,
    *    "dval" : 3.14
    *  }
    *}
    */
   const std::string JSON_OBJECT_START("{");
   const std::string JSON_OBJECT_END("}");
+  const std::string COMMA(",");
   std::string exp_ser_json =
     JSON_OBJECT_START + NEWLINE +
       Utils::quoted_str(ser_tag) + ID_SEP + JSON_OBJECT_START + NEWLINE +
-        Utils::quoted_str(name_tag) + ID_SEP + Utils::quoted_str(name) + NEWLINE +
-        Utils::quoted_str(ival_tag) + ID_SEP + std::to_string(ival) + NEWLINE +
+        Utils::quoted_str(name_tag) + ID_SEP + Utils::quoted_str(name) + COMMA + NEWLINE +
+        Utils::quoted_str(ival_tag) + ID_SEP + std::to_string(ival) + COMMA + NEWLINE +
         Utils::quoted_str(dval_tag) + ID_SEP + std::to_string(dval) + NEWLINE +
       JSON_OBJECT_END + NEWLINE +
     JSON_OBJECT_END + NEWLINE;
@@ -482,8 +483,8 @@ int test_tiered_data(int wrank)
    *{
    * "SerializedValsT1":{
    *  "SerializedValsT2":{
-   *      "name" : "helloworld"
-   *      "ival" : 3
+   *      "name" : "helloworld",
+   *      "ival" : 3,
    *      "dval" : 3.14
    *    }
    *  }
@@ -491,12 +492,13 @@ int test_tiered_data(int wrank)
    */
   const std::string JSON_OBJECT_START("{");
   const std::string JSON_OBJECT_END("}");
+  const std::string COMMA(",");
   std::string exp_ser_json =
     JSON_OBJECT_START + NEWLINE +
       Utils::quoted_str(ser_tag_tier1) + ID_SEP + JSON_OBJECT_START + NEWLINE +
         Utils::quoted_str(ser_tag_tier2) + ID_SEP + JSON_OBJECT_START + NEWLINE +
-          Utils::quoted_str(name_tag) + ID_SEP + Utils::quoted_str(name) + NEWLINE +
-          Utils::quoted_str(ival_tag) + ID_SEP + std::to_string(ival) + NEWLINE +
+          Utils::quoted_str(name_tag) + ID_SEP + Utils::quoted_str(name) + COMMA + NEWLINE +
+          Utils::quoted_str(ival_tag) + ID_SEP + std::to_string(ival) + COMMA + NEWLINE +
           Utils::quoted_str(dval_tag) + ID_SEP + std::to_string(dval) + NEWLINE +
         JSON_OBJECT_END + NEWLINE +
       JSON_OBJECT_END + NEWLINE +

--- a/tests/cunit/test_spio_serializer.cpp
+++ b/tests/cunit/test_spio_serializer.cpp
@@ -40,6 +40,16 @@ static std::string quoted_str(const std::string &str)
   return (std::string("\"") + str + std::string("\""));
 }
 
+static std::string get_start_xml_tag(const std::string &tag_name)
+{
+  return std::string("<") + tag_name + std::string(">");
+}
+
+static std::string get_end_xml_tag(const std::string &tag_name)
+{
+  return std::string("</") + tag_name + std::string(">");
+}
+
 } // namespace Utils
 
 /* Test serializing simple types */
@@ -97,6 +107,49 @@ int test_simple_types(int wrank)
   }
 
   LOG_RANK0(wrank, "Testing TEXT serializer PASSED\n");
+
+  /*
+   * ============ Expected Serialized XML ===========
+   * <SerializedVals>
+   *  <name> "helloworld" </name>
+   *  <ival> 3 </ival>
+   *  <dval> 3.14 </dval>
+   * </SerializedVals>
+   */
+  std::string exp_ser_xml =
+    Utils::get_start_xml_tag(ser_tag) + NEWLINE +
+      Utils::get_start_xml_tag(name_tag) +
+        Utils::quoted_str(name) +
+      Utils::get_end_xml_tag(name_tag) + NEWLINE +
+      Utils::get_start_xml_tag(ival_tag) +
+        std::to_string(ival) +
+      Utils::get_end_xml_tag(ival_tag) + NEWLINE +
+      Utils::get_start_xml_tag(dval_tag) +
+        std::to_string(dval) +
+      Utils::get_end_xml_tag(dval_tag) + NEWLINE +
+    Utils::get_end_xml_tag(ser_tag) + NEWLINE;
+
+  /* Create an XML serializer */
+  std::unique_ptr<PIO_Util::SPIO_serializer> spio_xml_ser =
+    PIO_Util::Serializer_Utils::create_serializer(
+      PIO_Util::Serializer_type::XML_SERIALIZER, "test_simple_types.xml");
+
+  /* Serialize the vals, sync and retrieve the serialized data */
+  spio_xml_ser->serialize(ser_tag, vals);
+  spio_xml_ser->sync();
+  std::string serialized_xml = spio_xml_ser->get_serialized_data();
+
+  if(Utils::rem_blank_str(serialized_xml) != Utils::rem_blank_str(exp_ser_xml)){
+    LOG_RANK0(wrank, "test_simple_types() FAILED\n");
+    LOG_RANK0(wrank, "Serialized XML : \n");
+    LOG_RANK0(wrank, "%s\n", serialized_xml.c_str());
+    LOG_RANK0(wrank, "Expected serialized XML : \n");
+    LOG_RANK0(wrank, "%s\n", exp_ser_xml.c_str());
+
+    return PIO_EINTERNAL;
+  }
+
+  LOG_RANK0(wrank, "Testing XML serializer PASSED\n");
 
   /*
    * ============ Expected Serialized JSON ===========
@@ -204,6 +257,51 @@ int test_array_types(int wrank)
   }
 
   LOG_RANK0(wrank, "Testing TEXT serializer PASSED\n");
+
+  /*
+   * ============ Expected Serialized XML ===========
+   * <SerializedVals>
+   *  <name> "helloworld1" </name>
+   * </SerializedVals>
+   * <SerializedVals>
+   *  <name> "helloworld2" </name>
+   * </SerializedVals>
+   * <SerializedVals>
+   *  <name> "helloworld3" </name>
+   * </SerializedVals>
+   */
+  std::string exp_ser_xml;
+  for(std::vector<std::pair<std::string, std::string> >::const_iterator
+        citer = names.cbegin(); citer != names.cend(); ++citer){
+    exp_ser_xml +=
+      Utils::get_start_xml_tag(ser_tag) + NEWLINE +
+        Utils::get_start_xml_tag(citer->first) +
+          Utils::quoted_str(citer->second) +
+        Utils::get_end_xml_tag(citer->first) + NEWLINE +
+      Utils::get_end_xml_tag(ser_tag) + NEWLINE;
+  }
+
+  /* Create an XML serializer */
+  std::unique_ptr<PIO_Util::SPIO_serializer> spio_xml_ser =
+    PIO_Util::Serializer_Utils::create_serializer(
+      PIO_Util::Serializer_type::XML_SERIALIZER, "test_array_types.xml");
+
+  /* Serialize the vals, sync and retrieve the serialized data */
+  spio_xml_ser->serialize(ser_tag, vvals, val_ids);
+  spio_xml_ser->sync();
+  std::string serialized_xml = spio_xml_ser->get_serialized_data();
+
+  if(Utils::rem_blank_str(serialized_xml) != Utils::rem_blank_str(exp_ser_xml)){
+    LOG_RANK0(wrank, "test_array_types() FAILED\n");
+    LOG_RANK0(wrank, "Serialized XML : \n");
+    LOG_RANK0(wrank, "%s\n", serialized_xml.c_str());
+    LOG_RANK0(wrank, "Expected serialized XML : \n");
+    LOG_RANK0(wrank, "%s\n", exp_ser_xml.c_str());
+
+    return PIO_EINTERNAL;
+  }
+
+  LOG_RANK0(wrank, "Testing XML serializer PASSED\n");
 
   /*
    * ============ Expected Serialized JSON ===========
@@ -330,6 +428,54 @@ int test_tiered_data(int wrank)
   }
 
   LOG_RANK0(wrank, "Testing TEXT serializer PASSED\n");
+
+  /*
+   * ============ Expected Serialized XML ===========
+   * <SerializedValsT1>
+   *  <SerializedValsT2>
+   *    <name> "helloworld" </name>
+   *    <ival> 3 </ival>
+   *    <dval> 3.14 </dval>
+   *  </SerializedValsT2>
+   * </SerializedValsT1>
+   */
+  std::string exp_ser_xml =
+    Utils::get_start_xml_tag(ser_tag_tier1) + NEWLINE +
+      Utils::get_start_xml_tag(ser_tag_tier2) + NEWLINE +
+        Utils::get_start_xml_tag(name_tag) +
+          Utils::quoted_str(name) +
+        Utils::get_end_xml_tag(name_tag) + NEWLINE +
+        Utils::get_start_xml_tag(ival_tag) +
+          std::to_string(ival) +
+        Utils::get_end_xml_tag(ival_tag) + NEWLINE +
+        Utils::get_start_xml_tag(dval_tag) +
+          std::to_string(dval) +
+        Utils::get_end_xml_tag(dval_tag) + NEWLINE +
+      Utils::get_end_xml_tag(ser_tag_tier2) + NEWLINE +
+    Utils::get_end_xml_tag(ser_tag_tier1) + NEWLINE;
+
+  /* Create an XML serializer */
+  std::unique_ptr<PIO_Util::SPIO_serializer> spio_xml_ser =
+    PIO_Util::Serializer_Utils::create_serializer(
+      PIO_Util::Serializer_type::XML_SERIALIZER, "test_htypes.xml");
+
+  /* Serialize the vals, sync and retrieve the serialized data */
+  t1_id = spio_xml_ser->serialize(ser_tag_tier1, empty_vals);
+  spio_xml_ser->serialize(t1_id, ser_tag_tier2, vals);
+  spio_xml_ser->sync();
+  std::string serialized_xml = spio_xml_ser->get_serialized_data();
+
+  if(Utils::rem_blank_str(serialized_xml) != Utils::rem_blank_str(exp_ser_xml)){
+    LOG_RANK0(wrank, "test_simple_types() FAILED\n");
+    LOG_RANK0(wrank, "Serialized XML : \n");
+    LOG_RANK0(wrank, "%s\n", serialized_xml.c_str());
+    LOG_RANK0(wrank, "Expected serialized XML : \n");
+    LOG_RANK0(wrank, "%s\n", exp_ser_xml.c_str());
+
+    return PIO_EINTERNAL;
+  }
+
+  LOG_RANK0(wrank, "Testing XML serializer PASSED\n");
 
   /*
    * ============ Expected Serialized JSON ===========


### PR DESCRIPTION
This PR includes the following changes,

* Adding an XML serializer and associated tests.
* Getting rid of the dummy root node in the internal tree
  used by the serializers.
* Also fixing issues in the JSON format used for writing
  out the I/O performance statistics