### PR TITLE
Adding <sstream> for stringstream

### DIFF
--- a/tools/util/argparser.cxx
+++ b/tools/util/argparser.cxx
@@ -1,5 +1,6 @@
 #include "mpi.h"
 #include <iostream>
+#include <sstream>
 #include <string>
 #include <vector>
 #include <map>


### PR DESCRIPTION
Adding the header required for std::stringstream

Fixes #378 