### PR TITLE
Miscellaneous bug fixes and enhancements for SCORPIO's performance replay tool

### DIFF
--- a/tests/performance/pioperformance_rearr.F90
+++ b/tests/performance/pioperformance_rearr.F90
@@ -965,13 +965,15 @@ contains
              enddo
           enddo
        enddo
-!       deallocate(compmap)
+       deallocate(compmap)
+       deallocate(gdims)
        deallocate(ifld)
        deallocate(ifld_in)
        deallocate(rfld)
        deallocate(dfld)
        deallocate(dfld_in)
        deallocate(rfld_in)
+       call MPI_Comm_free(comm, ierr)
     endif
 
   end subroutine pioperformance_rearrtest

--- a/tests/performance/pioperformance_rearr.F90
+++ b/tests/performance/pioperformance_rearr.F90
@@ -664,9 +664,9 @@ contains
 
        call MPI_ALLREDUCE(maplen,gmaplen,1,MPI_INTEGER8,MPI_SUM,comm,ierr)
 
-!       if(gmaplen /= product(gdims)) then
-!          print *,__FILE__,__LINE__,gmaplen,gdims
-!       endif
+       if (gmaplen > product(gdims)) then
+          gmaplen = product(gdims)
+       endif
     
        allocate(ifld(maplen,nvars))
        allocate(ifld_in(maplen,nvars,nframes))

--- a/tests/performance/pioperformance_rearr.F90
+++ b/tests/performance/pioperformance_rearr.F90
@@ -8,7 +8,7 @@ program pioperformance_rearr
 #endif
   use perf_mod, only : t_initf, t_finalizef
   use pio, only : pio_iotype_netcdf, pio_iotype_pnetcdf, pio_iotype_netcdf4p, &
-       pio_iotype_netcdf4c, pio_rearr_subset, pio_rearr_box, PIO_MAX_NAME,&
+       pio_iotype_netcdf4c, pio_iotype_adios, pio_rearr_subset, pio_rearr_box, PIO_MAX_NAME,&
         pio_rearr_opt_t, pio_rearr_comm_p2p, pio_rearr_comm_coll,&
         pio_rearr_comm_fc_2d_disable, pio_rearr_comm_fc_1d_comp2io,&
         pio_rearr_comm_fc_1d_io2comp, pio_rearr_comm_fc_2d_enable,&
@@ -214,6 +214,8 @@ contains
       pio_type = PIO_IOTYPE_NETCDF4C
     else if(pio_typename .eq. 'pnetcdf') then
       pio_type = PIO_IOTYPE_PNETCDF
+    else if(pio_typename .eq. 'adios') then
+      pio_type = PIO_IOTYPE_ADIOS
     else
       !print *, "ERROR: Unrecognized pio type :", pio_typename,&
       !          __FILE__, __LINE__

--- a/tests/performance/pioperformance_rearr.F90
+++ b/tests/performance/pioperformance_rearr.F90
@@ -700,11 +700,11 @@ contains
           if(mype==0) then
              !print *,'iotype=',piotypes(k)
           endif
-!          if(iotype==PIO_IOTYPE_PNETCDF) then
-!             mode = PIO_64BIT_DATA
-!          else
+          if(iotype==PIO_IOTYPE_PNETCDF) then
+             mode = PIO_64BIT_DATA
+          else
              mode = 0
-!          endif
+          endif
           do rearrtype=1,2
              rearr = rearrangers(rearrtype)
              if(rearr /= PIO_REARR_SUBSET .and. rearr /= PIO_REARR_BOX) exit

--- a/tests/performance/pioperformance_rearr.F90
+++ b/tests/performance/pioperformance_rearr.F90
@@ -603,7 +603,7 @@ contains
     integer(kind=PIO_Offset_kind) :: maplen, gmaplen
     integer :: ndims
     integer, pointer :: gdims(:)
-    character(len=20) :: fname
+    character(len=128) :: fname
     type(var_desc_t) :: vari(nvars), varr(nvars), vard(nvars)
     type(iosystem_desc_t) :: iosystem
     integer :: stride, n
@@ -718,7 +718,9 @@ contains
                 call pio_init(mype, comm, ntasks, 0, stride, PIO_REARR_SUBSET,&
                   iosystem, rearr_opts=rearr_opts)
                    
-                write(fname, '(a,i1,a,i4.4,a,i1,a)') 'pioperf.',rearr,'-',ntasks,'-',iotype,'.nc'
+                write(fname, '(a,i1,a,i5.5,a,i5.5,a,i5.5,a,i1,a,i5.5,a,i5.5,a)') 'pioperf-rearr-', rearr, &
+                      '-ncomptasks-', npe, '-niotasks-', ntasks, '-stride-', stride, '-iotype-', iotype, &
+                      '-nframes-',nframes,'-nvars-',nvars,'.nc'
 		
                 ierr =  PIO_CreateFile(iosystem, File, iotype, trim(fname), mode)
 


### PR DESCRIPTION
SCORPIO's performance replay tool has not been updated for
quite a while.

This PR includes:
* Fixes some confirmed memory leaks
* Sets upper bound of gmaplen
* Sets file mode to PIO_64BIT_DATA for PnetCDF type
* Uses a longer output file name with more information
* Excludes init decomp time to calculate write rate
* Supports replaying with ADIOS type