### PR TITLE
Support I/O performance summary for ADIOS type

### DIFF
--- a/src/clib/pio_darray.c
+++ b/src/clib/pio_darray.c
@@ -1565,6 +1565,8 @@ int PIOc_write_darray(int ncid, int varid, int ioid, PIO_Offset arraylen, void *
 #ifdef _ADIOS2
     if (file->iotype == PIO_IOTYPE_ADIOS)
     {
+        ios->io_fstats->wb += iodesc->mpitype_size * arraylen;
+        file->io_fstats->wb += iodesc->mpitype_size * arraylen;
         ierr = PIOc_write_darray_adios(file, varid, ioid, iodesc, arraylen, array, fillvalue);
         GPTLstop("PIO:PIOc_write_darray_adios");
         GPTLstop("PIO:write_total_adios");

--- a/src/clib/pio_darray_int.c
+++ b/src/clib/pio_darray_int.c
@@ -16,9 +16,7 @@
 #ifdef PIO_MICRO_TIMING
 #include "pio_timer.h"
 #endif
-#ifdef TIMING
 #include "spio_io_summary.h"
-#endif
 
 /* 10MB default limit. */
 extern PIO_Offset pio_buffer_size_limit;
@@ -229,11 +227,9 @@ int write_darray_multi_par(file_desc_t *file, int nvars, int fndims, const int *
                 break;
             }
 
-#ifdef TIMING
             assert(ios && (ios->io_fstats));
             ios->io_fstats->wb += (PIO_Offset ) (iodesc->mpitype_size * tot_count * nvars);
             file->io_fstats->wb += (PIO_Offset ) (iodesc->mpitype_size * tot_count * nvars);
-#endif /* TIMING */
 
             /* IO tasks will run the netCDF/pnetcdf functions to write the data. */
             switch (file->iotype)
@@ -732,11 +728,9 @@ int recv_and_write_data(file_desc_t *file, const int *varids, const int *frame,
                     LOG((3, "start[%d] = %d count[%d] = %d", i, start[i], i, count[i]));
                 }
 
-#ifdef TIMING
                 assert(ios && (ios->io_fstats));
                 ios->io_fstats->wb += (PIO_Offset ) (iodesc->mpitype_size * tot_count * nvars);
                 file->io_fstats->wb += (PIO_Offset ) (iodesc->mpitype_size * tot_count * nvars);
-#endif /* TIMING */
 
                 /* Process each variable in the buffer. */
                 for (int nv = 0; nv < nvars; nv++)
@@ -1079,11 +1073,9 @@ int pio_read_darray_nc(file_desc_t *file, int fndims, io_desc_t *iodesc, int vid
                 }
             }
 
-#ifdef TIMING
             assert(ios && (ios->io_fstats));
             ios->io_fstats->rb += (PIO_Offset ) (iodesc->mpitype_size * tot_count);
             file->io_fstats->rb += (PIO_Offset ) (iodesc->mpitype_size * tot_count);
-#endif /* TIMING */
 
             /* Do the read. */
             switch (file->iotype)
@@ -1463,11 +1455,9 @@ int pio_read_darray_nc_serial(file_desc_t *file, int fndims, io_desc_t *iodesc, 
                     }
                     loffset += regionsize;
 
-#ifdef TIMING
                     assert(ios && (ios->io_fstats));
                     ios->io_fstats->rb += (PIO_Offset ) (iodesc->mpitype_size * regionsize);
                     file->io_fstats->rb += (PIO_Offset ) (iodesc->mpitype_size * regionsize);
-#endif /* TIMING */
 
                     /* Read the data. */
                     /* ierr = nc_get_vara(file->fh, vid, start, count, bufptr); */

--- a/src/clib/pio_getput_int.c
+++ b/src/clib/pio_getput_int.c
@@ -281,7 +281,7 @@ int PIOc_put_att_tc(int ncid, int varid, const char *name, nc_type atttype,
 #ifdef _PNETCDF
         if (file->iotype == PIO_IOTYPE_PNETCDF)
         {
-            if(ios->io_rank == 0)
+            if (ios->iomaster == MPI_ROOT)
             {
                 ios->io_fstats->wb += len * atttype_len;
                 file->io_fstats->wb += len * atttype_len;
@@ -325,7 +325,7 @@ int PIOc_put_att_tc(int ncid, int varid, const char *name, nc_type atttype,
 
         if (file->iotype != PIO_IOTYPE_PNETCDF && file->iotype != PIO_IOTYPE_ADIOS && file->do_io)
         {
-            if(ios->io_rank == 0)
+            if (ios->iomaster == MPI_ROOT)
             {
                 ios->io_fstats->wb += len * atttype_len;
                 file->io_fstats->wb += len * atttype_len;

--- a/src/clib/pio_getput_int.c
+++ b/src/clib/pio_getput_int.c
@@ -238,6 +238,12 @@ int PIOc_put_att_tc(int ncid, int varid, const char *name, nc_type atttype,
         file->adios_attrs[num_attrs].adios_type = adios_type;
         file->num_attrs++;
 
+        if (file->adios_iomaster == MPI_ROOT)
+        {
+            ios->io_fstats->wb += len * atttype_len;
+            file->io_fstats->wb += len * atttype_len;
+        }
+
         char att_name[PIO_MAX_NAME];
         snprintf(att_name, PIO_MAX_NAME, "%s/%s", path, name);
         adios2_attribute *attributeH = adios2_inquire_attribute(file->ioH, att_name);
@@ -1585,6 +1591,9 @@ int PIOc_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
                     }
                 }
 
+                ios->io_fstats->wb += num_elem * typelen;
+                file->io_fstats->wb += num_elem * typelen;
+
                 av->adios_varid = adios2_inquire_variable(file->ioH, av->name);
                 if (av->adios_varid == NULL)
                 {
@@ -1632,9 +1641,8 @@ int PIOc_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
             }
 
             /* Only the IO master actually does these ADIOS calls. */
-            if (ios->iomaster == MPI_ROOT)
+            if (file->adios_iomaster == MPI_ROOT)
             {
-
                 int d_start = 0;
                 if (file->dim_values[av->gdimids[0]] == PIO_UNLIMITED)
                 {
@@ -1692,6 +1700,9 @@ int PIOc_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
                 }
                 buf_size *= av->adios_type_size;
                 av_size += buf_size;
+
+                ios->io_fstats->wb += num_elem * typelen;
+                file->io_fstats->wb += num_elem * typelen;
 
                 /* PIOc_put_var may be called multiple times with different start/count values
                  * for a variable. ADIOS should output data for each of those calls not just

--- a/src/clib/pioc.c
+++ b/src/clib/pioc.c
@@ -1064,14 +1064,12 @@ int PIOc_Init_Intracomm(MPI_Comm comp_comm, int num_iotasks, int stride, int bas
                         "PIO Init failed. Out of memory allocating %lld bytes for I/O system descriptor", (unsigned long long) sizeof(iosystem_desc_t));
     }
 
-#ifdef TIMING
     ios->io_fstats = calloc(1, sizeof(spio_io_fstats_summary_t));
     if(!(ios->io_fstats))
     {
         return pio_err(NULL, NULL, PIO_ENOMEM, __FILE__, __LINE__,
                         "PIO Init failed. Out of memory allocating %lld bytes for I/O statistics in the I/O system descriptor", (unsigned long long) sizeof(spio_io_fstats_summary_t));
     }
-#endif
 
     ios->sname[0] = '\0';
     ios->io_comm = MPI_COMM_NULL;
@@ -1228,9 +1226,9 @@ int PIOc_Init_Intracomm(MPI_Comm comp_comm, int num_iotasks, int stride, int bas
     }
 
     /* Set the timer names for this iosystem */
-    snprintf(ios->io_fstats->wr_timer_name, GPTL_TIMER_MAX_NAME, "PIO:wr_%s", ios->sname);
-    snprintf(ios->io_fstats->rd_timer_name, GPTL_TIMER_MAX_NAME, "PIO:rd_%s", ios->sname);
-    snprintf(ios->io_fstats->tot_timer_name, GPTL_TIMER_MAX_NAME, "PIO:tot_%s", ios->sname);
+    snprintf(ios->io_fstats->wr_timer_name, SPIO_TIMER_MAX_NAME, "PIO:wr_%s", ios->sname);
+    snprintf(ios->io_fstats->rd_timer_name, SPIO_TIMER_MAX_NAME, "PIO:rd_%s", ios->sname);
+    snprintf(ios->io_fstats->tot_timer_name, SPIO_TIMER_MAX_NAME, "PIO:tot_%s", ios->sname);
 
     LOG((2, "Init_Intracomm complete iosysid = %d", *iosysidp));
 
@@ -1395,7 +1393,6 @@ int PIOc_finalize(int iosysid)
         }
     }
 
-#ifdef TIMING
     ierr = spio_write_io_summary(ios);
     if(ierr != PIO_NOERR)
     {
@@ -1403,7 +1400,6 @@ int PIOc_finalize(int iosysid)
                         "PIO Finalize failed on iosytem (%d). Unable to write I/O summary for the iosystem", iosysid);
     }
     free(ios->io_fstats);
-#endif
 
     /* Free this memory that was allocated in init_intracomm. */
     if (ios->ioranks)
@@ -1801,14 +1797,12 @@ int PIOc_init_async(MPI_Comm world, int num_io_procs, int *io_proc_list,
             return pio_err(NULL, NULL, PIO_ENOMEM, __FILE__, __LINE__,
                             "PIO Init (async) failed. Out of memory");
         }
-#ifdef TIMING
         iosys[cmp1]->io_fstats = calloc(1, sizeof(spio_io_fstats_summary_t));
         if(!(iosys[cmp1]->io_fstats))
         {
             return pio_err(NULL, NULL, PIO_ENOMEM, __FILE__, __LINE__,
                             "PIO init (async) failed. Out of memory allocating %lld bytes for storing I/O statistics in the I/O system descriptor for component %d", (unsigned long long) sizeof(spio_io_fstats_summary_t), cmp1);
         }
-#endif
   }
 
     /* Create group for world. */
@@ -2119,9 +2113,9 @@ int PIOc_init_async(MPI_Comm world, int num_io_procs, int *io_proc_list,
             LOG((0, "Creating a unique name for the iosystem (iosysid=%d) failed,ret = %d", my_iosys->iosysid, ret));
         }
         /* Set the timer names for this iosystem */
-        snprintf(my_iosys->io_fstats->wr_timer_name, GPTL_TIMER_MAX_NAME, "PIO:wr_%s", my_iosys->sname);
-        snprintf(my_iosys->io_fstats->rd_timer_name, GPTL_TIMER_MAX_NAME, "PIO:rd_%s", my_iosys->sname);
-        snprintf(my_iosys->io_fstats->tot_timer_name, GPTL_TIMER_MAX_NAME, "PIO:tot_%s", my_iosys->sname);
+        snprintf(my_iosys->io_fstats->wr_timer_name, SPIO_TIMER_MAX_NAME, "PIO:wr_%s", my_iosys->sname);
+        snprintf(my_iosys->io_fstats->rd_timer_name, SPIO_TIMER_MAX_NAME, "PIO:rd_%s", my_iosys->sname);
+        snprintf(my_iosys->io_fstats->tot_timer_name, SPIO_TIMER_MAX_NAME, "PIO:tot_%s", my_iosys->sname);
     } /* next computational component */
 
     /* Initialize async message signatures */
@@ -2319,14 +2313,12 @@ int PIOc_init_intercomm(int component_count, const MPI_Comm peer_comm,
             return pio_err(NULL, NULL, PIO_ENOMEM, __FILE__, __LINE__,
                             "PIO init (async) failed. Out of memory allocating %lld bytes for storing I/O system descriptor for component %d", (unsigned long long) sizeof(iosystem_desc_t), i);
         }
-#ifdef TIMING
         iosys[i]->io_fstats = calloc(1, sizeof(spio_io_fstats_summary_t));
         if(!(iosys[i]->io_fstats))
         {
             return pio_err(NULL, NULL, PIO_ENOMEM, __FILE__, __LINE__,
                             "PIO init (async) failed. Out of memory allocating %lld bytes for storing I/O statistics in the I/O system descriptor for component %d", (unsigned long long) sizeof(spio_io_fstats_summary_t), i);
         }
-#endif
 
         /* Initialize the iosystem */
         iosys[i]->iosysid = -1;
@@ -2756,9 +2748,9 @@ int PIOc_init_intercomm(int component_count, const MPI_Comm peer_comm,
             LOG((0, "Creating a unique name for the iosystem (iosysid=%d) failed,ret = %d", iosys[i]->iosysid, ret));
         }
         /* Set the timer names for this iosystem */
-        snprintf(iosys[i]->io_fstats->wr_timer_name, GPTL_TIMER_MAX_NAME, "PIO:wr_%s", iosys[i]->sname);
-        snprintf(iosys[i]->io_fstats->rd_timer_name, GPTL_TIMER_MAX_NAME, "PIO:rd_%s", iosys[i]->sname);
-        snprintf(iosys[i]->io_fstats->tot_timer_name, GPTL_TIMER_MAX_NAME, "PIO:tot_%s", iosys[i]->sname);
+        snprintf(iosys[i]->io_fstats->wr_timer_name, SPIO_TIMER_MAX_NAME, "PIO:wr_%s", iosys[i]->sname);
+        snprintf(iosys[i]->io_fstats->rd_timer_name, SPIO_TIMER_MAX_NAME, "PIO:rd_%s", iosys[i]->sname);
+        snprintf(iosys[i]->io_fstats->tot_timer_name, SPIO_TIMER_MAX_NAME, "PIO:tot_%s", iosys[i]->sname);
     }
 
     /* The comp_comms array is freed. The communicators will be freed internally

--- a/src/clib/pioc_support.c
+++ b/src/clib/pioc_support.c
@@ -2208,7 +2208,7 @@ int PIO_get_avail_iotypes(char *buf, size_t sz)
 int PIOc_createfile_int(int iosysid, int *ncidp, int *iotype, const char *filename,
                         int mode)
 {
-    char tname[GPTL_TIMER_MAX_NAME];
+    char tname[SPIO_TIMER_MAX_NAME];
     iosystem_desc_t *ios;  /* Pointer to io system information. */
     file_desc_t *file;     /* Pointer to file information. */
     int mpierr = MPI_SUCCESS;  /* Return code from MPI function codes. */
@@ -2257,7 +2257,7 @@ int PIOc_createfile_int(int iosysid, int *ncidp, int *iotype, const char *filena
     /* Fill in some file values. */
     file->fh = -1;
     strncpy(file->fname, filename, PIO_MAX_NAME);
-    ierr = pio_create_uniq_str(ios, NULL, tname, GPTL_TIMER_MAX_NAME, "tmp_", "_file");
+    ierr = pio_create_uniq_str(ios, NULL, tname, SPIO_TIMER_MAX_NAME, "tmp_", "_file");
     if(ierr != PIO_NOERR)
     {
         /* Not a fatal error */
@@ -2265,9 +2265,9 @@ int PIOc_createfile_int(int iosysid, int *ncidp, int *iotype, const char *filena
         tname[0] = '\0';
     }
 
-    snprintf(file->io_fstats->wr_timer_name, GPTL_TIMER_MAX_NAME, "PIO:wr_%s", tname);
-    snprintf(file->io_fstats->rd_timer_name, GPTL_TIMER_MAX_NAME, "PIO:rd_%s", tname);
-    snprintf(file->io_fstats->tot_timer_name, GPTL_TIMER_MAX_NAME, "PIO:tot_%s", tname);
+    snprintf(file->io_fstats->wr_timer_name, SPIO_TIMER_MAX_NAME, "PIO:wr_%s", tname);
+    snprintf(file->io_fstats->rd_timer_name, SPIO_TIMER_MAX_NAME, "PIO:rd_%s", tname);
+    snprintf(file->io_fstats->tot_timer_name, SPIO_TIMER_MAX_NAME, "PIO:tot_%s", tname);
 
     spio_ltimer_start(file->io_fstats->wr_timer_name);
     spio_ltimer_start(file->io_fstats->tot_timer_name);
@@ -2778,7 +2778,7 @@ int check_unlim_use(int ncid)
 int PIOc_openfile_retry(int iosysid, int *ncidp, int *iotype, const char *filename,
                         int mode, int retry)
 {
-    char tname[GPTL_TIMER_MAX_NAME];
+    char tname[SPIO_TIMER_MAX_NAME];
     iosystem_desc_t *ios;      /* Pointer to io system information. */
     file_desc_t *file;         /* Pointer to file information. */
     int imode;                 /* Internal mode val for netcdf4 file open. */
@@ -2836,7 +2836,7 @@ int PIOc_openfile_retry(int iosysid, int *ncidp, int *iotype, const char *filena
     /* Fill in some file values. */
     file->fh = -1;
     strncpy(file->fname, filename, PIO_MAX_NAME);
-    ierr = pio_create_uniq_str(ios, NULL, tname, GPTL_TIMER_MAX_NAME, "tmp_", "_file");
+    ierr = pio_create_uniq_str(ios, NULL, tname, SPIO_TIMER_MAX_NAME, "tmp_", "_file");
     if(ierr != PIO_NOERR)
     {
         /* Not a fatal error */
@@ -2844,9 +2844,9 @@ int PIOc_openfile_retry(int iosysid, int *ncidp, int *iotype, const char *filena
         tname[0] = '\0';
     }
 
-    snprintf(file->io_fstats->wr_timer_name, GPTL_TIMER_MAX_NAME, "PIO:wr_%s", tname);
-    snprintf(file->io_fstats->rd_timer_name, GPTL_TIMER_MAX_NAME, "PIO:rd_%s", tname);
-    snprintf(file->io_fstats->tot_timer_name, GPTL_TIMER_MAX_NAME, "PIO:tot_%s", tname);
+    snprintf(file->io_fstats->wr_timer_name, SPIO_TIMER_MAX_NAME, "PIO:wr_%s", tname);
+    snprintf(file->io_fstats->rd_timer_name, SPIO_TIMER_MAX_NAME, "PIO:rd_%s", tname);
+    snprintf(file->io_fstats->tot_timer_name, SPIO_TIMER_MAX_NAME, "PIO:tot_%s", tname);
 
     /* FIXME: Files can be opened for rds and writes */
     spio_ltimer_start(file->io_fstats->rd_timer_name);

--- a/src/clib/spio_io_summary.cpp
+++ b/src/clib/spio_io_summary.cpp
@@ -576,10 +576,6 @@ int spio_write_io_summary(iosystem_desc_t *ios)
     ios->io_fstats->tot_timer_name
   };
 
-#ifndef TIMING
-  return PIO_NOERR;
-#endif
-
 #ifndef SPIO_IO_STATS
   return PIO_NOERR;
 #endif
@@ -720,10 +716,6 @@ int spio_write_file_io_summary(file_desc_t *file)
   const std::vector<std::string> tot_timers = {
     file->io_fstats->tot_timer_name
   };
-
-#ifndef TIMING
-  return PIO_NOERR;
-#endif
 
 #ifndef SPIO_IO_STATS
   return PIO_NOERR;

--- a/src/clib/spio_io_summary.h
+++ b/src/clib/spio_io_summary.h
@@ -5,15 +5,16 @@
 #include "pio.h"
 #include "pio_internal.h"
 
-#define GPTL_TIMER_MAX_NAME 63
+/* GPTL timers assume this as the maximum name size */
+#define SPIO_TIMER_MAX_NAME 63
 /* The struct below is used to cache I/O statistics
  * for I/O systems and files
  */
 typedef struct spio_io_fstats_summary{
   /* Timer names for capturing write/read/total times */
-  char wr_timer_name[GPTL_TIMER_MAX_NAME + 1];
-  char rd_timer_name[GPTL_TIMER_MAX_NAME + 1];
-  char tot_timer_name[GPTL_TIMER_MAX_NAME + 1];
+  char wr_timer_name[SPIO_TIMER_MAX_NAME + 1];
+  char rd_timer_name[SPIO_TIMER_MAX_NAME + 1];
+  char tot_timer_name[SPIO_TIMER_MAX_NAME + 1];
 
   /* Number of bytes read */
   PIO_Offset rb;


### PR DESCRIPTION
Support I/O performance summary for ADIOS type by adding
the information on the bytes written out.

Some unnecessary TIMING macros are also removed since we no
longer use GPTL timers to output I/O performance summary.

Fixes #400