### PR TITLE
Update the calculation of bytes read or written for darray

### DIFF
--- a/src/clib/pio_darray.c
+++ b/src/clib/pio_darray.c
@@ -1523,21 +1523,29 @@ int PIOc_write_darray(int ncid, int varid, int ioid, PIO_Offset arraylen, void *
         spio_ltimer_stop(file->io_fstats->tot_timer_name);
 
         /* Find out PIO data type of var. */
-        if ((ierr = PIOc_inq_vartype(ncid, varid, &vdesc->pio_type)))
+        if (vdesc->pio_type == NC_NAT)
         {
-            GPTLstop("PIO:PIOc_write_darray");
-            GPTLstop("PIO:write_total");
-            return pio_err(ios, NULL, ierr, __FILE__, __LINE__,
-                            "Writing variable (%s, varid=%d) to file (%s, ncid=%d) failed. Inquiring variable data type failed", pio_get_vname_from_file(file, varid), varid, pio_get_fname_from_file(file), file->pio_ncid);
+            if ((ierr = PIOc_inq_vartype(ncid, varid, &vdesc->pio_type)))
+            {
+                GPTLstop("PIO:PIOc_write_darray");
+                GPTLstop("PIO:write_total");
+                return pio_err(ios, NULL, ierr, __FILE__, __LINE__,
+                                "Writing variable (%s, varid=%d) to file (%s, ncid=%d) failed. Inquiring variable data type failed", pio_get_vname_from_file(file, varid), varid, pio_get_fname_from_file(file), file->pio_ncid);
+            }
         }
 
+        assert(vdesc->pio_type != NC_NAT);
+
         /* Find out length of type. */
-        if ((ierr = PIOc_inq_type(ncid, vdesc->pio_type, NULL, &vdesc->type_size)))
+        if (vdesc->type_size == 0)
         {
-            GPTLstop("PIO:PIOc_write_darray");
-            GPTLstop("PIO:write_total");
-            return pio_err(ios, NULL, ierr, __FILE__, __LINE__,
-                            "Writing variable (%s, varid=%d) to file (%s, ncid=%d) failed. Inquiring variable data type length failed", pio_get_vname_from_file(file, varid), varid, pio_get_fname_from_file(file), file->pio_ncid);
+            if ((ierr = PIOc_inq_type(ncid, vdesc->pio_type, NULL, &vdesc->type_size)))
+            {
+                GPTLstop("PIO:PIOc_write_darray");
+                GPTLstop("PIO:write_total");
+                return pio_err(ios, NULL, ierr, __FILE__, __LINE__,
+                                "Writing variable (%s, varid=%d) to file (%s, ncid=%d) failed. Inquiring variable data type length failed", pio_get_vname_from_file(file, varid), varid, pio_get_fname_from_file(file), file->pio_ncid);
+            }
         }
 
         assert(vdesc->type_size > 0);
@@ -1998,19 +2006,27 @@ int PIOc_read_darray(int ncid, int varid, int ioid, PIO_Offset arraylen,
         spio_ltimer_stop(file->io_fstats->tot_timer_name);
 
         /* Find out PIO data type of var. */
-        if ((ierr = PIOc_inq_vartype(ncid, varid, &vdesc->pio_type)))
+        if (vdesc->pio_type == NC_NAT)
         {
-            GPTLstop("PIO:PIOc_read_darray");
-            return pio_err(ios, NULL, ierr, __FILE__, __LINE__,
-                            "Reading variable (%s, varid=%d) from file (%s, ncid=%d) failed. Inquiring variable data type failed", pio_get_vname_from_file(file, varid), varid, pio_get_fname_from_file(file), file->pio_ncid);
+            if ((ierr = PIOc_inq_vartype(ncid, varid, &vdesc->pio_type)))
+            {
+                GPTLstop("PIO:PIOc_read_darray");
+                return pio_err(ios, NULL, ierr, __FILE__, __LINE__,
+                                "Reading variable (%s, varid=%d) from file (%s, ncid=%d) failed. Inquiring variable data type failed", pio_get_vname_from_file(file, varid), varid, pio_get_fname_from_file(file), file->pio_ncid);
+            }
         }
 
+        assert(vdesc->pio_type != NC_NAT);
+
         /* Find out length of type. */
-        if ((ierr = PIOc_inq_type(ncid, vdesc->pio_type, NULL, &vdesc->type_size)))
+        if (vdesc->type_size == 0)
         {
-            GPTLstop("PIO:PIOc_read_darray");
-            return pio_err(ios, NULL, ierr, __FILE__, __LINE__,
-                            "Reading variable (%s, varid=%d) from file (%s, ncid=%d) failed. Inquiring variable data type length failed", pio_get_vname_from_file(file, varid), varid, pio_get_fname_from_file(file), file->pio_ncid);
+            if ((ierr = PIOc_inq_type(ncid, vdesc->pio_type, NULL, &vdesc->type_size)))
+            {
+                GPTLstop("PIO:PIOc_read_darray");
+                return pio_err(ios, NULL, ierr, __FILE__, __LINE__,
+                                "Reading variable (%s, varid=%d) from file (%s, ncid=%d) failed. Inquiring variable data type length failed", pio_get_vname_from_file(file, varid), varid, pio_get_fname_from_file(file), file->pio_ncid);
+            }
         }
 
         assert(vdesc->type_size > 0);

--- a/src/clib/pio_darray.c
+++ b/src/clib/pio_darray.c
@@ -1525,6 +1525,9 @@ int PIOc_write_darray(int ncid, int varid, int ioid, PIO_Offset arraylen, void *
     vdesc = &(file->varlist[varid]);
     LOG((2, "vdesc record %d nreqs %d", vdesc->record, vdesc->nreqs));
 
+    ios->io_fstats->wb += iodesc->mpitype_size * iodesc->llen;
+    file->io_fstats->wb += iodesc->mpitype_size * iodesc->llen;
+
     /* If we don't know the fill value for this var, get it. */
     if (!vdesc->fillvalue)
     {
@@ -1565,8 +1568,6 @@ int PIOc_write_darray(int ncid, int varid, int ioid, PIO_Offset arraylen, void *
 #ifdef _ADIOS2
     if (file->iotype == PIO_IOTYPE_ADIOS)
     {
-        ios->io_fstats->wb += iodesc->mpitype_size * arraylen;
-        file->io_fstats->wb += iodesc->mpitype_size * arraylen;
         ierr = PIOc_write_darray_adios(file, varid, ioid, iodesc, arraylen, array, fillvalue);
         GPTLstop("PIO:PIOc_write_darray_adios");
         GPTLstop("PIO:write_total_adios");
@@ -1959,6 +1960,9 @@ int PIOc_read_darray(int ncid, int varid, int ioid, PIO_Offset arraylen,
     }
     pioassert(iodesc->rearranger == PIO_REARR_BOX || iodesc->rearranger == PIO_REARR_SUBSET,
               "unknown rearranger", __FILE__, __LINE__);
+
+    ios->io_fstats->rb += iodesc->mpitype_size * iodesc->llen;
+    file->io_fstats->rb += iodesc->mpitype_size * iodesc->llen;
 
 #ifdef PIO_MICRO_TIMING
     mtimer_start(file->varlist[varid].rd_mtimer);

--- a/src/clib/pio_darray.c
+++ b/src/clib/pio_darray.c
@@ -700,23 +700,11 @@ int find_var_fillvalue(file_desc_t *file, int varid, var_desc_t *vdesc)
 
     LOG((3, "find_var_fillvalue file->pio_ncid = %d varid = %d", file->pio_ncid, varid));
 
-    /* Find out PIO data type of var. */
-    if ((ierr = PIOc_inq_vartype(file->pio_ncid, varid, &vdesc->pio_type)))
-    {
-        return pio_err(ios, NULL, ierr, __FILE__, __LINE__,
-                        "Finding fillvalue for variable (%s, varid=%d) in file (%s, ncid=%d), failed. Inquiring variable data type failed", vdesc->vname, varid, file->fname, file->pio_ncid); 
-    }
-
-    /* Find out length of type. */
-    if ((ierr = PIOc_inq_type(file->pio_ncid, vdesc->pio_type, NULL, &vdesc->type_size)))
-    {
-        return pio_err(ios, NULL, ierr, __FILE__, __LINE__,
-                        "Finding fillvalue for variable (%s, varid=%d) in file (%s, ncid=%d), failed. Inquiring variable data type length failed", vdesc->vname, varid, file->fname, file->pio_ncid); 
-    }
     LOG((3, "getting fill value for varid = %d pio_type = %d type_size = %d",
          varid, vdesc->pio_type, vdesc->type_size));
 
     /* Allocate storage for the fill value. */
+    assert(vdesc->type_size > 0);
     if (!(vdesc->fillvalue = malloc(vdesc->type_size)))
     {
         return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__,
@@ -1525,8 +1513,43 @@ int PIOc_write_darray(int ncid, int varid, int ioid, PIO_Offset arraylen, void *
     vdesc = &(file->varlist[varid]);
     LOG((2, "vdesc record %d nreqs %d", vdesc->record, vdesc->nreqs));
 
-    ios->io_fstats->wb += iodesc->mpitype_size * iodesc->llen;
-    file->io_fstats->wb += iodesc->mpitype_size * iodesc->llen;
+    /* Run these on all tasks if async is not in use, but only on
+     * non-IO tasks if async is in use. */
+    if (!ios->async || !ios->ioproc)
+    {
+        spio_ltimer_stop(ios->io_fstats->wr_timer_name);
+        spio_ltimer_stop(ios->io_fstats->tot_timer_name);
+        spio_ltimer_stop(file->io_fstats->wr_timer_name);
+        spio_ltimer_stop(file->io_fstats->tot_timer_name);
+
+        /* Find out PIO data type of var. */
+        if ((ierr = PIOc_inq_vartype(ncid, varid, &vdesc->pio_type)))
+        {
+            GPTLstop("PIO:PIOc_write_darray");
+            GPTLstop("PIO:write_total");
+            return pio_err(ios, NULL, ierr, __FILE__, __LINE__,
+                            "Writing variable (%s, varid=%d) to file (%s, ncid=%d) failed. Inquiring variable data type failed", pio_get_vname_from_file(file, varid), varid, pio_get_fname_from_file(file), file->pio_ncid);
+        }
+
+        /* Find out length of type. */
+        if ((ierr = PIOc_inq_type(ncid, vdesc->pio_type, NULL, &vdesc->type_size)))
+        {
+            GPTLstop("PIO:PIOc_write_darray");
+            GPTLstop("PIO:write_total");
+            return pio_err(ios, NULL, ierr, __FILE__, __LINE__,
+                            "Writing variable (%s, varid=%d) to file (%s, ncid=%d) failed. Inquiring variable data type length failed", pio_get_vname_from_file(file, varid), varid, pio_get_fname_from_file(file), file->pio_ncid);
+        }
+
+        assert(vdesc->type_size > 0);
+
+        spio_ltimer_start(ios->io_fstats->wr_timer_name);
+        spio_ltimer_start(ios->io_fstats->tot_timer_name);
+        spio_ltimer_start(file->io_fstats->wr_timer_name);
+        spio_ltimer_start(file->io_fstats->tot_timer_name);
+    }
+
+    ios->io_fstats->wb += vdesc->type_size * iodesc->llen;
+    file->io_fstats->wb += vdesc->type_size * iodesc->llen;
 
     /* If we don't know the fill value for this var, get it. */
     if (!vdesc->fillvalue)
@@ -1923,6 +1946,7 @@ int PIOc_read_darray(int ncid, int varid, int ioid, PIO_Offset arraylen,
     iosystem_desc_t *ios;  /* Pointer to io system information. */
     file_desc_t *file;     /* Pointer to file information. */
     io_desc_t *iodesc;     /* Pointer to IO description information. */
+    var_desc_t *vdesc;     /* Info about the var being read. */
     void *iobuf = NULL;    /* holds the data as read on the io node. */
     size_t rlen = 0;       /* the length of data in iobuf. */
     int ierr = PIO_NOERR, mpierr = MPI_SUCCESS;           /* Return code. */
@@ -1961,8 +1985,44 @@ int PIOc_read_darray(int ncid, int varid, int ioid, PIO_Offset arraylen,
     pioassert(iodesc->rearranger == PIO_REARR_BOX || iodesc->rearranger == PIO_REARR_SUBSET,
               "unknown rearranger", __FILE__, __LINE__);
 
-    ios->io_fstats->rb += iodesc->mpitype_size * iodesc->llen;
-    file->io_fstats->rb += iodesc->mpitype_size * iodesc->llen;
+    /* Get var description. */
+    vdesc = &(file->varlist[varid]);
+
+    /* Run these on all tasks if async is not in use, but only on
+     * non-IO tasks if async is in use. */
+    if (!ios->async || !ios->ioproc)
+    {
+        spio_ltimer_stop(ios->io_fstats->rd_timer_name);
+        spio_ltimer_stop(ios->io_fstats->tot_timer_name);
+        spio_ltimer_stop(file->io_fstats->rd_timer_name);
+        spio_ltimer_stop(file->io_fstats->tot_timer_name);
+
+        /* Find out PIO data type of var. */
+        if ((ierr = PIOc_inq_vartype(ncid, varid, &vdesc->pio_type)))
+        {
+            GPTLstop("PIO:PIOc_read_darray");
+            return pio_err(ios, NULL, ierr, __FILE__, __LINE__,
+                            "Reading variable (%s, varid=%d) from file (%s, ncid=%d) failed. Inquiring variable data type failed", pio_get_vname_from_file(file, varid), varid, pio_get_fname_from_file(file), file->pio_ncid);
+        }
+
+        /* Find out length of type. */
+        if ((ierr = PIOc_inq_type(ncid, vdesc->pio_type, NULL, &vdesc->type_size)))
+        {
+            GPTLstop("PIO:PIOc_read_darray");
+            return pio_err(ios, NULL, ierr, __FILE__, __LINE__,
+                            "Reading variable (%s, varid=%d) from file (%s, ncid=%d) failed. Inquiring variable data type length failed", pio_get_vname_from_file(file, varid), varid, pio_get_fname_from_file(file), file->pio_ncid);
+        }
+
+        assert(vdesc->type_size > 0);
+
+        spio_ltimer_start(ios->io_fstats->rd_timer_name);
+        spio_ltimer_start(ios->io_fstats->tot_timer_name);
+        spio_ltimer_start(file->io_fstats->rd_timer_name);
+        spio_ltimer_start(file->io_fstats->tot_timer_name);
+    }
+
+    ios->io_fstats->rb += vdesc->type_size * iodesc->llen;
+    file->io_fstats->rb += vdesc->type_size * iodesc->llen;
 
 #ifdef PIO_MICRO_TIMING
     mtimer_start(file->varlist[varid].rd_mtimer);

--- a/src/clib/pio_darray_int.c
+++ b/src/clib/pio_darray_int.c
@@ -87,12 +87,10 @@ int compute_buffer_init(iosystem_desc_t *ios)
  * @author Ed Hartnett
  */
 int find_start_count(int ndims, const int *dimlen, int fndims, var_desc_t *vdesc,
-                     io_region *region, size_t *start, size_t *count, size_t *tot_count)
+                     io_region *region, size_t *start, size_t *count)
 {
     assert((ndims > 0) && dimlen && (fndims > 0) && vdesc &&
-            start && count && tot_count);
-
-    *tot_count = 0;
+            start && count);
 
     /* Init start/count arrays to zero. */
     for (int i = 0; i < fndims; i++)
@@ -113,7 +111,6 @@ int find_start_count(int ndims, const int *dimlen, int fndims, var_desc_t *vdesc
                           __FILE__, __LINE__);
         }
 
-        *tot_count = 1;
         if (vdesc->record >= 0 && fndims > 1)
         {
             /* This is a record based multidimensional
@@ -123,7 +120,6 @@ int find_start_count(int ndims, const int *dimlen, int fndims, var_desc_t *vdesc
             {
                 start[i] = region->start[num_extra_dims + (i - 1)];
                 count[i] = region->count[num_extra_dims + (i - 1)];
-                *tot_count *= count[i];
             }
 
             /* Set count for record dimension (start cannot be determined so far). */
@@ -137,7 +133,6 @@ int find_start_count(int ndims, const int *dimlen, int fndims, var_desc_t *vdesc
             {
                 start[i] = region->start[num_extra_dims + i];
                 count[i] = region->count[num_extra_dims + i];
-                *tot_count *= count[i];
             }
         }
 
@@ -145,8 +140,6 @@ int find_start_count(int ndims, const int *dimlen, int fndims, var_desc_t *vdesc
         /* Log arrays for debug purposes. */
         for (int i = 0; i < fndims; i++)
             LOG((3, "start[%d] = %d count[%d] = %d", i, start[i], i, count[i]));
-
-        LOG((3, "tot_count = %lld", (long long int)(*tot_count)));
 #endif /* PIO_ENABLE_LOGGING */
     }
     
@@ -209,7 +202,6 @@ int write_darray_multi_par(file_desc_t *file, int nvars, int fndims, const int *
         void *bufptr = NULL;
         size_t start[fndims];
         size_t count[fndims];
-        size_t tot_count;
         PIO_Offset *startlist[num_regions]; /* Array of start arrays for ncmpi_iput_varn(). */
         PIO_Offset *countlist[num_regions]; /* Array of count  arrays for ncmpi_iput_varn(). */
 
@@ -218,18 +210,13 @@ int write_darray_multi_par(file_desc_t *file, int nvars, int fndims, const int *
         /* Process each region of data to be written. */
         for (int regioncnt = 0; regioncnt < num_regions; regioncnt++)
         {
-            tot_count = 0;
             /* Fill the start/count arrays. */
-            if ((ierr = find_start_count(iodesc->ndims, iodesc->dimlen, fndims, vdesc, region, start, count, &tot_count)))
+            if ((ierr = find_start_count(iodesc->ndims, iodesc->dimlen, fndims, vdesc, region, start, count)))
             {
                 ierr = pio_err(ios, file, ierr, __FILE__, __LINE__,
                                 "Writing variables (number of variables = %d) to file (%s, ncid=%d) failed. Internal error, finding start/count for the I/O regions written out from the I/O process failed", nvars, pio_get_fname_from_file(file), file->pio_ncid);
                 break;
             }
-
-            assert(ios && (ios->io_fstats));
-            ios->io_fstats->wb += (PIO_Offset ) (iodesc->mpitype_size * tot_count * nvars);
-            file->io_fstats->wb += (PIO_Offset ) (iodesc->mpitype_size * tot_count * nvars);
 
             /* IO tasks will run the netCDF/pnetcdf functions to write the data. */
             switch (file->iotype)
@@ -717,20 +704,14 @@ int recv_and_write_data(file_desc_t *file, const int *varids, const int *frame,
             {
                 LOG((3, "writing data for region with regioncnt = %d", regioncnt));
 
-                size_t tot_count = 1;
                 assert(fndims > 0);
                 /* Get the start/count arrays for this region. */
                 for (int i = 0; i < fndims; i++)
                 {
                     start[i] = tmp_start[i + regioncnt * fndims];
                     count[i] = tmp_count[i + regioncnt * fndims];
-                    tot_count *= count[i];
                     LOG((3, "start[%d] = %d count[%d] = %d", i, start[i], i, count[i]));
                 }
-
-                assert(ios && (ios->io_fstats));
-                ios->io_fstats->wb += (PIO_Offset ) (iodesc->mpitype_size * tot_count * nvars);
-                file->io_fstats->wb += (PIO_Offset ) (iodesc->mpitype_size * tot_count * nvars);
 
                 /* Process each variable in the buffer. */
                 for (int nv = 0; nv < nvars; nv++)
@@ -1011,7 +992,6 @@ int pio_read_darray_nc(file_desc_t *file, int fndims, io_desc_t *iodesc, int vid
         for (int regioncnt = 0; regioncnt < iodesc->maxregions; regioncnt++)
         {
             tmp_bufsize = 1;
-            size_t tot_count = 0;
             if (region == NULL || iodesc->llen == 0)
             {
                 /* No data for this region. */
@@ -1043,7 +1023,6 @@ int pio_read_darray_nc(file_desc_t *file, int fndims, io_desc_t *iodesc, int vid
                 }
 
                 assert(fndims > 0);
-                tot_count = 1;
                 /* Get the start/count arrays. */
                 if (vdesc->record >= 0 && fndims > 1)
                 {
@@ -1054,7 +1033,6 @@ int pio_read_darray_nc(file_desc_t *file, int fndims, io_desc_t *iodesc, int vid
                     {
                         start[i] = region->start[num_extra_dims + (i - 1)];
                         count[i] = region->count[num_extra_dims + (i - 1)];
-                        tot_count *= count[i];
                     }
 
                     /* Read one record. */
@@ -1068,14 +1046,9 @@ int pio_read_darray_nc(file_desc_t *file, int fndims, io_desc_t *iodesc, int vid
                     {
                         start[i] = region->start[num_extra_dims + i];
                         count[i] = region->count[num_extra_dims + i];
-                        tot_count *= count[i];
                     }
                 }
             }
-
-            assert(ios && (ios->io_fstats));
-            ios->io_fstats->rb += (PIO_Offset ) (iodesc->mpitype_size * tot_count);
-            file->io_fstats->rb += (PIO_Offset ) (iodesc->mpitype_size * tot_count);
 
             /* Do the read. */
             switch (file->iotype)
@@ -1454,10 +1427,6 @@ int pio_read_darray_nc_serial(file_desc_t *file, int fndims, io_desc_t *iodesc, 
                         }
                     }
                     loffset += regionsize;
-
-                    assert(ios && (ios->io_fstats));
-                    ios->io_fstats->rb += (PIO_Offset ) (iodesc->mpitype_size * regionsize);
-                    file->io_fstats->rb += (PIO_Offset ) (iodesc->mpitype_size * regionsize);
 
                     /* Read the data. */
                     /* ierr = nc_get_vara(file->fh, vid, start, count, bufptr); */

--- a/src/clib/pio_nc.c
+++ b/src/clib/pio_nc.c
@@ -3012,6 +3012,7 @@ int PIOc_def_var(int ncid, const char *name, nc_type xtype, int ndims,
         }
 
         strncpy(file->varlist[*varidp].vname, name, PIO_MAX_NAME);
+        file->varlist[*varidp].pio_type = xtype;
         if (file->num_unlim_dimids > 0)
         {
             int is_rec_var = 0;
@@ -3117,6 +3118,7 @@ int PIOc_def_var(int ncid, const char *name, nc_type xtype, int ndims,
         }
 
     strncpy(file->varlist[*varidp].vname, name, PIO_MAX_NAME);
+    file->varlist[*varidp].pio_type = xtype;
     if(file->num_unlim_dimids > 0)
     {
         int is_rec_var = 0;

--- a/src/clib/pioc_support.c
+++ b/src/clib/pioc_support.c
@@ -2281,13 +2281,21 @@ int PIOc_createfile_int(int iosysid, int *ncidp, int *iotype, const char *filena
     */
     for (int i = 0; i < PIO_MAX_VARS; i++)
     {
+        file->varlist[i].varid = -1;
         file->varlist[i].vname[0] = '\0';
+        file->varlist[i].vdesc[0] = '\0';
+        file->varlist[i].rec_var = 0;
         file->varlist[i].record = -1;
         file->varlist[i].request = NULL;
+        file->varlist[i].request_sz = NULL;
         file->varlist[i].nreqs = 0;
         file->varlist[i].fillvalue = NULL;
-        file->varlist[i].pio_type = 0;
+        file->varlist[i].pio_type = NC_NAT;
         file->varlist[i].type_size = 0;
+        file->varlist[i].vrsize = 0;
+        file->varlist[i].rb_pend = 0;
+        file->varlist[i].vrsize = 0;
+        file->varlist[i].wb_pend = 0;
         file->varlist[i].use_fill = 0;
         file->varlist[i].fillbuf = NULL;
     }
@@ -2878,8 +2886,23 @@ int PIOc_openfile_retry(int iosysid, int *ncidp, int *iotype, const char *filena
 
     for (int i = 0; i < PIO_MAX_VARS; i++)
     {
+        file->varlist[i].varid = -1;
         file->varlist[i].vname[0] = '\0';
+        file->varlist[i].vdesc[0] = '\0';
+        file->varlist[i].rec_var = 0;
         file->varlist[i].record = -1;
+        file->varlist[i].request = NULL;
+        file->varlist[i].request_sz = NULL;
+        file->varlist[i].nreqs = 0;
+        file->varlist[i].fillvalue = NULL;
+        file->varlist[i].pio_type = NC_NAT;
+        file->varlist[i].type_size = 0;
+        file->varlist[i].vrsize = 0;
+        file->varlist[i].rb_pend = 0;
+        file->varlist[i].vrsize = 0;
+        file->varlist[i].wb_pend = 0;
+        file->varlist[i].use_fill = 0;
+        file->varlist[i].fillbuf = NULL;
     }
 
     /* Set to true if this task should participate in IO (only true


### PR DESCRIPTION
This PR simplifies the calculation of bytes read or written for
darray, which works for all IO types including ADIOS.

It also accounts for the variable type conversion in the I/O stats,
to make the stats closer to what the application developer expects.