### PR TITLE
Use PIO_NAT instead of NC_NAT

### DIFF
--- a/src/clib/pio.h
+++ b/src/clib/pio.h
@@ -157,6 +157,7 @@ unsigned long get_adios2_io_cnt();
 #define PIO_UNLIMITED NC_UNLIMITED
 
 /* NetCDF types. */
+#define PIO_NAT    NC_NAT
 #define PIO_BYTE   NC_BYTE
 #define PIO_CHAR   NC_CHAR
 #define PIO_SHORT  NC_SHORT

--- a/src/clib/pio_darray.c
+++ b/src/clib/pio_darray.c
@@ -1523,7 +1523,7 @@ int PIOc_write_darray(int ncid, int varid, int ioid, PIO_Offset arraylen, void *
         spio_ltimer_stop(file->io_fstats->tot_timer_name);
 
         /* Find out PIO data type of var. */
-        if (vdesc->pio_type == NC_NAT)
+        if (vdesc->pio_type == PIO_NAT)
         {
             if ((ierr = PIOc_inq_vartype(ncid, varid, &vdesc->pio_type)))
             {
@@ -1534,7 +1534,7 @@ int PIOc_write_darray(int ncid, int varid, int ioid, PIO_Offset arraylen, void *
             }
         }
 
-        assert(vdesc->pio_type != NC_NAT);
+        assert(vdesc->pio_type != PIO_NAT);
 
         /* Find out length of type. */
         if (vdesc->type_size == 0)
@@ -2006,7 +2006,7 @@ int PIOc_read_darray(int ncid, int varid, int ioid, PIO_Offset arraylen,
         spio_ltimer_stop(file->io_fstats->tot_timer_name);
 
         /* Find out PIO data type of var. */
-        if (vdesc->pio_type == NC_NAT)
+        if (vdesc->pio_type == PIO_NAT)
         {
             if ((ierr = PIOc_inq_vartype(ncid, varid, &vdesc->pio_type)))
             {
@@ -2016,7 +2016,7 @@ int PIOc_read_darray(int ncid, int varid, int ioid, PIO_Offset arraylen,
             }
         }
 
-        assert(vdesc->pio_type != NC_NAT);
+        assert(vdesc->pio_type != PIO_NAT);
 
         /* Find out length of type. */
         if (vdesc->type_size == 0)

--- a/src/clib/pio_get_nc.c
+++ b/src/clib/pio_get_nc.c
@@ -1093,7 +1093,7 @@ int PIOc_get_var1_longlong(int ncid, int varid, const PIO_Offset *index,
  */
 int PIOc_get_var(int ncid, int varid, void *buf)
 {
-    return PIOc_get_var_tc(ncid, varid, NC_NAT, buf);
+    return PIOc_get_var_tc(ncid, varid, PIO_NAT, buf);
 }
 
 /**
@@ -1114,7 +1114,7 @@ int PIOc_get_var(int ncid, int varid, void *buf)
  */
 int PIOc_get_var1(int ncid, int varid, const PIO_Offset *index, void *buf)
 {
-    return PIOc_get_var1_tc(ncid, varid, index, NC_NAT, buf);
+    return PIOc_get_var1_tc(ncid, varid, index, PIO_NAT, buf);
 }
 
 /**
@@ -1139,7 +1139,7 @@ int PIOc_get_var1(int ncid, int varid, const PIO_Offset *index, void *buf)
 int PIOc_get_vara(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
                   void *buf)
 {
-    return PIOc_get_vars_tc(ncid, varid, start, count, NULL, NC_NAT, buf);
+    return PIOc_get_vars_tc(ncid, varid, start, count, NULL, PIO_NAT, buf);
 }
 
 /**
@@ -1167,5 +1167,5 @@ int PIOc_get_vara(int ncid, int varid, const PIO_Offset *start, const PIO_Offset
 int PIOc_get_vars(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
                   const PIO_Offset *stride, void *buf)
 {
-    return PIOc_get_vars_tc(ncid, varid, start, count, stride, NC_NAT, buf);
+    return PIOc_get_vars_tc(ncid, varid, start, count, stride, PIO_NAT, buf);
 }

--- a/src/clib/pio_getput_int.c
+++ b/src/clib/pio_getput_int.c
@@ -440,7 +440,7 @@ int PIOc_get_att_tc(int ncid, int varid, const char *name, nc_type memtype, void
 {
     iosystem_desc_t *ios;   /* Pointer to io system information. */
     file_desc_t *file;      /* Pointer to file information. */
-    nc_type atttype = NC_NAT;   /* The type of the attribute. */
+    nc_type atttype = PIO_NAT;   /* The type of the attribute. */
     PIO_Offset attlen = 0;      /* Number of elements in the attribute array. */
     PIO_Offset atttype_len = 0; /* Length in bytes of one element of the attribute type. */
     PIO_Offset memtype_len = 0; /* Length in bytes of one element of the memory type. */
@@ -745,7 +745,7 @@ int PIOc_get_att_tc(int ncid, int varid, const char *name, nc_type memtype, void
  * used.
  * @param xtype the netCDF type of the data being passed in buf. Data
  * will be automatically covnerted from the type of the variable being
- * read from to this type. If NC_NAT then the variable's file type
+ * read from to this type. If PIO_NAT then the variable's file type
  * will be used. Use special PIO_LONG_INTERNAL for _long() functions.
  * @param buf pointer to the data to be written.
  * @return PIO_NOERR on success, error code otherwise.
@@ -759,7 +759,7 @@ int PIOc_get_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
     int ndims = 0;         /* The number of dimensions in the variable. */
     PIO_Offset typelen = 0; /* Size (in bytes) of the data type of data in buf. */
     PIO_Offset num_elem = 1; /* Number of data elements in the buffer. */
-    nc_type vartype = NC_NAT; /* The type of the var we are reading from. */
+    nc_type vartype = PIO_NAT; /* The type of the var we are reading from. */
     char start_present = start ? true : false;
     char count_present = count ? true : false;
     char stride_present = stride ? true : false;
@@ -816,7 +816,7 @@ int PIOc_get_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
         }
 
         /* If no type was specified, use the var type. */
-        if (xtype == NC_NAT)
+        if (xtype == PIO_NAT)
             xtype = vartype;
 
         /* Handle _long() calls with an special type. */
@@ -1277,7 +1277,7 @@ int PIOc_get_var_tc(int ncid, int varid, nc_type xtype, void *buf)
  * used.
  * @param xtype the netCDF type of the data being passed in buf. Data
  * will be automatically covnerted from this type to the type of the
- * variable being written to. If NC_NAT then the variable's file type
+ * variable being written to. If PIO_NAT then the variable's file type
  * will be used. Use special PIO_LONG_INTERNAL for _long() functions.
  * @param buf pointer to the data to be written.
  *
@@ -1298,7 +1298,7 @@ int PIOc_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
     var_desc_t *vdesc;
     int *request = NULL;
     PIO_Offset *request_sz = NULL;
-    nc_type vartype = NC_NAT;   /* The type of the var we are reading from. */
+    nc_type vartype = PIO_NAT;   /* The type of the var we are reading from. */
     int mpierr = MPI_SUCCESS;  /* Return code from MPI function codes. */
     int ierr = PIO_NOERR;          /* Return code from function calls. */
 
@@ -1372,7 +1372,7 @@ int PIOc_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
         }
 
         /* If no type was specified, use the var type. */
-        if (xtype == NC_NAT)
+        if (xtype == PIO_NAT)
             xtype = vartype;
 
         /* Get the number of dims for this var. */
@@ -1543,7 +1543,7 @@ int PIOc_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
         /* Write ADIOS with memory type since ADIOS does not do conversions.
          * Add an attribute describing the target output type (defined type).
          */
-        if (xtype == NC_NAT)
+        if (xtype == PIO_NAT)
             xtype = vartype;
 
         if (xtype == PIO_LONG_INTERNAL)

--- a/src/clib/pio_nc.c
+++ b/src/clib/pio_nc.c
@@ -3223,7 +3223,7 @@ int PIOc_def_var_fill(int ncid, int varid, int fill_mode, const void *fill_value
 {
     iosystem_desc_t *ios;  /* Pointer to io system information. */
     file_desc_t *file;     /* Pointer to file information. */
-    nc_type xtype = NC_NAT;    /* The type of the variable (and fill value att). */
+    nc_type xtype = PIO_NAT;    /* The type of the variable (and fill value att). */
     PIO_Offset type_size = 0;  /* Size in bytes of this variable's type. */
     int ierr = PIO_NOERR;              /* Return code from function calls. */
     int mpierr = MPI_SUCCESS;  /* Return code from MPI function codes. */
@@ -3390,7 +3390,7 @@ int PIOc_inq_var_fill(int ncid, int varid, int *no_fill, void *fill_valuep)
 {
     iosystem_desc_t *ios;  /* Pointer to io system information. */
     file_desc_t *file;     /* Pointer to file information. */
-    nc_type xtype = NC_NAT;  /* Type of variable and its _FillValue attribute. */
+    nc_type xtype = PIO_NAT;  /* Type of variable and its _FillValue attribute. */
     PIO_Offset type_size = 0;  /* Size in bytes of this variable's type. */
     int mpierr = MPI_SUCCESS;  /* Return code from MPI function codes. */
     int ierr = PIO_NOERR;  /* Return code from function calls. */

--- a/src/clib/pio_put_nc.c
+++ b/src/clib/pio_put_nc.c
@@ -1167,7 +1167,7 @@ int PIOc_put_var_double(int ncid, int varid, const double *op)
  */
 int PIOc_put_var(int ncid, int varid, const void *op)
 {
-    return PIOc_put_var_tc(ncid, varid, NC_NAT, op);
+    return PIOc_put_var_tc(ncid, varid, PIO_NAT, op);
 }
 
 /**
@@ -1187,7 +1187,7 @@ int PIOc_put_var(int ncid, int varid, const void *op)
  */
 int PIOc_put_var1(int ncid, int varid, const PIO_Offset *index, const void *op)
 {
-    return PIOc_put_var1_tc(ncid, varid, index, NC_NAT, op);
+    return PIOc_put_var1_tc(ncid, varid, index, PIO_NAT, op);
 }
 
 /**
@@ -1211,7 +1211,7 @@ int PIOc_put_var1(int ncid, int varid, const PIO_Offset *index, const void *op)
 int PIOc_put_vara(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
                   const void *op)
 {
-    return PIOc_put_vars_tc(ncid, varid, start, count, NULL, NC_NAT, op);
+    return PIOc_put_vars_tc(ncid, varid, start, count, NULL, PIO_NAT, op);
 }
 
 /**
@@ -1238,5 +1238,5 @@ int PIOc_put_vara(int ncid, int varid, const PIO_Offset *start, const PIO_Offset
 int PIOc_put_vars(int ncid, int varid, const PIO_Offset *start, const PIO_Offset *count,
                   const PIO_Offset *stride, const void *op)
 {
-    return PIOc_put_vars_tc(ncid, varid, start, count, stride, NC_NAT, op);
+    return PIOc_put_vars_tc(ncid, varid, start, count, stride, PIO_NAT, op);
 }

--- a/src/clib/pioc_support.c
+++ b/src/clib/pioc_support.c
@@ -2290,7 +2290,7 @@ int PIOc_createfile_int(int iosysid, int *ncidp, int *iotype, const char *filena
         file->varlist[i].request_sz = NULL;
         file->varlist[i].nreqs = 0;
         file->varlist[i].fillvalue = NULL;
-        file->varlist[i].pio_type = NC_NAT;
+        file->varlist[i].pio_type = PIO_NAT;
         file->varlist[i].type_size = 0;
         file->varlist[i].vrsize = 0;
         file->varlist[i].rb_pend = 0;
@@ -2895,7 +2895,7 @@ int PIOc_openfile_retry(int iosysid, int *ncidp, int *iotype, const char *filena
         file->varlist[i].request_sz = NULL;
         file->varlist[i].nreqs = 0;
         file->varlist[i].fillvalue = NULL;
-        file->varlist[i].pio_type = NC_NAT;
+        file->varlist[i].pio_type = PIO_NAT;
         file->varlist[i].type_size = 0;
         file->varlist[i].vrsize = 0;
         file->varlist[i].rb_pend = 0;


### PR DESCRIPTION
For consistency, define PIO_NAT in pio.h to replace NC_NAT. Each
valid NC_\<type\> already has an associated PIO_\<type\> macro.