### PR TITLE
The replay tool should not initialize/finalize GPTL if PIO_ENABLE_INTERNAL_TIMING is ON

### DIFF
--- a/tests/performance/pioperformance_rearr.F90
+++ b/tests/performance/pioperformance_rearr.F90
@@ -81,12 +81,14 @@ program pioperformance_rearr
   else
     use_gptl = .true.
   end if
+#ifndef TIMING_INTERNAL
   if(use_gptl) then
     call gptlinitialize()
   else
     call t_initf(PIO_NML_FNAME, LogPrint=.false.,&
       mpicom=MPI_COMM_WORLD, MasterTask=MasterTask)
   end if
+#endif
   niotypes = 0
   do i=1,MAX_PIO_TYPES
      if (piotypes(i) > -1) niotypes = niotypes+1
@@ -112,11 +114,13 @@ program pioperformance_rearr
      enddo
   enddo
 
+#ifndef TIMING_INTERNAL
   if(use_gptl) then
     call gptlfinalize()
   else
     call t_finalizef()
   end if
+#endif
 
   call MPI_Finalize(ierr)
 contains


### PR DESCRIPTION
The pioperf_rearr tool must be built with GPTL timing library and
the macro TIMING is always defined for it.

If the macro TIMING_INTERNAL is also defined, SCORPIO will
internally initialize and finalize GPTL. In this case, the
pioperf_rearr tool should no longer perform these operations.