### PR TITLE
Add -qnoopt -qnosmp flags to any OLCF machine (Ascent)

### DIFF
--- a/src/clib/CMakeLists.txt
+++ b/src/clib/CMakeLists.txt
@@ -219,7 +219,7 @@ endif ()
 # Hack to circumvent IBM XL (16.1.1-3) internal compiler error by
 # disabling optimization for pioc_support.c
 cmake_host_system_information (RESULT FQDN_SITENAME QUERY FQDN)
-if (FQDN_SITENAME MATCHES "^.*summit[.]olcf")
+if (FQDN_SITENAME MATCHES "^.*[.]olcf")
   if (CMAKE_C_COMPILER_NAME STREQUAL "XL")
     set_source_files_properties(pioc_support.c PROPERTIES COMPILE_FLAGS "-qnoopt -qnosmp")
   endif()


### PR DESCRIPTION
Adding the necessary compiler flags to build pioc_support.c with the
IBM XL compiler on OLCF machines (Ascent)

Addresses E3SM-Project/scorpio#215, E3SM-Project/scorpio#220