### PR TITLE
Set default striping factor and unit hints for Lustre and GPFS file systems

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,6 +100,37 @@ else()
   set(PIO_MAX_CACHED_IO_REGIONS 0)
 endif()
 
+if(DEFINED PIO_MAX_LUSTRE_OSTS)
+  message (STATUS "Using PIO_MAX_LUSTRE_OSTS = " ${PIO_MAX_LUSTRE_OSTS})
+else()
+  cmake_host_system_information (RESULT FQDN_SITENAME QUERY FQDN)
+  if(FQDN_SITENAME MATCHES "^cori")
+    set(PIO_MAX_LUSTRE_OSTS 72)
+    message (STATUS "Using PIO_MAX_LUSTRE_OSTS = " ${PIO_MAX_LUSTRE_OSTS} " (default)")
+  elseif(FQDN_SITENAME MATCHES "^theta")
+    set(PIO_MAX_LUSTRE_OSTS 48)
+    message (STATUS "Using PIO_MAX_LUSTRE_OSTS = " ${PIO_MAX_LUSTRE_OSTS} " (default)")
+  else()
+    set(PIO_MAX_LUSTRE_OSTS 0)
+  endif()
+endif()
+
+if(DEFINED PIO_STRIPING_UNIT)
+  message (STATUS "Using PIO_STRIPING_UNIT = " ${PIO_STRIPING_UNIT})
+else()
+  cmake_host_system_information (RESULT FQDN_SITENAME QUERY FQDN)
+  if(FQDN_SITENAME MATCHES "^cori" OR
+     FQDN_SITENAME MATCHES "^theta")
+    set(PIO_STRIPING_UNIT 1048576)
+    message (STATUS "Using PIO_STRIPING_UNIT = " ${PIO_STRIPING_UNIT} " (default)")
+  elseif(FQDN_SITENAME MATCHES "^.*[.]olcf")
+    set(PIO_STRIPING_UNIT 16777216)
+    message (STATUS "Using PIO_STRIPING_UNIT = " ${PIO_STRIPING_UNIT} " (default)")
+  else()
+    set(PIO_STRIPING_UNIT 0)
+  endif()
+endif()
+
 #==============================================================================
 #  PREPEND TO CMAKE MODULE PATH
 #==============================================================================

--- a/src/clib/pio_config.h.in
+++ b/src/clib/pio_config.h.in
@@ -37,6 +37,12 @@
 /** Maximum number of non-contiguous regions cached in a single IO process. */
 #define PIO_MAX_CACHED_IO_REGIONS @PIO_MAX_CACHED_IO_REGIONS@
 
+/** Maximum number of OSTs to be used in a Lustre file syestem. */
+#define PIO_MAX_LUSTRE_OSTS @PIO_MAX_LUSTRE_OSTS@
+
+/** Striping unit hint in bytes for a Lustre or GPFS file system. */
+#define PIO_STRIPING_UNIT @PIO_STRIPING_UNIT@
+
 /** Set to 1 if the library is configured to use the PnetCDF library,
  *  0 otherwise */
 #define PIO_USE_PNETCDF @PIO_USE_PNETCDF@

--- a/src/clib/pioc_support.c
+++ b/src/clib/pioc_support.c
@@ -2590,35 +2590,58 @@ int PIOc_createfile_int(int iosysid, int *ncidp, int *iotype, const char *filena
                MPI-IO. If they are not explicitly set with PIO_set_hint or PIOc_set_hint,
                use some default values below.
              */
+
+#if PIO_MAX_LUSTRE_OSTS
+            /* A Lustre file system has a limited number of available OSTs to use. For example,
+               this number is 248 on Cori and 56 on Theta currently.
+
+               We should not go to full as Lustre will bypass assigning slow OSTs to the file
+               at file creation time, going to a recommended smaller number (e.g. 72 on Cori
+               and 48 on Theta) leaves room for this.
+
+               We also do not want to create high metadata requests which might negatively
+               impact other users.
+             */
             char info_striping_factor[PIO_MAX_NAME];
-            char info_striping_unit[PIO_MAX_NAME];
-            int flag;
+            int flag_striping_factor;
 
             /* Number of Object Storage Targets (OSTs) a file exists on */
-            MPI_Info_get(ios->info, "striping_factor", PIO_MAX_NAME, info_striping_factor, &flag);
-            if (!flag)
+            MPI_Info_get(ios->info, "striping_factor", PIO_MAX_NAME, info_striping_factor, &flag_striping_factor);
+            if (!flag_striping_factor)
             {
-                /* NERSC warning:
-                   Do not use a stripe count larger than stripe_large (72 OSTs).
-                   This will result in poor performance and can adversely affect
-                   the entire file system.
-                 */
-                const int STRIPE_LIMIT = 72;
-
-                int striping_factor_size = (ios->num_iotasks < STRIPE_LIMIT)? ios->num_iotasks : STRIPE_LIMIT;
+                int striping_factor_size = (ios->num_iotasks < PIO_MAX_LUSTRE_OSTS)? ios->num_iotasks : PIO_MAX_LUSTRE_OSTS;
                 char striping_factor_str[PIO_MAX_NAME];
                 snprintf(striping_factor_str, PIO_MAX_NAME, "%d", striping_factor_size);
 
                 MPI_Info_set(ios->info, "striping_factor", striping_factor_str);
             }
+#endif
 
-            /* Number of bytes write on one OST before cycling to the next */
-            MPI_Info_get(ios->info, "striping_unit", PIO_MAX_NAME, info_striping_unit, &flag);
-            if (!flag)
+#if PIO_STRIPING_UNIT
+            /* In a Lustre file system, striping_unit (stripe-size) is the number of bytes write on one
+               OST before cycling to the next. Default (1MB) has been most successful.
+
+               One optimization we need for GPFS is to align writes to the file system block size.
+               We can do this by setting the "striping_unit" hint to GPFS block size (16MB on Summit).
+
+               For a block-based parallel file system such as GPFS, an application write becomes a block
+               write at the file system layer. If a write straddles two blocks, locks must be acquired
+               for both blocks. Aligning the start of a variable to a block boundary, combined with
+               collective I/O optimizations in the MPI-IO library can often eliminate all unaligned
+               file system accesses.
+             */
+            char info_striping_unit[PIO_MAX_NAME];
+            int flag_striping_unit;
+
+            MPI_Info_get(ios->info, "striping_unit", PIO_MAX_NAME, info_striping_unit, &flag_striping_unit);
+            if (!flag_striping_unit)
             {
-                /* Default (1MB) has been most successful on NERSC */
-                MPI_Info_set(ios->info, "striping_unit", "1048576");
+                char striping_unit_str[PIO_MAX_NAME];
+                snprintf(striping_unit_str, PIO_MAX_NAME, "%d", PIO_STRIPING_UNIT);
+
+                MPI_Info_set(ios->info, "striping_unit", striping_unit_str);
             }
+#endif
 
             /* Set some PnetCDF I/O hints below */
 


### PR DESCRIPTION
SCORPIO classic sets the stripe settings to some default values by
setting the following MPI-IO hints:
striping_factor = min(Number of I/O tasks, Number of OSTs available)
striping_unit = 1MB

If these hints are not explicitly set by users, we can similarly set
some default values inside SCORPIO.

Users can still override these default values by calling Fortran API
PIO_set_hint or C API PIOc_set_hint.

Fixes #409