### PR TITLE
Conditionally initialize/finalize GPTL in the pioperf_rearr tool

### DIFF
--- a/tests/performance/pioperformance_rearr.F90
+++ b/tests/performance/pioperformance_rearr.F90
@@ -37,6 +37,13 @@ program pioperformance_rearr
 #ifdef BGQTRY
   external :: print_memusage
 #endif
+
+#ifdef TIMING
+#ifndef TIMING_INTERNAL
+  external :: gptlinitialize, gptlfinalize
+#endif
+#endif
+
 #ifdef _PIO1
   integer, parameter :: PIO_FILL_INT   = 02147483647
   real, parameter    :: PIO_FILL_FLOAT = 9.969209968E+36
@@ -72,6 +79,12 @@ program pioperformance_rearr
         niotasks, nframes, unlimdimindof, nvars, varsize,&
         rearr_opts, ierr)
 
+#ifdef TIMING
+#ifndef TIMING_INTERNAL
+  call gptlinitialize()
+#endif
+#endif
+
   niotypes = 0
   do i=1,MAX_PIO_TYPES
      if (piotypes(i) > -1) niotypes = niotypes+1
@@ -96,6 +109,12 @@ program pioperformance_rearr
         endif
      enddo
   enddo
+
+#ifdef TIMING
+#ifndef TIMING_INTERNAL
+  call gptlfinalize()
+#endif
+#endif
 
   call MPI_Finalize(ierr)
 contains


### PR DESCRIPTION
This PR fixes a bug introduced by PR #410.

If the macro TIMING_INTERNAL is not defined, SCORPIO will not
internally initialize and finalize GPTL. In this case, the replay
tool should explicitly perform these operations to avoid error
messages on "GPTLinitialize has not been called".