### PR TITLE
Minor improvements to the I/O performance summary statistics

### DIFF
--- a/src/clib/io_perf_summary.schema.json
+++ b/src/clib/io_perf_summary.schema.json
@@ -33,13 +33,23 @@
           "minimum": 0
         },
         "tot_wtime(s)": {
-          "description": "Total elapsed wallclock time (seconds)",
+          "description": "Total write time (seconds)",
+          "type": "number",
+          "minimum": 0
+        },
+        "tot_rtime(s)": {
+          "description": "Total read time (seconds)",
+          "type": "number",
+          "minimum": 0
+        },
+        "tot_time(s)": {
+          "description": "Total time (seconds)",
           "type": "number",
           "minimum": 0
         }
       },
 
-      "required": ["name", "avg_wtput(MB/s)", "avg_rtput(MB/s)", "tot_wb(bytes)", "tot_rb(bytes)", "tot_wtime(s)"]
+      "required": ["name", "avg_wtput(MB/s)", "avg_rtput(MB/s)", "tot_wb(bytes)", "tot_rb(bytes)", "tot_wtime(s)", "tot_rtime(s)", "tot_time(s)"]
     }
   },
 

--- a/src/clib/io_perf_summary.schema.json
+++ b/src/clib/io_perf_summary.schema.json
@@ -12,34 +12,34 @@
           "description": "The name of the Model/Component/File",
           "type": "string"
         },
-        "avg_wtput": {
+        "avg_wtput(MB/s)": {
           "description": "The average write throughput (MB/s)",
           "type": "number",
           "minimum": 0
         },
-        "avg_rtput": {
+        "avg_rtput(MB/s)": {
           "description": "The average read throughput (MB/s)",
           "type": "number",
           "minimum": 0
         },
-        "tot_wb": {
+        "tot_wb(bytes)": {
           "description": "Total data written to the file system (bytes)",
           "type": "integer",
           "minimum": 0
         },
-        "tot_rb": {
+        "tot_rb(bytes)": {
           "description": "Total data read from the file system (bytes)",
           "type": "integer",
           "minimum": 0
         },
-        "tot_wtime": {
+        "tot_wtime(s)": {
           "description": "Total elapsed wallclock time (seconds)",
           "type": "number",
           "minimum": 0
         }
       },
 
-      "required": ["name", "avg_wtput", "avg_rtput", "tot_wb", "tot_rb", "tot_wtime"]
+      "required": ["name", "avg_wtput(MB/s)", "avg_rtput(MB/s)", "tot_wb(bytes)", "tot_rb(bytes)", "tot_wtime(s)"]
     }
   },
 

--- a/src/clib/io_perf_summary.text_expected
+++ b/src/clib/io_perf_summary.text_expected
@@ -1,36 +1,36 @@
   "ScorpioIOSummaryStatistics":
     "OverallModelIOStatistics":
       "name" : "E3SM",
-      "avg_wtput" : 2.5,
-      "avg_rtput" : 1.5,
-      "tot_wb" : 1024,
-      "tot_rb" : 1024,
-      "tot_wtime" : 234
+      "avg_wtput(MB/s)" : 2.5,
+      "avg_rtput(MB/s)" : 1.5,
+      "tot_wb(bytes)" : 1024,
+      "tot_rb(bytes)" : 1024,
+      "tot_wtime(s)" : 234
     "ModelComponentIOStatistics":
       "name" : "EAM",
-      "avg_wtput" : 2.5,
-      "avg_rtput" : 1.5,
-      "tot_wb" : 1024,
-      "tot_rb" : 1024,
-      "tot_wtime" : 234
+      "avg_wtput(MB/s)" : 2.5,
+      "avg_rtput(MB/s)" : 1.5,
+      "tot_wb(bytes)" : 1024,
+      "tot_rb(bytes)" : 1024,
+      "tot_wtime(s)" : 234
     "ModelComponentIOStatistics":
       "name" : "LND",
-      "avg_wtput" : 2.5,
-      "avg_rtput" : 1.5,
-      "tot_wb" : 1024,
-      "tot_rb" : 1024,
-      "tot_wtime" : 234
+      "avg_wtput(MB/s)" : 2.5,
+      "avg_rtput(MB/s)" : 1.5,
+      "tot_wb(bytes)" : 1024,
+      "tot_rb(bytes)" : 1024,
+      "tot_wtime(s)" : 234
     "FileIOStatistics":
       "name" : "file1.nc",
-      "avg_wtput" : 2.5,
-      "avg_rtput" : 1.5,
-      "tot_wb" : 1024,
-      "tot_rb" : 1024,
-      "tot_wtime" : 234
+      "avg_wtput(MB/s)" : 2.5,
+      "avg_rtput(MB/s)" : 1.5,
+      "tot_wb(bytes)" : 1024,
+      "tot_rb(bytes)" : 1024,
+      "tot_wtime(s)" : 234
     "FileIOStatistics":
       "name" : "file2.nc",
-      "avg_wtput" : 2.5,
-      "avg_rtput" : 1.5,
-      "tot_wb" : 1024,
-      "tot_rb" : 1024,
-      "tot_wtime" : 234
+      "avg_wtput(MB/s)" : 2.5,
+      "avg_rtput(MB/s)" : 1.5,
+      "tot_wb(bytes)" : 1024,
+      "tot_rb(bytes)" : 1024,
+      "tot_wtime(s)" : 234

--- a/src/clib/io_perf_summary.text_expected
+++ b/src/clib/io_perf_summary.text_expected
@@ -6,6 +6,8 @@
       "tot_wb(bytes)" : 1024,
       "tot_rb(bytes)" : 1024,
       "tot_wtime(s)" : 234
+      "tot_rtime(s)" : 234
+      "tot_time(s)" : 512
     "ModelComponentIOStatistics":
       "name" : "EAM",
       "avg_wtput(MB/s)" : 2.5,
@@ -13,6 +15,8 @@
       "tot_wb(bytes)" : 1024,
       "tot_rb(bytes)" : 1024,
       "tot_wtime(s)" : 234
+      "tot_rtime(s)" : 234
+      "tot_time(s)" : 512
     "ModelComponentIOStatistics":
       "name" : "LND",
       "avg_wtput(MB/s)" : 2.5,
@@ -20,6 +24,8 @@
       "tot_wb(bytes)" : 1024,
       "tot_rb(bytes)" : 1024,
       "tot_wtime(s)" : 234
+      "tot_rtime(s)" : 234
+      "tot_time(s)" : 512
     "FileIOStatistics":
       "name" : "file1.nc",
       "avg_wtput(MB/s)" : 2.5,
@@ -27,6 +33,8 @@
       "tot_wb(bytes)" : 1024,
       "tot_rb(bytes)" : 1024,
       "tot_wtime(s)" : 234
+      "tot_rtime(s)" : 234
+      "tot_time(s)" : 512
     "FileIOStatistics":
       "name" : "file2.nc",
       "avg_wtput(MB/s)" : 2.5,
@@ -34,3 +42,5 @@
       "tot_wb(bytes)" : 1024,
       "tot_rb(bytes)" : 1024,
       "tot_wtime(s)" : 234
+      "tot_rtime(s)" : 234
+      "tot_time(s)" : 512

--- a/src/clib/io_perf_summary.xml_expected
+++ b/src/clib/io_perf_summary.xml_expected
@@ -1,42 +1,42 @@
 <ScorpioIOSummaryStatistics>
   <OverallModelIOStatistics>
     <name>"E3SM"</name>
-    <avg_wtput>2.5</avg_wtput>
-    <avg_rtput>1.5</avg_rtput>
-    <tot_wb>1024</tot_wb>
-    <tot_rb>1024</tot_rb>
-    <tot_wtime>234</tot_wtime>
+    <avg_wtput(MB/s)>2.5</avg_wtput(MB/s)>
+    <avg_rtput(MB/s)>1.5</avg_rtput(MB/s)>
+    <tot_wb(bytes)>1024</tot_wb(bytes)>
+    <tot_rb(bytes)>1024</tot_rb(bytes)>
+    <tot_wtime(s)>234</tot_wtime(s)>
   </OverallModelIOStatistics>
   <ModelComponentIOStatistics>
     <name>"EAM"</name>
-    <avg_wtput>2.5</avg_wtput>
-    <avg_rtput>1.5</avg_rtput>
-    <tot_wb>1024</tot_wb>
-    <tot_rb>1024</tot_rb>
-    <tot_wtime>234</tot_wtime>
+    <avg_wtput(MB/s)>2.5</avg_wtput(MB/s)>
+    <avg_rtput(MB/s)>1.5</avg_rtput(MB/s)>
+    <tot_wb(bytes)>1024</tot_wb(bytes)>
+    <tot_rb(bytes)>1024</tot_rb(bytes)>
+    <tot_wtime(s)>234</tot_wtime(s)>
   </ModelComponentIOStatistics>
   <ModelComponentIOStatistics>
     <name>"LND"</name>
-    <avg_wtput>2.5</avg_wtput>
-    <avg_rtput>1.5</avg_rtput>
-    <tot_wb>1024</tot_wb>
-    <tot_rb>1024</tot_rb>
-    <tot_wtime>234</tot_wtime>
+    <avg_wtput(MB/s)>2.5</avg_wtput(MB/s)>
+    <avg_rtput(MB/s)>1.5</avg_rtput(MB/s)>
+    <tot_wb(bytes)>1024</tot_wb(bytes)>
+    <tot_rb(bytes)>1024</tot_rb(bytes)>
+    <tot_wtime(s)>234</tot_wtime(s)>
   </ModelComponentIOStatistics>
   <FileIOStatistics>
     <name>"file1.nc"</name>
-    <avg_wtput>2.5</avg_wtput>
-    <avg_rtput>1.5</avg_rtput>
-    <tot_wb>1024</tot_wb>
-    <tot_rb>1024</tot_rb>
-    <tot_wtime>234</tot_wtime>
+    <avg_wtput(MB/s)>2.5</avg_wtput(MB/s)>
+    <avg_rtput(MB/s)>1.5</avg_rtput(MB/s)>
+    <tot_wb(bytes)>1024</tot_wb(bytes)>
+    <tot_rb(bytes)>1024</tot_rb(bytes)>
+    <tot_wtime(s)>234</tot_wtime(s)>
   </FileIOStatistics>
   <FileIOStatistics>
     <name>"file2.nc"</name>
-    <avg_wtput>2.5</avg_wtput>
-    <avg_rtput>1.5</avg_rtput>
-    <tot_wb>1024</tot_wb>
-    <tot_rb>1024</tot_rb>
-    <tot_wtime>234</tot_wtime>
+    <avg_wtput(MB/s)>2.5</avg_wtput(MB/s)>
+    <avg_rtput(MB/s)>1.5</avg_rtput(MB/s)>
+    <tot_wb(bytes)>1024</tot_wb(bytes)>
+    <tot_rb(bytes)>1024</tot_rb(bytes)>
+    <tot_wtime(s)>234</tot_wtime(s)>
   </FileIOStatistics>
 </ScorpioIOSummaryStatistics>

--- a/src/clib/io_perf_summary.xml_expected
+++ b/src/clib/io_perf_summary.xml_expected
@@ -6,6 +6,8 @@
     <tot_wb(bytes)>1024</tot_wb(bytes)>
     <tot_rb(bytes)>1024</tot_rb(bytes)>
     <tot_wtime(s)>234</tot_wtime(s)>
+    <tot_rtime(s)>234</tot_rtime(s)>
+    <tot_time(s)>512</tot_time(s)>
   </OverallModelIOStatistics>
   <ModelComponentIOStatistics>
     <name>"EAM"</name>
@@ -14,6 +16,8 @@
     <tot_wb(bytes)>1024</tot_wb(bytes)>
     <tot_rb(bytes)>1024</tot_rb(bytes)>
     <tot_wtime(s)>234</tot_wtime(s)>
+    <tot_rtime(s)>234</tot_rtime(s)>
+    <tot_time(s)>512</tot_time(s)>
   </ModelComponentIOStatistics>
   <ModelComponentIOStatistics>
     <name>"LND"</name>
@@ -22,6 +26,8 @@
     <tot_wb(bytes)>1024</tot_wb(bytes)>
     <tot_rb(bytes)>1024</tot_rb(bytes)>
     <tot_wtime(s)>234</tot_wtime(s)>
+    <tot_rtime(s)>234</tot_rtime(s)>
+    <tot_time(s)>512</tot_time(s)>
   </ModelComponentIOStatistics>
   <FileIOStatistics>
     <name>"file1.nc"</name>
@@ -30,6 +36,8 @@
     <tot_wb(bytes)>1024</tot_wb(bytes)>
     <tot_rb(bytes)>1024</tot_rb(bytes)>
     <tot_wtime(s)>234</tot_wtime(s)>
+    <tot_rtime(s)>234</tot_rtime(s)>
+    <tot_time(s)>512</tot_time(s)>
   </FileIOStatistics>
   <FileIOStatistics>
     <name>"file2.nc"</name>
@@ -38,5 +46,7 @@
     <tot_wb(bytes)>1024</tot_wb(bytes)>
     <tot_rb(bytes)>1024</tot_rb(bytes)>
     <tot_wtime(s)>234</tot_wtime(s)>
+    <tot_rtime(s)>234</tot_rtime(s)>
+    <tot_time(s)>512</tot_time(s)>
   </FileIOStatistics>
 </ScorpioIOSummaryStatistics>

--- a/src/clib/pio_darray_int.c
+++ b/src/clib/pio_darray_int.c
@@ -2199,9 +2199,12 @@ int flush_buffer(int ncid, wmulti_buffer *wmb, bool flushtodisk)
     ios = file->iosystem;
     assert(ios);
 
-    spio_ltimer_start(ios->io_fstats->wr_timer_name);
+    if(file->mode & PIO_WRITE)
+    {
+        spio_ltimer_start(ios->io_fstats->wr_timer_name);
+        spio_ltimer_start(file->io_fstats->wr_timer_name);
+    }
     spio_ltimer_start(ios->io_fstats->tot_timer_name);
-    spio_ltimer_start(file->io_fstats->wr_timer_name);
     spio_ltimer_start(file->io_fstats->tot_timer_name);
 
     LOG((1, "flush_buffer ncid = %d flushtodisk = %d", ncid, flushtodisk));
@@ -2210,16 +2213,22 @@ int flush_buffer(int ncid, wmulti_buffer *wmb, bool flushtodisk)
     if (wmb->num_arrays > 0)
     {
         /* Write any data in the buffer. */
-        spio_ltimer_stop(ios->io_fstats->wr_timer_name);
+        if(file->mode & PIO_WRITE)
+        {
+            spio_ltimer_stop(ios->io_fstats->wr_timer_name);
+            spio_ltimer_stop(file->io_fstats->wr_timer_name);
+        }
         spio_ltimer_stop(ios->io_fstats->tot_timer_name);
-        spio_ltimer_stop(file->io_fstats->wr_timer_name);
         spio_ltimer_stop(file->io_fstats->tot_timer_name);
         ret = PIOc_write_darray_multi(ncid, wmb->vid,  wmb->ioid, wmb->num_arrays,
                                       wmb->arraylen, wmb->data, wmb->frame,
                                       wmb->fillvalue, flushtodisk);
-        spio_ltimer_start(ios->io_fstats->wr_timer_name);
+        if(file->mode & PIO_WRITE)
+        {
+            spio_ltimer_start(ios->io_fstats->wr_timer_name);
+            spio_ltimer_start(file->io_fstats->wr_timer_name);
+        }
         spio_ltimer_start(ios->io_fstats->tot_timer_name);
-        spio_ltimer_start(file->io_fstats->wr_timer_name);
         spio_ltimer_start(file->io_fstats->tot_timer_name);
         LOG((2, "return from PIOc_write_darray_multi ret = %d", ret));
 
@@ -2246,9 +2255,12 @@ int flush_buffer(int ncid, wmulti_buffer *wmb, bool flushtodisk)
         if (ret)
         {
             GPTLstop("PIO:flush_buffer");
-            spio_ltimer_stop(ios->io_fstats->wr_timer_name);
+            if(file->mode & PIO_WRITE)
+            {
+                spio_ltimer_stop(ios->io_fstats->wr_timer_name);
+                spio_ltimer_stop(file->io_fstats->wr_timer_name);
+            }
             spio_ltimer_stop(ios->io_fstats->tot_timer_name);
-            spio_ltimer_stop(file->io_fstats->wr_timer_name);
             spio_ltimer_stop(file->io_fstats->tot_timer_name);
             return pio_err(NULL, file, ret, __FILE__, __LINE__,
                         "Internal error flushing data cached in a write multi buffer to file (%s, ncid=%d). Error while flushing data to %s. Internal error flushing arrays (%d) in the write multi buffer", pio_get_fname_from_file(file), file->pio_ncid, (flushtodisk) ? "disk" : "I/O processes", wmb->num_arrays);
@@ -2256,9 +2268,12 @@ int flush_buffer(int ncid, wmulti_buffer *wmb, bool flushtodisk)
     }
 
     GPTLstop("PIO:flush_buffer");
-    spio_ltimer_stop(ios->io_fstats->wr_timer_name);
+    if(file->mode & PIO_WRITE)
+    {
+        spio_ltimer_stop(ios->io_fstats->wr_timer_name);
+        spio_ltimer_stop(file->io_fstats->wr_timer_name);
+    }
     spio_ltimer_stop(ios->io_fstats->tot_timer_name);
-    spio_ltimer_stop(file->io_fstats->wr_timer_name);
     spio_ltimer_stop(file->io_fstats->tot_timer_name);
     return PIO_NOERR;
 }

--- a/src/clib/pio_file.c
+++ b/src/clib/pio_file.c
@@ -286,9 +286,12 @@ static int sync_file(int ncid)
         return PIO_NOERR;
 #endif
 
-    spio_ltimer_start(ios->io_fstats->wr_timer_name);
+    if(file->mode & PIO_WRITE)
+    {
+        spio_ltimer_start(ios->io_fstats->wr_timer_name);
+        spio_ltimer_start(file->io_fstats->wr_timer_name);
+    }
     spio_ltimer_start(ios->io_fstats->tot_timer_name);
-    spio_ltimer_start(file->io_fstats->wr_timer_name);
     spio_ltimer_start(file->io_fstats->tot_timer_name);
 
     ios = file->iosystem;
@@ -342,9 +345,12 @@ static int sync_file(int ncid)
         PIO_SEND_ASYNC_MSG(ios, msg, &ierr, ncid);
         if (ierr != PIO_NOERR)
         {
-            spio_ltimer_stop(ios->io_fstats->wr_timer_name);
+            if(file->mode & PIO_WRITE)
+            {
+                spio_ltimer_stop(ios->io_fstats->wr_timer_name);
+                spio_ltimer_stop(file->io_fstats->wr_timer_name);
+            }
             spio_ltimer_stop(ios->io_fstats->tot_timer_name);
-            spio_ltimer_stop(file->io_fstats->wr_timer_name);
             spio_ltimer_stop(file->io_fstats->tot_timer_name);
             return pio_err(ios, NULL, ierr, __FILE__, __LINE__,
                             "Syncing file %s (ncid=%d) failed. Unable to send asynchronous message, PIO_MSG_SYNC, on iosystem (iosysid=%d)", pio_get_fname_from_file(file), ncid, ios->iosysid);
@@ -401,16 +407,22 @@ static int sync_file(int ncid)
     if (ierr != PIO_NOERR)
     {
         LOG((1, "nc*_sync failed, ierr = %d", ierr));
-        spio_ltimer_stop(ios->io_fstats->wr_timer_name);
+        if(file->mode & PIO_WRITE)
+        {
+            spio_ltimer_stop(ios->io_fstats->wr_timer_name);
+            spio_ltimer_stop(file->io_fstats->wr_timer_name);
+        }
         spio_ltimer_stop(ios->io_fstats->tot_timer_name);
-        spio_ltimer_stop(file->io_fstats->wr_timer_name);
         spio_ltimer_stop(file->io_fstats->tot_timer_name);
         return ierr;
     }
 
-    spio_ltimer_stop(ios->io_fstats->wr_timer_name);
+    if(file->mode & PIO_WRITE)
+    {
+        spio_ltimer_stop(ios->io_fstats->wr_timer_name);
+        spio_ltimer_stop(file->io_fstats->wr_timer_name);
+    }
     spio_ltimer_stop(ios->io_fstats->tot_timer_name);
-    spio_ltimer_stop(file->io_fstats->wr_timer_name);
     spio_ltimer_stop(file->io_fstats->tot_timer_name);
     return PIO_NOERR;
 }

--- a/src/clib/pioc.c
+++ b/src/clib/pioc.c
@@ -1218,7 +1218,7 @@ int PIOc_Init_Intracomm(MPI_Comm comp_comm, int num_iotasks, int stride, int bas
                         "PIO Init failed. Internal error allocating buffer space on compute processes to cache user data");
     }
 
-    ret = pio_create_uniq_str(ios, NULL, ios->sname, PIO_MAX_NAME, "tmp_", "_comp");
+    ret = pio_create_uniq_str(ios, NULL, ios->sname, PIO_MAX_NAME, "UNKNOWN:SPIO_COMP_", "_tmp_name");
     if(ret != PIO_NOERR)
     {
         /* Not a fatal error */
@@ -2106,7 +2106,7 @@ int PIOc_init_async(MPI_Comm world, int num_io_procs, int *io_proc_list,
         iosysidp[cmp] = pio_add_to_iosystem_list(my_iosys, MPI_COMM_NULL);
         LOG((2, "new iosys ID added to iosystem_list iosysid = %d", iosysidp[cmp]));
 
-        ret = pio_create_uniq_str(my_iosys, NULL, my_iosys->sname, PIO_MAX_NAME, "tmp_", "_comp");
+        ret = pio_create_uniq_str(my_iosys, NULL, my_iosys->sname, PIO_MAX_NAME, "UNKNOWN:SPIO_COMP_", "_tmp_name");
         if(ret != PIO_NOERR)
         {
             /* Not Fatal error */
@@ -2741,7 +2741,7 @@ int PIOc_init_intercomm(int component_count, const MPI_Comm peer_comm,
         LOG((2, "PIOc_init_intercomm : iosys[%d]->ioid=%d, iosys[%d]->uniontasks = %d, iosys[%d]->union_rank=%d, %s", i, iosys[i]->iosysid, i, iosys[i]->num_uniontasks, i, iosys[i]->union_rank, ((iosys[i]->ioproc) ? ("IS IO PROC"):((iosys[i]->compproc) ? ("IS COMPUTE PROC") : ("NEITHER IO NOR COMPUTE PROC"))) ));
         LOG((2, "New IOsystem added to iosystem_list iosysid = %d", iosysidps[i]));
 
-        ret = pio_create_uniq_str(iosys[i], NULL, iosys[i]->sname, PIO_MAX_NAME, "tmp_", "_comp");
+        ret = pio_create_uniq_str(iosys[i], NULL, iosys[i]->sname, PIO_MAX_NAME, "UNKNOWN:SPIO_COMP_", "_tmp_name");
         if(ret != PIO_NOERR)
         {
             /* Not Fatal error */

--- a/src/clib/pioc.c
+++ b/src/clib/pioc.c
@@ -428,16 +428,27 @@ int pio_create_uniq_str(iosystem_desc_t *ios, io_desc_t *iodesc, char *str, int 
     if(ios)
     {
         /* Add ios specific info into the str */
+        assert(ios->iosysid < MILLION);
         assert(ios->num_comptasks < MILLION);
         assert(rem_len > 0);
+        const char *iosysid_fmt = (ios->iosysid < HUNDRED) ? (INT_FMT_LT_HUNDRED) : ((ios->iosysid < TEN_THOUSAND) ? (INT_FMT_LT_TEN_THOUSAND): INT_FMT_LT_MILLION);
         const char *num_comptasks_fmt = (ios->num_comptasks < HUNDRED) ? (INT_FMT_LT_HUNDRED) : ((ios->num_comptasks < TEN_THOUSAND) ? (INT_FMT_LT_TEN_THOUSAND): INT_FMT_LT_MILLION);
         const char *num_iotasks_fmt = num_comptasks_fmt;
+
+        snprintf(sptr, rem_len, iosysid_fmt, ios->iosysid);
+        rem_len = len - strlen(str);
+        sptr = str + strlen(str);
+        snprintf(sptr, rem_len, "%s", "id");
+        rem_len = len - strlen(str);
+        sptr = str + strlen(str);
+
         snprintf(sptr, rem_len, num_comptasks_fmt, ios->num_comptasks);
         rem_len = len - strlen(str);
         sptr = str + strlen(str);
         snprintf(sptr, rem_len, "%s", "tasks");
         rem_len = len - strlen(str);
         sptr = str + strlen(str);
+
         snprintf(sptr, rem_len, num_iotasks_fmt, ios->num_iotasks);
         rem_len = len - strlen(str);
         sptr = str + strlen(str);

--- a/src/clib/spio_io_summary.cpp
+++ b/src/clib/spio_io_summary.cpp
@@ -316,7 +316,8 @@ static std::string file_names_to_ios_name(iosystem_desc_t *ios,
   assert(ios);
 
   std::string ios_name(ios->sname);
-  std::vector<std::pair<std::string, std::string> > e3sm_comp_names =
+  /* Output file name hints */
+  std::vector<std::pair<std::string, std::string> > e3sm_comp_ohints =
     {
       {".cpl.","CPL"},
       {".eam.","EAM"},
@@ -326,13 +327,40 @@ static std::string file_names_to_ios_name(iosystem_desc_t *ios,
       {".mpasli.","MPASLI"},
       {".mpassi.","MPASSI"}
     };
+  /* Input file name hints */
+  std::vector<std::pair<std::string, std::string> > e3sm_comp_ihints =
+    {
+      {"/inputdata/cpl","CPL"},
+      {"/inputdata/atm","EAM"},
+      {"/inputdata/clm","ELM"},
+      {"/inputdata/lnd","ELM"},
+      {"/inputdata/rof/mosart","MOSART"},
+      {"/inputdata/rof","RTM"},
+      {"/inputdata/ocn/mpas-o","MPASO"},
+      {"/inputdata/ocn","OCN"},
+      {"/inputdata/glc/mpasli","MPASLI"},
+      {"/inputdata/glc","GLC"},
+      {"/inputdata/ice/mpas-cice","MPASSI"},
+      {"/inputdata/ice","CICE"},
+      {"/inputdata/wav","WAV"}
+    };
+  /* FIXME: We currently have no hints for IAC & ESP components */
 
   for(std::vector<std::string>::const_iterator fiter = file_names.cbegin();
       fiter != file_names.cend(); ++fiter){
+    /* First check output files for hints */
     for(std::vector<std::pair<std::string, std::string> >::const_iterator
-          efiter = e3sm_comp_names.cbegin(); efiter != e3sm_comp_names.cend(); ++efiter){
-      if((*fiter).find(efiter->first) != std::string::npos){
-        return efiter->second;
+          hiter = e3sm_comp_ohints.cbegin(); hiter != e3sm_comp_ohints.cend(); ++hiter){
+      if((*fiter).find(hiter->first) != std::string::npos){
+        return hiter->second;
+      }
+    }
+
+    /* Check input files for hints */
+    for(std::vector<std::pair<std::string, std::string> >::const_iterator
+          hiter = e3sm_comp_ihints.cbegin(); hiter != e3sm_comp_ihints.cend(); ++hiter){
+      if((*fiter).find(hiter->first) != std::string::npos){
+        return hiter->second;
       }
     }
   }

--- a/src/clib/spio_io_summary.cpp
+++ b/src/clib/spio_io_summary.cpp
@@ -425,23 +425,23 @@ static int cache_or_print_stats(iosystem_desc_t *ios, int root_proc,
     /* Add Overall I/O performance statistics */
     std::vector<std::pair<std::string, std::string> > overall_comp_vals;
     PIO_Util::Serializer_Utils::serialize_pack("name", model_name, overall_comp_vals);
-    PIO_Util::Serializer_Utils::serialize_pack("avg_wtput",
+    PIO_Util::Serializer_Utils::serialize_pack("avg_wtput(MB/s)",
       (cached_overall_gio_sstats.wtime_max > 0.0) ?
       (cached_overall_gio_sstats.wb_total / (ONE_MB * cached_overall_gio_sstats.wtime_max)) : 0.0,
       overall_comp_vals);
 
-    PIO_Util::Serializer_Utils::serialize_pack("avg_rtput",
+    PIO_Util::Serializer_Utils::serialize_pack("avg_rtput(MB/s)",
       (cached_overall_gio_sstats.rtime_max > 0.0) ?
       (cached_overall_gio_sstats.rb_total / (ONE_MB * cached_overall_gio_sstats.rtime_max)) : 0.0,
       overall_comp_vals);
 
-    PIO_Util::Serializer_Utils::serialize_pack("tot_wb",
+    PIO_Util::Serializer_Utils::serialize_pack("tot_wb(bytes)",
       cached_overall_gio_sstats.wb_total, overall_comp_vals);
 
-    PIO_Util::Serializer_Utils::serialize_pack("tot_rb",
+    PIO_Util::Serializer_Utils::serialize_pack("tot_rb(bytes)",
       cached_overall_gio_sstats.rb_total, overall_comp_vals);
 
-    PIO_Util::Serializer_Utils::serialize_pack("tot_wtime",
+    PIO_Util::Serializer_Utils::serialize_pack("tot_wtime(s)",
       cached_overall_gio_sstats.ttime_max, overall_comp_vals);
 
     spio_ser->serialize(id, "OverallIOStatistics", overall_comp_vals);
@@ -470,23 +470,23 @@ static int cache_or_print_stats(iosystem_desc_t *ios, int root_proc,
 
 
       PIO_Util::Serializer_Utils::serialize_pack("name", cached_ios_names[i], comp_vals);
-      PIO_Util::Serializer_Utils::serialize_pack("avg_wtput",
+      PIO_Util::Serializer_Utils::serialize_pack("avg_wtput(MB/s)",
         (cached_ios_gio_sstats[i].wtime_max > 0.0) ?
         (cached_ios_gio_sstats[i].wb_total / (ONE_MB * cached_ios_gio_sstats[i].wtime_max)) : 0.0,
         comp_vals);
 
-      PIO_Util::Serializer_Utils::serialize_pack("avg_rtput",
+      PIO_Util::Serializer_Utils::serialize_pack("avg_rtput(MB/s)",
         (cached_ios_gio_sstats[i].rtime_max > 0.0) ?
         (cached_ios_gio_sstats[i].rb_total / (ONE_MB * cached_ios_gio_sstats[i].rtime_max)) : 0.0,
         comp_vals);
 
-      PIO_Util::Serializer_Utils::serialize_pack("tot_wb",
+      PIO_Util::Serializer_Utils::serialize_pack("tot_wb(bytes)",
         cached_ios_gio_sstats[i].wb_total, comp_vals);
 
-      PIO_Util::Serializer_Utils::serialize_pack("tot_rb",
+      PIO_Util::Serializer_Utils::serialize_pack("tot_rb(bytes)",
         cached_ios_gio_sstats[i].rb_total, comp_vals);
 
-      PIO_Util::Serializer_Utils::serialize_pack("tot_wtime",
+      PIO_Util::Serializer_Utils::serialize_pack("tot_wtime(s)",
         cached_ios_gio_sstats[i].ttime_max, comp_vals);
 
       comp_vvals.push_back(comp_vals);
@@ -520,23 +520,23 @@ static int cache_or_print_stats(iosystem_desc_t *ios, int root_proc,
         const std::size_t ONE_MB = 1024 * 1024;
 
         PIO_Util::Serializer_Utils::serialize_pack("name", cached_file_names[i][j], file_vals);
-        PIO_Util::Serializer_Utils::serialize_pack("avg_wtput",
+        PIO_Util::Serializer_Utils::serialize_pack("avg_wtput(MB/s)",
           (cached_file_gio_sstats[i][j].wtime_max > 0.0) ?
           (cached_file_gio_sstats[i][j].wb_total / (ONE_MB * cached_file_gio_sstats[i][j].wtime_max)) : 0.0,
           file_vals);
 
-        PIO_Util::Serializer_Utils::serialize_pack("avg_rtput",
+        PIO_Util::Serializer_Utils::serialize_pack("avg_rtput(MB/s)",
           (cached_file_gio_sstats[i][j].rtime_max > 0.0) ?
           (cached_file_gio_sstats[i][j].rb_total / (ONE_MB * cached_file_gio_sstats[i][j].rtime_max)) : 0.0,
           file_vals);
 
-        PIO_Util::Serializer_Utils::serialize_pack("tot_wb",
+        PIO_Util::Serializer_Utils::serialize_pack("tot_wb(bytes)",
           cached_file_gio_sstats[i][j].wb_total, file_vals);
 
-        PIO_Util::Serializer_Utils::serialize_pack("tot_rb",
+        PIO_Util::Serializer_Utils::serialize_pack("tot_rb(bytes)",
           cached_file_gio_sstats[i][j].rb_total, file_vals);
 
-        PIO_Util::Serializer_Utils::serialize_pack("tot_wtime",
+        PIO_Util::Serializer_Utils::serialize_pack("tot_wtime(s)",
           cached_file_gio_sstats[i][j].ttime_max, file_vals);
 
         file_vvals.push_back(file_vals);

--- a/src/clib/spio_io_summary.cpp
+++ b/src/clib/spio_io_summary.cpp
@@ -319,30 +319,30 @@ static std::string file_names_to_ios_name(iosystem_desc_t *ios,
   /* Output file name hints */
   std::vector<std::pair<std::string, std::string> > e3sm_comp_ohints =
     {
-      {".cpl.","CPL"},
-      {".eam.","EAM"},
-      {".elm.","ELM"},
-      {".mosart.","MOSART"},
-      {".mpaso.","MPASO"},
-      {".mpasli.","MPASLI"},
-      {".mpassi.","MPASSI"}
+      {".cpl.","COMP_CPL: CPL"},
+      {".eam.","COMP_ATM: EAM"},
+      {".elm.","COMP_LND: ELM"},
+      {".mosart.","COMP_ROF: MOSART"},
+      {".mpaso.","COMP_OCN: MPASO"},
+      {".mpasli.","COMP_GLC: MPASLI"},
+      {".mpassi.","COMP_ICE: MPASSI"}
     };
   /* Input file name hints */
   std::vector<std::pair<std::string, std::string> > e3sm_comp_ihints =
     {
-      {"/inputdata/cpl","CPL"},
-      {"/inputdata/atm","EAM"},
-      {"/inputdata/clm","ELM"},
-      {"/inputdata/lnd","ELM"},
-      {"/inputdata/rof/mosart","MOSART"},
-      {"/inputdata/rof","RTM"},
-      {"/inputdata/ocn/mpas-o","MPASO"},
-      {"/inputdata/ocn","OCN"},
-      {"/inputdata/glc/mpasli","MPASLI"},
-      {"/inputdata/glc","GLC"},
-      {"/inputdata/ice/mpas-cice","MPASSI"},
-      {"/inputdata/ice","CICE"},
-      {"/inputdata/wav","WAV"}
+      {"/inputdata/cpl","COMP_CPL: CPL"},
+      {"/inputdata/atm","COMP_ATM: EAM"},
+      {"/inputdata/clm","COMP_LND: ELM"},
+      {"/inputdata/lnd","COMP_LND: ELM"},
+      {"/inputdata/rof/mosart","COMP_ROF: MOSART"},
+      {"/inputdata/rof","COMP_ROF: ROF"},
+      {"/inputdata/ocn/mpas-o","COMP_OCN: MPASO"},
+      {"/inputdata/ocn","COMP_OCN: OCN"},
+      {"/inputdata/glc/mpasli","COMP_GLC: MPASLI"},
+      {"/inputdata/glc","COMP_GLC: GLC"},
+      {"/inputdata/ice/mpas-cice","COMP_ICE: MPASSI"},
+      {"/inputdata/ice","COMP_ICE: ICE"},
+      {"/inputdata/wav","COMP_WAV: WAV"}
     };
   /* FIXME: We currently have no hints for IAC & ESP components */
 

--- a/src/clib/spio_io_summary.cpp
+++ b/src/clib/spio_io_summary.cpp
@@ -442,6 +442,12 @@ static int cache_or_print_stats(iosystem_desc_t *ios, int root_proc,
       cached_overall_gio_sstats.rb_total, overall_comp_vals);
 
     PIO_Util::Serializer_Utils::serialize_pack("tot_wtime(s)",
+      cached_overall_gio_sstats.wtime_max, overall_comp_vals);
+
+    PIO_Util::Serializer_Utils::serialize_pack("tot_rtime(s)",
+      cached_overall_gio_sstats.rtime_max, overall_comp_vals);
+
+    PIO_Util::Serializer_Utils::serialize_pack("tot_time(s)",
       cached_overall_gio_sstats.ttime_max, overall_comp_vals);
 
     spio_ser->serialize(id, "OverallIOStatistics", overall_comp_vals);
@@ -487,6 +493,12 @@ static int cache_or_print_stats(iosystem_desc_t *ios, int root_proc,
         cached_ios_gio_sstats[i].rb_total, comp_vals);
 
       PIO_Util::Serializer_Utils::serialize_pack("tot_wtime(s)",
+        cached_ios_gio_sstats[i].wtime_max, comp_vals);
+
+      PIO_Util::Serializer_Utils::serialize_pack("tot_rtime(s)",
+        cached_ios_gio_sstats[i].rtime_max, comp_vals);
+
+      PIO_Util::Serializer_Utils::serialize_pack("tot_time(s)",
         cached_ios_gio_sstats[i].ttime_max, comp_vals);
 
       comp_vvals.push_back(comp_vals);
@@ -537,6 +549,12 @@ static int cache_or_print_stats(iosystem_desc_t *ios, int root_proc,
           cached_file_gio_sstats[i][j].rb_total, file_vals);
 
         PIO_Util::Serializer_Utils::serialize_pack("tot_wtime(s)",
+          cached_file_gio_sstats[i][j].wtime_max, file_vals);
+
+        PIO_Util::Serializer_Utils::serialize_pack("tot_rtime(s)",
+          cached_file_gio_sstats[i][j].rtime_max, file_vals);
+
+        PIO_Util::Serializer_Utils::serialize_pack("tot_time(s)",
           cached_file_gio_sstats[i][j].ttime_max, file_vals);
 
         file_vvals.push_back(file_vals);

--- a/src/clib/spio_serializer.cpp
+++ b/src/clib/spio_serializer.cpp
@@ -3,6 +3,8 @@
 #include <stdexcept>
 #include <iostream>
 #include <fstream>
+#include <sys/types.h>
+#include <sys/stat.h>
 
 /* Text Serializer function definitions */
 
@@ -68,7 +70,8 @@ void PIO_Util::Text_serializer::sync(void )
 
   /* Write the data out to the text file */
   std::ofstream fstr;
-  fstr.open(pname_.c_str(), std::ofstream::out | std::ofstream::trunc);
+  std::string pname = PIO_Util::Serializer_Utils::get_fname_prefix() + pname_;
+  fstr.open(pname.c_str(), std::ofstream::out | std::ofstream::trunc);
   fstr << sdata_.c_str();
   fstr.close();
 }
@@ -170,7 +173,8 @@ void PIO_Util::XML_serializer::sync(void )
 
   /* Write the data out to the XML file */
   std::ofstream fstr;
-  fstr.open(pname_.c_str(), std::ofstream::out | std::ofstream::trunc);
+  std::string pname = PIO_Util::Serializer_Utils::get_fname_prefix() + pname_;
+  fstr.open(pname.c_str(), std::ofstream::out | std::ofstream::trunc);
   fstr << sdata_.c_str();
   fstr.close();
 }
@@ -358,7 +362,8 @@ void PIO_Util::Json_serializer::sync(void )
 
   /* Write the serialized data to the JSON file */
   std::ofstream fstr;
-  fstr.open(pname_.c_str(), std::ofstream::out | std::ofstream::trunc);
+  std::string pname = PIO_Util::Serializer_Utils::get_fname_prefix() + pname_;
+  fstr.open(pname.c_str(), std::ofstream::out | std::ofstream::trunc);
   fstr << sdata_.c_str();
   fstr.close();
 }
@@ -482,6 +487,27 @@ std::string PIO_Util::Serializer_Utils::to_string(const PIO_Util::Serializer_typ
   else{
     return "UNKNOWN";
   }
+}
+
+/* Get the prefix for file names used by file-based (Text, XML, Json) serializers */
+std::string PIO_Util::Serializer_Utils::get_fname_prefix(void )
+{
+  const std::string default_timing_dir("spio_stats");
+  const std::string dir_sep("/");
+  std::string fname_prefix;
+
+  struct stat sb;
+  /* If there exists a directory named "spio_stats" use it as the file name prefix
+   * So if there is a directory named "spio_stats" all text based serializers
+   * will create/collect stats/files in this directory
+   */
+  if(stat(default_timing_dir.c_str(), &sb) == 0){
+    if(S_ISDIR(sb.st_mode)){
+      fname_prefix = default_timing_dir + dir_sep;
+    }
+  }
+
+  return fname_prefix;
 }
 
 /* Create a serializer */

--- a/src/clib/spio_serializer.hpp
+++ b/src/clib/spio_serializer.hpp
@@ -255,6 +255,16 @@ namespace Serializer_Utils{
   /* Convert Serializer type to string */
   std::string to_string(const Serializer_type &type);
 
+  /* Get the file name prefix. An empty string is returned if there is no
+   * prefix required.
+   * The text based serializers need to use this prefix to create all files
+   *
+   * e.g. For file based serializers if all the serialized files need to be moved
+   * to a separate directory this function will return the name of the directory
+   * used to consolidate the serialized files
+   */
+  std::string get_fname_prefix(void );
+
   /* Factory for serializers */
   std::unique_ptr<SPIO_serializer> create_serializer(const Serializer_type &type,
                                     const std::string &persistent_name);

--- a/tests/general/CMakeLists.txt
+++ b/tests/general/CMakeLists.txt
@@ -50,6 +50,9 @@ foreach (SRC_FILE IN LISTS GENERATED_SRCS)
     DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${SRC_FILE}.in)
 endforeach ()
 
+set(DEF_SPIO_TIMING_DIR ${CMAKE_BINARY_DIR}/spio_stats)
+file(MAKE_DIRECTORY ${DEF_SPIO_TIMING_DIR})
+
 # The PIO library is written using C, C++ and Fortran languages
 # IBM compilers require Fortran/C/C++ mixed language programs
 # to be linked with the C++ linker. Other compilers require the


### PR DESCRIPTION
The following improvements are included in this PR,

* Support for consolidating performance summary output files into
   a separate directory. The performance summary output for
   tests in the test suite is now moved to a separate directory
* Adding read/write times and the units to performance summary
  output
* Moving to E3SM format for naming components
* Avoiding sync/flush write times for read only files
* Improvements in E3SM component auto detection logic
* Using iosystem id when generating unique strings 

Fixes #414 
Fixes #401 