### PR TITLE
Fix crashes when user buffer size mismatches the variable size

### DIFF
--- a/src/flib/pio_support.F90.in
+++ b/src/flib/pio_support.F90.in
@@ -22,6 +22,7 @@ module pio_support
   public :: pio_writedof
   public :: replace_c_null
   public :: get_text_var_sz
+  public :: get_var_dim_sz
 
   public :: Fstring2Cstring
 
@@ -185,6 +186,105 @@ contains
 
     get_text_var_sz = ierr
   end function get_text_var_sz
+
+!>
+!! @public
+!! @brief Get the dim size of a variable
+!! @details
+!! @param File : File containing the variable
+!! @param varid : Id of the queried variable
+!! @param var_sz : The total size of the variable is
+!!                      returned in this arg
+!! @param var_dim_sz : The dimension sizes of the variable is
+!!                      returned in this optional arg
+!! @retval ierr
+!<
+  integer function get_var_dim_sz(File, varid, var_sz, var_dim_sz)
+    type (File_desc_t), intent(in) :: File
+    integer, intent(in) :: varid
+    integer(PIO_OFFSET_KIND), intent(out) :: var_sz
+    integer(PIO_OFFSET_KIND), intent(inout), allocatable, optional :: var_dim_sz(:)
+
+    integer :: ndims = 0
+    integer, allocatable :: dimids(:)
+    integer(C_SIZE_T), allocatable :: dim_sz(:)
+    integer :: i, ierr = PIO_NOERR
+
+    interface
+       integer(C_INT) function PIOc_inq_varndims(ncid       ,varid,ndims) &
+            bind(C                                          ,name="PIOc_inq_varndims")
+         use iso_c_binding
+         integer(C_INT)                                     , value :: ncid
+         integer(C_INT)                                     , value :: varid
+         integer(C_INT) :: ndims
+       end function PIOc_inq_varndims
+    end interface
+    interface
+       integer(C_INT) function PIOc_inq_vardimid(ncid       ,varid,dimids) &
+            bind(C                                          ,name="PIOc_inq_vardimid")
+         use iso_c_binding
+         integer(C_INT)                                     , value :: ncid
+         integer(C_INT)                                     , value :: varid
+         integer(C_INT) :: dimids(*)
+       end function PIOc_inq_vardimid
+    end interface
+    interface
+       integer(C_INT) function PIOc_inq_dimlen(ncid         ,dimid,len) &
+            bind(C                                          ,name="PIOc_inq_dimlen")
+         use iso_c_binding
+         integer(C_INT)                                     , value :: ncid
+         integer(c_int)                                     , value :: dimid
+         integer(c_size_t) :: len
+       end function PIOc_inq_dimlen
+    end interface
+
+    var_sz = 0
+    ! Get the number of dimensions in variable
+    ierr = PIOc_inq_varndims(File%fh, varid-1, ndims)
+    if(ierr /= PIO_NOERR) then
+      call piodie(__PIO_FILE__, __LINE__, "Inquiring number of dims of variable failed")
+    end if
+    if(ndims == 0) then
+      ! A scalar variable
+      var_sz = 1
+
+      if(present(var_dim_sz)) then
+        allocate(var_dim_sz(1))
+        var_dim_sz(1) = 1
+      end if
+
+      get_var_dim_sz = PIO_NOERR
+      return
+    end if
+
+    ! Get the dimension ids for the variable
+    allocate(dimids(ndims))
+    ierr = PIOc_inq_vardimid(File%fh, varid-1, dimids)
+    if(ierr /= PIO_NOERR) then
+      call piodie(__PIO_FILE__, __LINE__, "Inquiring the variable dimension ids for the variable failed")
+    end if
+
+    allocate(dim_sz(ndims))
+    if(present(var_dim_sz)) then
+      allocate(var_dim_sz(ndims))
+    end if
+    var_sz = 1
+    do i=1,ndims
+      ierr = PIOc_inq_dimlen(File%fh, dimids(i), dim_sz(i))
+      if(ierr /= PIO_NOERR) then
+        call piodie(__PIO_FILE__, __LINE__, "Inquiring the lengths of dimension for the variable failed")
+      end if
+      var_sz = var_sz * INT(dim_sz(i), PIO_OFFSET_KIND)
+      if(present(var_dim_sz)) then
+        var_dim_sz(ndims - i + 1) = INT(dim_sz(i), PIO_OFFSET_KIND)
+      end if
+    end do
+
+    deallocate(dim_sz)
+    deallocate(dimids)
+
+    get_var_dim_sz = ierr
+  end function get_var_dim_sz
 
 !>
 !! @public

--- a/src/flib/pio_support.F90.in
+++ b/src/flib/pio_support.F90.in
@@ -242,7 +242,11 @@ contains
     ! Get the number of dimensions in variable
     ierr = PIOc_inq_varndims(File%fh, varid-1, ndims)
     if(ierr /= PIO_NOERR) then
-      call piodie(__PIO_FILE__, __LINE__, "Inquiring number of dims of variable failed")
+      ! Since we don't handle error handlers in the Fortran wrapper
+      ! issue a warning and return an error code (instead of abort)
+      print *, "WARNING: Inquiring number of dims of variable failed.",&
+                __PIO_FILE__, ":", __LINE__
+      return
     end if
     if(ndims == 0) then
       ! A scalar variable

--- a/src/flib/pionfget_mod.F90.in
+++ b/src/flib/pionfget_mod.F90.in
@@ -470,7 +470,10 @@ CONTAINS
 
     ierr = get_var_dim_sz(File, varid, var_sz)
     if(ierr /= PIO_NOERR) then
-      call piodie(__PIO_FILE__, __LINE__, "Unable to get variable dimension size")
+      print *, "WARNING: Getting variable dimensions failed, (varid = ", varid, ")"
+      ! Instead of aborting here let the internal/C APIs handle the error
+      ! based on the error handler chosen by the user
+      var_sz = INT(SIZE(ival), PIO_OFFSET_KIND)
     end if
 
     if(INT(SIZE(ival), PIO_OFFSET_KIND) < var_sz) then

--- a/src/flib/pionfget_mod.F90.in
+++ b/src/flib/pionfget_mod.F90.in
@@ -8,9 +8,9 @@ module pionfget_mod
 #ifdef TIMING
   use perf_mod, only : t_startf, t_stopf      ! _EXTERNAL
 #endif
-  use pio_kinds, only: i4,r4,r8
+  use pio_kinds, only: i4,r4,r8,pio_offset_kind
   use pio_types, only : file_desc_t, var_desc_t, pio_noerr
-  use pio_support, only : replace_c_null, get_text_var_sz, piodie
+  use pio_support, only : replace_c_null, get_text_var_sz, get_var_dim_sz, piodie
   implicit none
   private
 !>
@@ -466,6 +466,18 @@ CONTAINS
     type (File_desc_t), intent(in) :: File
     integer, intent(in) :: varid
     {VTYPE}, intent(out) :: ival{DIMSTR}
+    integer(PIO_OFFSET_KIND) :: var_sz
+
+    ierr = get_var_dim_sz(File, varid, var_sz)
+    if(ierr /= PIO_NOERR) then
+      call piodie(__PIO_FILE__, __LINE__, "Unable to get variable dimension size")
+    end if
+
+    if(INT(SIZE(ival), PIO_OFFSET_KIND) < var_sz) then
+      print *, "ERROR: The size of the user buffer (", SIZE(ival), " elements) ",&
+                "is smaller than the size of the variable (", var_sz, " elements)"
+      call piodie(__PIO_FILE__, __LINE__, "Insufficient user buffer size")
+    end if
 
     ierr = get_var_{TYPE}_internal(File%fh, varid, ival)
 

--- a/src/flib/pionfget_mod.F90.in
+++ b/src/flib/pionfget_mod.F90.in
@@ -556,6 +556,12 @@ CONTAINS
     max_flen= len(fstr(1))
     do j=1,fstr_dim_sz(1)
       cstr_copied = .false.
+      if(cstr_idx * max_clen + min(max_clen, max_flen) > cstr_sz) then
+        print *, "WARNING: The number of strings read (", cstr_idx, ") ",&
+                  "is less than the number of expected strings in the ",&
+                  "Fortran array (", fstr_dim_sz(1), " strings) "
+        exit
+      end if
       do i=1,min(max_clen, max_flen)
         fstr(j)(i:i) = cstr(cstr_idx * max_clen + i)
         if(fstr(j)(i:i) == C_NULL_CHAR) then
@@ -580,6 +586,12 @@ CONTAINS
     do k=1,fstr_dim_sz(2)
       do j=1,fstr_dim_sz(1)
         cstr_copied = .false.
+        if(cstr_idx * max_clen + min(max_clen, max_flen) > cstr_sz) then
+          print *, "WARNING: The number of strings read (", cstr_idx, ") ",&
+                    "is less than the number of expected strings in the ",&
+                    "Fortran array (", fstr_dim_sz(1) * fstr_dim_sz(2), " strings) "
+          exit
+        end if
         do i=1,min(max_clen, max_flen)
           fstr(j,k)(i:i) = cstr(cstr_idx * max_clen + i)
           if(fstr(j,k)(i:i) == C_NULL_CHAR) then
@@ -606,6 +618,13 @@ CONTAINS
       do k=1,fstr_dim_sz(2)
         do j=1,fstr_dim_sz(1)
           cstr_copied = .false.
+          if(cstr_idx * max_clen + min(max_clen, max_flen) > cstr_sz) then
+            print *, "WARNING: The number of strings read (", cstr_idx, ") ",&
+                      "is less than the number of expected strings in the ",&
+                      "Fortran array (",&
+                      fstr_dim_sz(1) * fstr_dim_sz(2) * fstr_dim_sz(3), " strings) "
+            exit
+          end if
           do i=1,min(max_clen, max_flen)
             fstr(j,k,m)(i:i) = cstr(cstr_idx * max_clen + i)
             if(fstr(j,k,m)(i:i) == C_NULL_CHAR) then
@@ -634,6 +653,14 @@ CONTAINS
         do k=1,fstr_dim_sz(2)
           do j=1,fstr_dim_sz(1)
             cstr_copied = .false.
+            if(cstr_idx * max_clen + min(max_clen, max_flen) > cstr_sz) then
+              print *, "WARNING: The number of strings read (", cstr_idx, ") ",&
+                        "is less than the number of expected strings in the ",&
+                        "Fortran array (",&
+                        fstr_dim_sz(1) * fstr_dim_sz(2) * fstr_dim_sz(3) * fstr_dim_sz(4),&
+                        " strings) "
+              exit
+            end if
             do i=1,min(max_clen, max_flen)
               fstr(j,k,m,n)(i:i) = cstr(cstr_idx * max_clen + i)
               if(fstr(j,k,m,n)(i:i) == C_NULL_CHAR) then
@@ -664,6 +691,14 @@ CONTAINS
           do k=1,fstr_dim_sz(2)
             do j=1,fstr_dim_sz(1)
               cstr_copied = .false.
+              if(cstr_idx * max_clen + min(max_clen, max_flen) > cstr_sz) then
+                print *, "WARNING: The number of strings read (", cstr_idx, ") ",&
+                          "is less than the number of expected strings in the ",&
+                          "Fortran array (",&
+                          fstr_dim_sz(1) * fstr_dim_sz(2) * fstr_dim_sz(3) * fstr_dim_sz(4) * fstr_dim_sz(5),&
+                          " strings) "
+                exit
+              end if
               do i=1,min(max_clen, max_flen)
                 fstr(j,k,m,n,q)(i:i) = cstr(cstr_idx * max_clen + i)
                 if(fstr(j,k,m,n,q)(i:i) == C_NULL_CHAR) then

--- a/src/flib/pionfput_mod.F90.in
+++ b/src/flib/pionfput_mod.F90.in
@@ -8,9 +8,9 @@ module pionfput_mod
   use perf_mod, only : t_startf, t_stopf      ! _EXTERNAL
 #endif
   use iso_c_binding
-  use pio_kinds, only: i4,r4,r8
+  use pio_kinds, only: i4,r4,r8,pio_offset_kind
   use pio_types, only : file_desc_t, var_desc_t, pio_noerr
-  use pio_support, only : piodie, get_text_var_sz
+  use pio_support, only : piodie, get_text_var_sz, get_var_dim_sz
   use pio_support, only : Fstring2Cstring
 
   implicit none
@@ -327,13 +327,38 @@ contains
     type (File_desc_t), intent(inout) :: File
     integer, intent(in) :: varid
     {VTYPE}, intent(in) :: ival{DIMSTR}
-    {VTYPE}, allocatable :: cval(:)
-    integer :: clen
+
+    {VTYPE}, allocatable :: cval(:), tmp_cval(:)
+    integer(PIO_OFFSET_KIND) :: var_sz
+    integer :: i, clen
+
     clen = size(ival)
     if (clen > 0) then
         allocate(cval(clen))
         cval = reshape(ival,(/clen/))
-        ierr = put_var_internal_{TYPE} (File%fh, varid, cval)
+
+        ierr = get_var_dim_sz(File, varid, var_sz)
+        if(ierr /= PIO_NOERR) then
+            call piodie(__PIO_FILE__, __LINE__, "Getting variable size failed")
+        end if
+
+        if(INT(clen, PIO_OFFSET_KIND) >= var_sz) then
+            ierr = put_var_internal_{TYPE} (File%fh, varid, cval)
+        else
+            print *,  "PIO: WARNING: The user buffer passed to PIO_put_var ",&
+                      "is smaller (total size of user buffer = ", size(ival),&
+                      " elements) than the size of the variable (total size ",&
+                      "of the variable = ", var_sz, " elements). Only part ",&
+                      "of the variable will be written out"
+            allocate(tmp_cval(var_sz))
+            tmp_cval = 0
+            do i=1,clen
+                tmp_cval(i) = cval(i)
+            end do
+            ierr = put_var_internal_{TYPE} (File%fh, varid, tmp_cval)
+            deallocate(tmp_cval)
+        end if
+
         deallocate(cval)
     else
         print *, "PIO: WARNING: Empty {DIMS}d {TYPE} data passed to PIO_put_var",&

--- a/src/flib/pionfput_mod.F90.in
+++ b/src/flib/pionfput_mod.F90.in
@@ -339,7 +339,10 @@ contains
 
         ierr = get_var_dim_sz(File, varid, var_sz)
         if(ierr /= PIO_NOERR) then
-            call piodie(__PIO_FILE__, __LINE__, "Getting variable size failed")
+            print *, "WARNING: Getting variable dimensions failed (varid = ", varid, ")"
+            ! Instead of aborting here let the internal/C APIs handle
+            ! the error using the error handler chosen by the user
+            var_sz = INT(clen, PIO_OFFSET_KIND)
         end if
 
         if(INT(clen, PIO_OFFSET_KIND) >= var_sz) then

--- a/tests/general/ncdf_get_put.F90.in
+++ b/tests/general/ncdf_get_put.F90.in
@@ -290,6 +290,177 @@ PIO_TF_AUTO_TEST_SUB_BEGIN test_put_get_1dvar
 
 PIO_TF_AUTO_TEST_SUB_END test_put_get_1dvar
 
+! Put and get variables with large/small (compared to the variable size) user buffers
+PIO_TF_TEMPLATE<PIO_TF_PREDEF_TYPENAME PIO_TF_DATA_TYPE, PIO_TF_PREDEF_TYPENAME PIO_TF_FC_DATA_TYPE>
+PIO_TF_AUTO_TEST_SUB_BEGIN test_put_get_1dvar_ls_buf
+  Implicit none
+  type(file_desc_t) :: pio_file
+  character(len=PIO_TF_MAX_STR_LEN) :: filename
+  type(var_desc_t)  :: pio_var, pio_cvar
+  integer :: pio_dim
+
+  integer, parameter :: DIM_LEN = 200
+  integer, parameter :: DIM_LARGE_LEN = DIM_LEN + 100
+  integer, parameter :: DIM_SMALL_LEN = DIM_LEN - 100
+  ! User buffer to put/get the value is larger than the variable dim
+  PIO_TF_FC_DATA_TYPE, dimension(DIM_LARGE_LEN) :: lpval, lgval
+  CHARACTER(len=DIM_LARGE_LEN) :: lpcval, lgcval
+  ! User buffer to put the value is smaller than the variable dim
+  PIO_TF_FC_DATA_TYPE, dimension(DIM_SMALL_LEN) :: spval
+  CHARACTER(len=DIM_SMALL_LEN) :: spcval
+
+  integer, dimension(:), allocatable :: iotypes
+  character(len=PIO_TF_MAX_STR_LEN), dimension(:), allocatable :: iotype_descs
+  character(len=*), parameter :: PIO_VAR_NAME = 'dummy_var_put_val'
+  character(len=*), parameter :: PIO_CVAR_NAME = 'dummy_var_put_cval'
+  integer :: num_iotypes
+  integer :: i, j, ret
+
+  ! Initialize the part of the user buffer written out to the file
+  do i=1,DIM_SMALL_LEN
+    spval(i) = i
+    spcval(i:i) = 's'
+  end do
+
+  ! Initialize the part of the user buffer written out to the file
+  do i=1,DIM_LEN
+    lpval(i) = i
+    lpcval(i:i) = 'l'
+  end do
+
+  ! Initialize the part of get/put user buffers not read_from/written_to the file
+  do i=DIM_LEN+1,DIM_LARGE_LEN
+    lpval(i) = pio_tf_world_sz_
+    ! Note : For strings the entire get buffer gets initialized by Scorpio, so
+    ! any prior contents in the get buffer is erased. So any non-space character
+    ! that is assigned to gcval(i:i) will be overwritten by Scorpio
+    lpcval(i:i) = ''
+    lgval(i) = lpval(i)
+    lgcval(i:i) = lpcval(i:i)
+  end do
+
+  num_iotypes = 0
+  call PIO_TF_Get_nc_iotypes(iotypes, iotype_descs, num_iotypes)
+  filename = "test_pio_ncdf_get_put.testfile"
+  do i=1,num_iotypes
+    PIO_TF_LOG(0,*) "Testing type :", iotype_descs(i)
+    ret = PIO_createfile(pio_tf_iosystem_, pio_file, iotypes(i), filename, PIO_CLOBBER)
+    PIO_TF_CHECK_ERR(ret, "Failed to open:" // trim(filename))
+
+    ! Since file is just created no need to enter redef
+    ret = PIO_def_dim(pio_file, 'dummy_dim_put_val', DIM_LEN, pio_dim)
+    PIO_TF_CHECK_ERR(ret, "Failed to define dim:" // trim(filename))
+
+    ret = PIO_def_var(pio_file, PIO_VAR_NAME, PIO_TF_DATA_TYPE, (/pio_dim/), pio_var)
+    PIO_TF_CHECK_ERR(ret, "Failed to define var:" // trim(filename))
+
+    ret = PIO_def_var(pio_file, PIO_CVAR_NAME, PIO_char, (/pio_dim/), pio_cvar)
+    PIO_TF_CHECK_ERR(ret, "Failed to define char var:" // trim(filename))
+
+    ret = PIO_enddef(pio_file)
+    PIO_TF_CHECK_ERR(ret, "Failed to enddef:" // trim(filename))
+
+    ! Put and get the values using a user buffer that is larger than the
+    ! variable
+    ret = PIO_put_var(pio_file, pio_var, lpval);
+    PIO_TF_CHECK_ERR(ret, "Failed to put var:" // trim(filename))
+
+    ret = PIO_put_var(pio_file, pio_cvar, lpcval);
+    PIO_TF_CHECK_ERR(ret, "Failed to put char var:" // trim(filename))
+
+#ifdef PIO_TEST_CLOSE_OPEN_FOR_SYNC
+    call PIO_closefile(pio_file)
+
+    ret = PIO_openfile(pio_tf_iosystem_, pio_file, iotypes(i), filename, PIO_nowrite)
+    PIO_TF_CHECK_ERR(ret, "Failed to reopen:" // trim(filename))
+
+    ret = PIO_inq_varid(pio_file, PIO_VAR_NAME, pio_var)
+    PIO_TF_CHECK_ERR(ret, "Failed to get scalar var:" // trim(filename))
+
+    ret = PIO_inq_varid(pio_file, PIO_CVAR_NAME, pio_cvar)
+    PIO_TF_CHECK_ERR(ret, "Failed to get scalar char var:" // trim(filename))
+#else
+    call PIO_syncfile(pio_file)
+#endif
+
+    ret = PIO_get_var(pio_file, pio_var, lgval);
+    PIO_TF_CHECK_ERR(ret, "Failed to get var:" // trim(filename))
+
+    PIO_TF_CHECK_VAL((lgval, lpval), "Get with large user buffer : Got wrong value")
+
+    ret = PIO_get_var(pio_file, pio_cvar, lgcval);
+    PIO_TF_CHECK_ERR(ret, "Failed to get char var:" // trim(filename))
+
+    PIO_TF_CHECK_VAL((lgcval, lpcval), "Get with large user buffer : Got wrong value")
+
+    ! Put the values using a user buffer that is smaller than the
+    ! variable and get it with a larger buffer
+    ret = PIO_put_var(pio_file, pio_var, spval);
+    PIO_TF_CHECK_ERR(ret, "Failed to put var:" // trim(filename))
+
+    ret = PIO_put_var(pio_file, pio_cvar, spcval);
+    PIO_TF_CHECK_ERR(ret, "Failed to put char var:" // trim(filename))
+
+#ifdef PIO_TEST_CLOSE_OPEN_FOR_SYNC
+    call PIO_closefile(pio_file)
+
+    ret = PIO_openfile(pio_tf_iosystem_, pio_file, iotypes(i), filename, PIO_nowrite)
+    PIO_TF_CHECK_ERR(ret, "Failed to reopen:" // trim(filename))
+
+    ret = PIO_inq_varid(pio_file, PIO_VAR_NAME, pio_var)
+    PIO_TF_CHECK_ERR(ret, "Failed to get scalar var:" // trim(filename))
+
+    ret = PIO_inq_varid(pio_file, PIO_CVAR_NAME, pio_cvar)
+    PIO_TF_CHECK_ERR(ret, "Failed to get scalar char var:" // trim(filename))
+#else
+    call PIO_syncfile(pio_file)
+#endif
+
+  do j=1,DIM_SMALL_LEN
+    lpcval(j:j) = spcval(j:j)
+  end do
+
+  ! Since only values in spval and spcval, i.e., <= DIM_SMALL_LEN, is written
+  ! out initialize the rest of the values in the buffer used to read the data
+  ! and compare
+  do j=DIM_SMALL_LEN+1,DIM_LARGE_LEN
+    lpval(j) = 0
+    ! Note : For strings the entire get buffer gets initialized by Scorpio, so
+    ! any prior contents in the get buffer is erased. So any non-space character
+    ! that is assigned to gcval(i:i) will be overwritten by Scorpio
+    lpcval(j:j) = ''
+    lgval(j) = lpval(j)
+    lgcval(j:j) = lpcval(j:j)
+  end do
+
+    ! Note: Getting a variable with a buffer smaller than the size of the variable
+    ! is an error, so use a large buffer for reading this data
+    ret = PIO_get_var(pio_file, pio_var, lgval);
+    PIO_TF_CHECK_ERR(ret, "Failed to get var:" // trim(filename))
+
+    PIO_TF_CHECK_VAL((lgval, lpval), "Get with large user buffer : Got wrong value")
+
+    ret = PIO_get_var(pio_file, pio_cvar, lgcval);
+    PIO_TF_CHECK_ERR(ret, "Failed to get char var:" // trim(filename))
+
+    ! Since the variable is written out with a smaller buffer (than the size of the
+    ! variable), the rest of the variable might contain invalid/uninitialized
+    ! values. Reset these values, that were not written out, before checking the
+    ! results
+    lgcval(DIM_SMALL_LEN+1:DIM_LARGE_LEN) = ''
+
+    PIO_TF_CHECK_VAL((lgcval, lpcval), "Get with large user buffer : Got wrong value")
+
+    call PIO_closefile(pio_file)
+    call PIO_deletefile(pio_tf_iosystem_, filename);
+  end do
+  if(allocated(iotypes)) then
+    deallocate(iotypes)
+    deallocate(iotype_descs)
+  end if
+
+PIO_TF_AUTO_TEST_SUB_END test_put_get_1dvar_ls_buf
+
 ! Write out a 1d var slice from a 2d var
 PIO_TF_TEMPLATE<PIO_TF_PREDEF_TYPENAME PIO_TF_DATA_TYPE, PIO_TF_PREDEF_TYPENAME PIO_TF_FC_DATA_TYPE>
 PIO_TF_AUTO_TEST_SUB_BEGIN test_put_get_1dvar_slice


### PR DESCRIPTION
This change fixes issues (crashes) when the user buffer size used
in put/get is different from the variable size.

A test is added that covers the different cases fixed by the PR.