### PR TITLE
Fix puts to read only file in ls test

### DIFF
--- a/tests/general/ncdf_get_put.F90.in
+++ b/tests/general/ncdf_get_put.F90.in
@@ -371,7 +371,7 @@ PIO_TF_AUTO_TEST_SUB_BEGIN test_put_get_1dvar_ls_buf
 #ifdef PIO_TEST_CLOSE_OPEN_FOR_SYNC
     call PIO_closefile(pio_file)
 
-    ret = PIO_openfile(pio_tf_iosystem_, pio_file, iotypes(i), filename, PIO_nowrite)
+    ret = PIO_openfile(pio_tf_iosystem_, pio_file, iotypes(i), filename, PIO_write)
     PIO_TF_CHECK_ERR(ret, "Failed to reopen:" // trim(filename))
 
     ret = PIO_inq_varid(pio_file, PIO_VAR_NAME, pio_var)


### PR DESCRIPTION
Fixing bug in the new test added in PR #417.

Ensure that the file is opened in write mode the second time
before writing data to it.