### PR TITLE
Consolidate I/O performance summary files for Fortran tests

### DIFF
--- a/tests/general/CMakeLists.txt
+++ b/tests/general/CMakeLists.txt
@@ -50,7 +50,7 @@ foreach (SRC_FILE IN LISTS GENERATED_SRCS)
     DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${SRC_FILE}.in)
 endforeach ()
 
-set(DEF_SPIO_TIMING_DIR ${CMAKE_BINARY_DIR}/spio_stats)
+set(DEF_SPIO_TIMING_DIR ${CMAKE_CURRENT_BINARY_DIR}/spio_stats)
 file(MAKE_DIRECTORY ${DEF_SPIO_TIMING_DIR})
 
 # The PIO library is written using C, C++ and Fortran languages


### PR DESCRIPTION
The spio_stats directory was created in the build root directory
in b599d969c02c1ecab586c432d29e96582da3de1a

Create the spio_stats directory inside the Fortran tests directory
instead of the build root directory to consolidate I/O
performance summary files for the Fortran tests
