### PR TITLE
Add missing inqs in Fortran tests

### DIFF
--- a/tests/general/ncdf_get_put.F90.in
+++ b/tests/general/ncdf_get_put.F90.in
@@ -1663,6 +1663,9 @@ PIO_TF_AUTO_TEST_SUB_BEGIN test_put_get_misc_str
     ret = PIO_inq_varid(pio_file, var2d_name, var2d)
     PIO_TF_CHECK_ERR(ret, "Failed to inquire 2d array of strings var in file " // trim(filename))
 
+    ret = PIO_inq_varid(pio_file, var3d_name, var3d)
+    PIO_TF_CHECK_ERR(ret, "Failed to inquire 3d array of strings var in file " // trim(filename))
+
 #else
     call PIO_syncfile(pio_file)
 #endif
@@ -2208,6 +2211,18 @@ PIO_TF_AUTO_TEST_SUB_BEGIN test_put_get_str_idx
     PIO_TF_CHECK_ERR(ret, "Failed to reopen:" // trim(filename))
 
     ret = PIO_inq_varid(pio_file, var1d_name, var1d)
+    PIO_TF_CHECK_ERR(ret, "Failed to inquire 1d array of strings var in file " // trim(filename))
+
+    ret = PIO_inq_varid(pio_file, var1d_shrt_name, var1d_shrt)
+    PIO_TF_CHECK_ERR(ret, "Failed to inquire 1d array of strings var in file " // trim(filename))
+
+    ret = PIO_inq_varid(pio_file, var1d_long_name, var1d_long)
+    PIO_TF_CHECK_ERR(ret, "Failed to inquire 1d array of strings var in file " // trim(filename))
+
+    ret = PIO_inq_varid(pio_file, var1d_trnc_name, var1d_trnc)
+    PIO_TF_CHECK_ERR(ret, "Failed to inquire 1d array of strings var in file " // trim(filename))
+
+    ret = PIO_inq_varid(pio_file, var1d_midx_name, var1d_midx)
     PIO_TF_CHECK_ERR(ret, "Failed to inquire 1d array of strings var in file " // trim(filename))
 #else
     call PIO_syncfile(pio_file)

--- a/tests/general/pio_buf_lim_tests.F90.in
+++ b/tests/general/pio_buf_lim_tests.F90.in
@@ -213,6 +213,9 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_wr_mvar_impl_flush
 
     ierr = PIO_inq_varid(pio_file, PIO_VAR2_NAME, pio_var2)
     PIO_TF_CHECK_ERR(ierr, "Could not inq var2 : " // trim(filename))
+
+    ierr = PIO_inq_varid(pio_file, PIO_VAR3_NAME, pio_var3)
+    PIO_TF_CHECK_ERR(ierr, "Could not inq var3 : " // trim(filename))
 #else
     call PIO_syncfile(pio_file)
 #endif
@@ -260,6 +263,9 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_wr_mvar_impl_flush
 
     ierr = PIO_inq_varid(pio_file, PIO_VAR3_NAME, pio_var3)
     PIO_TF_CHECK_ERR(ierr, "Could not inq var3 : " // trim(filename))
+
+    ierr = PIO_inq_varid(pio_file, PIO_VAR4_NAME, pio_var4)
+    PIO_TF_CHECK_ERR(ierr, "Could not inq var4 : " // trim(filename))
 #else
     call PIO_syncfile(pio_file)
 #endif


### PR DESCRIPTION
Adding missing pio_inq*s for variables in Fortran tests when a
file is closed+reopened for syncing data.