### PR TITLE
Improve testing of error handlers

### DIFF
--- a/cmake/PIOTest.cmake
+++ b/cmake/PIOTest.cmake
@@ -20,6 +20,7 @@ include (LibMPI)
 #   testname_np[8,16]_nio[1,2,4]_st[1,2,4] tests
 #
 # Syntax:  add_pio_test (<TESTNAME>
+#                        WILLFAIL
 #                        EXECUTABLE <command>
 #                        ARGUMENTS <arg1> <arg2> ...
 #                        MINNUMPROCS <min_num_procs>
@@ -32,7 +33,7 @@ include (LibMPI)
 function (add_pio_test TESTNAME)
 
     # Parse the input arguments
-    set (options)
+    set (options WILLFAIL)
     set (oneValueArgs EXECUTABLE MINNUMPROCS MAXNUMPROCS MINNUMIOPROCS MAXNUMIOPROCS MINSTRIDE MAXSTRIDE TIMEOUT)
     set (multiValueArgs ARGUMENTS)
     cmake_parse_arguments (${TESTNAME} "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
@@ -47,6 +48,11 @@ function (add_pio_test TESTNAME)
     set (min_stride ${${TESTNAME}_MINSTRIDE})
     set (max_stride ${${TESTNAME}_MAXSTRIDE})
     set (timeout ${${TESTNAME}_TIMEOUT})
+    if (${TESTNAME}_WILLFAIL)
+      set (will_fail true)
+    else()
+      set (will_fail false)
+    endif()
 
     # Sanity checks on the user args
     if (min_num_procs GREATER max_num_procs)
@@ -68,6 +74,11 @@ function (add_pio_test TESTNAME)
       
       # Adjust the test timeout
       set_tests_properties (${TESTNAME}_1proc PROPERTIES TIMEOUT ${timeout})
+
+      # Set the will fail (test will fail) flag if needed
+      if (${will_fail})
+        set_tests_properties (${TESTNAME}_1proc PROPERTIES WILL_FAIL true)
+      endif()
 
     else () # if (PIO_USE_MPISERIAL)
 
@@ -122,6 +133,11 @@ function (add_pio_test TESTNAME)
               ARGUMENTS ${exec_args} --pio-tf-num-io-tasks=${inioprocs} --pio-tf-stride=${istride}
               NUMPROCS ${inprocs}
               TIMEOUT ${timeout})
+
+              # Set the will fail (test will fail) flag if needed
+              if (${will_fail})
+                set_tests_properties (${TESTNAME}_np${inprocs}_nio${inioprocs}_st${istride} PROPERTIES WILL_FAIL true)
+              endif()
 
             math (EXPR istride "${istride} * 2")
           endwhile () # while ((istride ...)

--- a/src/clib/pioc_support.c
+++ b/src/clib/pioc_support.c
@@ -2701,7 +2701,10 @@ int PIOc_createfile_int(int iosysid, int *ncidp, int *iotype, const char *filena
     if ((mpierr = MPI_Bcast(&file->mode, 1, MPI_INT, ios->ioroot, ios->union_comm)))
     {
 #ifdef _ADIOS2
-        free(file->filename);
+        if(file->iotype == PIO_IOTYPE_ADIOS)
+        {
+            free(file->filename);
+        }
 #endif
         spio_ltimer_stop(file->io_fstats->wr_timer_name);
         spio_ltimer_stop(file->io_fstats->tot_timer_name);
@@ -2714,7 +2717,10 @@ int PIOc_createfile_int(int iosysid, int *ncidp, int *iotype, const char *filena
     /* If there was an error, free the memory we allocated and handle error. */
     if(ierr != PIO_NOERR){
 #ifdef _ADIOS2
-        free(file->filename);
+        if(file->iotype == PIO_IOTYPE_ADIOS)
+        {
+            free(file->filename);
+        }
 #endif
         spio_ltimer_stop(file->io_fstats->wr_timer_name);
         spio_ltimer_stop(file->io_fstats->tot_timer_name);

--- a/src/clib/pioc_support.c
+++ b/src/clib/pioc_support.c
@@ -2697,6 +2697,19 @@ int PIOc_createfile_int(int iosysid, int *ncidp, int *iotype, const char *filena
         }
     }
 
+    /* Broadcast mode to all tasks. */
+    if ((mpierr = MPI_Bcast(&file->mode, 1, MPI_INT, ios->ioroot, ios->union_comm)))
+    {
+#ifdef _ADIOS2
+        free(file->filename);
+#endif
+        spio_ltimer_stop(file->io_fstats->wr_timer_name);
+        spio_ltimer_stop(file->io_fstats->tot_timer_name);
+        free(file->io_fstats);
+        free(file);
+        return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
+    }
+
     ierr = check_netcdf(ios, file, ierr, __FILE__, __LINE__);
     /* If there was an error, free the memory we allocated and handle error. */
     if(ierr != PIO_NOERR){
@@ -2709,14 +2722,6 @@ int PIOc_createfile_int(int iosysid, int *ncidp, int *iotype, const char *filena
         free(file);
         return pio_err(ios, NULL, ierr, __FILE__, __LINE__,
                         "Creating file (%s) failed. Internal error", filename);
-    }
-
-    /* Broadcast mode to all tasks. */
-    if ((mpierr = MPI_Bcast(&file->mode, 1, MPI_INT, ios->ioroot, ios->union_comm)))
-    {
-        spio_ltimer_stop(file->io_fstats->wr_timer_name);
-        spio_ltimer_stop(file->io_fstats->tot_timer_name);
-        return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
     }
 
     /* This flag is implied by netcdf create functions but we need
@@ -3125,6 +3130,18 @@ int PIOc_openfile_retry(int iosysid, int *ncidp, int *iotype, const char *filena
         }
     }
 
+    /* Broadcast open mode to all tasks. */
+    if ((mpierr = MPI_Bcast(&file->mode, 1, MPI_INT, ios->ioroot, ios->my_comm)))
+    {
+        spio_ltimer_stop(ios->io_fstats->rd_timer_name);
+        spio_ltimer_stop(ios->io_fstats->tot_timer_name);
+        spio_ltimer_stop(file->io_fstats->rd_timer_name);
+        spio_ltimer_stop(file->io_fstats->tot_timer_name);
+        free(file->io_fstats);
+        free(file);
+        return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
+    }
+
     ierr = check_netcdf(ios, file, ierr, __FILE__, __LINE__);
     /* If there was an error, free allocated memory and deal with the error. */
     if(ierr != PIO_NOERR){
@@ -3138,16 +3155,6 @@ int PIOc_openfile_retry(int iosysid, int *ncidp, int *iotype, const char *filena
         LOG((1, "PIOc_openfile_retry failed, ierr = %d", ierr));
         return pio_err(ios, NULL, ierr, __FILE__, __LINE__,
                         "Opening file (%s) with iotype %d (%s) failed. The low level I/O library call failed", filename, tmp_iotype, pio_iotype_to_string(tmp_iotype));;
-    }
-
-    /* Broadcast open mode to all tasks. */
-    if ((mpierr = MPI_Bcast(&file->mode, 1, MPI_INT, ios->ioroot, ios->my_comm)))
-    {
-        spio_ltimer_stop(ios->io_fstats->rd_timer_name);
-        spio_ltimer_stop(ios->io_fstats->tot_timer_name);
-        spio_ltimer_stop(file->io_fstats->rd_timer_name);
-        spio_ltimer_stop(file->io_fstats->tot_timer_name);
-        return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
     }
 
     /* Add this file to the list of currently open files. */

--- a/src/clib/pioc_support.c
+++ b/src/clib/pioc_support.c
@@ -544,7 +544,7 @@ int check_netcdf(iosystem_desc_t *ios, file_desc_t *file, int status,
             int ret = PIOc_strerror(status, errmsg);
             assert(ret == PIO_NOERR);
             LOG((1, "check_netcdf errmsg = %s", errmsg));
-            piodie(fname, line, "FATAL ERROR: %s", errmsg);
+            piodie(fname, line, "FATAL ERROR: %s (file = %s)", errmsg, (file)?(file->fname):"UNKNOWN");
         }
     }
 
@@ -2697,7 +2697,7 @@ int PIOc_createfile_int(int iosysid, int *ncidp, int *iotype, const char *filena
         }
     }
 
-    ierr = check_netcdf(ios, NULL, ierr, __FILE__, __LINE__);
+    ierr = check_netcdf(ios, file, ierr, __FILE__, __LINE__);
     /* If there was an error, free the memory we allocated and handle error. */
     if(ierr != PIO_NOERR){
 #ifdef _ADIOS2
@@ -3125,7 +3125,7 @@ int PIOc_openfile_retry(int iosysid, int *ncidp, int *iotype, const char *filena
         }
     }
 
-    ierr = check_netcdf(ios, NULL, ierr, __FILE__, __LINE__);
+    ierr = check_netcdf(ios, file, ierr, __FILE__, __LINE__);
     /* If there was an error, free allocated memory and deal with the error. */
     if(ierr != PIO_NOERR){
         int tmp_iotype = file->iotype;

--- a/tests/general/CMakeLists.txt
+++ b/tests/general/CMakeLists.txt
@@ -14,6 +14,7 @@ SET(GENERATED_SRCS pio_file_simple_tests.F90
   ncdf_simple_tests.F90
   ncdf_get_put.F90
   ncdf_fail.F90
+  ncdf_eh_one_test.F90
   ncdf_inq.F90
   pio_copy.F90
   pio_set_hint.F90
@@ -317,6 +318,120 @@ add_pio_test(ncdf_fail_reduce
   MINSTRIDE 1
   MAXSTRIDE ${PIO_TF_C2_MAXSTRIDE}
   TIMEOUT ${DEFAULT_TEST_TIMEOUT})
+
+add_pio_test(ncdf_fail_intrnl
+  EXECUTABLE ${CMAKE_CURRENT_BINARY_DIR}/ncdf_fail
+  ARGUMENTS --pio-tf-err-handler=PIO_INTERNAL_ERROR
+  MINNUMPROCS 4
+  MAXNUMPROCS ${PIO_TF_MAXNUMPROCS}
+  MINNUMIOPROCS 2
+  MAXNUMIOPROCS ${PIO_TF_C2_MAXNUMIOPROCS}
+  MINSTRIDE 1
+  MAXSTRIDE ${PIO_TF_C2_MAXSTRIDE}
+  TIMEOUT ${DEFAULT_TEST_TIMEOUT}
+  WILLFAIL)
+
+# Error handler tests
+#===== ncdf_eh_one_test =====
+add_executable (ncdf_eh_one_test EXCLUDE_FROM_ALL
+  ncdf_eh_one_test.F90)
+set_property(TARGET ncdf_eh_one_test PROPERTY LINKER_LANGUAGE ${PIO_LINKER_LANGUAGE})
+target_link_libraries (ncdf_eh_one_test pio_tutil piof)
+add_dependencies (ncdf_eh_one_test pio_tutil)
+add_dependencies (tests ncdf_eh_one_test)
+
+add_pio_test(ncdf_eh_one_test_bcast
+  EXECUTABLE ${CMAKE_CURRENT_BINARY_DIR}/ncdf_eh_one_test
+  ARGUMENTS --pio-tf-err-handler=PIO_BCAST_ERROR
+  MINNUMPROCS 4
+  MAXNUMPROCS ${PIO_TF_MAXNUMPROCS}
+  MINNUMIOPROCS 2
+  MAXNUMIOPROCS ${PIO_TF_C2_MAXNUMIOPROCS}
+  MINSTRIDE 1
+  MAXSTRIDE ${PIO_TF_C2_MAXSTRIDE}
+  TIMEOUT ${DEFAULT_TEST_TIMEOUT})
+
+add_pio_test(ncdf_eh_one_test_reduce
+  EXECUTABLE ${CMAKE_CURRENT_BINARY_DIR}/ncdf_eh_one_test
+  ARGUMENTS --pio-tf-err-handler=PIO_REDUCE_ERROR
+  MINNUMPROCS 4
+  MAXNUMPROCS ${PIO_TF_MAXNUMPROCS}
+  MINNUMIOPROCS 2
+  MAXNUMIOPROCS ${PIO_TF_C2_MAXNUMIOPROCS}
+  MINSTRIDE 1
+  MAXSTRIDE ${PIO_TF_C2_MAXSTRIDE}
+  TIMEOUT ${DEFAULT_TEST_TIMEOUT})
+
+add_pio_test(ncdf_eh_one_test_ret
+  EXECUTABLE ${CMAKE_CURRENT_BINARY_DIR}/ncdf_eh_one_test
+  ARGUMENTS --pio-tf-err-handler=PIO_RETURN_ERROR
+  MINNUMPROCS 4
+  MAXNUMPROCS ${PIO_TF_MAXNUMPROCS}
+  MINNUMIOPROCS 2
+  MAXNUMIOPROCS ${PIO_TF_C2_MAXNUMIOPROCS}
+  MINSTRIDE 1
+  MAXSTRIDE ${PIO_TF_C2_MAXSTRIDE}
+  TIMEOUT ${DEFAULT_TEST_TIMEOUT})
+
+add_pio_test(ncdf_eh_one_test_intrnl_pnet
+  EXECUTABLE ${CMAKE_CURRENT_BINARY_DIR}/ncdf_eh_one_test
+  ARGUMENTS --pio-tf-err-handler=PIO_INTERNAL_ERROR --pio-tf-targ-iotype=PNETCDF
+  MINNUMPROCS 4
+  MAXNUMPROCS ${PIO_TF_MAXNUMPROCS}
+  MINNUMIOPROCS 2
+  MAXNUMIOPROCS ${PIO_TF_C2_MAXNUMIOPROCS}
+  MINSTRIDE 1
+  MAXSTRIDE ${PIO_TF_C2_MAXSTRIDE}
+  TIMEOUT ${DEFAULT_TEST_TIMEOUT}
+  WILLFAIL)
+
+add_pio_test(ncdf_eh_one_test_intrnl_net
+  EXECUTABLE ${CMAKE_CURRENT_BINARY_DIR}/ncdf_eh_one_test
+  ARGUMENTS --pio-tf-err-handler=PIO_INTERNAL_ERROR --pio-tf-targ-iotype=NETCDF
+  MINNUMPROCS 4
+  MAXNUMPROCS ${PIO_TF_MAXNUMPROCS}
+  MINNUMIOPROCS 2
+  MAXNUMIOPROCS ${PIO_TF_C2_MAXNUMIOPROCS}
+  MINSTRIDE 1
+  MAXSTRIDE ${PIO_TF_C2_MAXSTRIDE}
+  TIMEOUT ${DEFAULT_TEST_TIMEOUT}
+  WILLFAIL)
+
+add_pio_test(ncdf_eh_one_test_intrnl_net4c
+  EXECUTABLE ${CMAKE_CURRENT_BINARY_DIR}/ncdf_eh_one_test
+  ARGUMENTS --pio-tf-err-handler=PIO_INTERNAL_ERROR --pio-tf-targ-iotype=NETCDF4C
+  MINNUMPROCS 4
+  MAXNUMPROCS ${PIO_TF_MAXNUMPROCS}
+  MINNUMIOPROCS 2
+  MAXNUMIOPROCS ${PIO_TF_C2_MAXNUMIOPROCS}
+  MINSTRIDE 1
+  MAXSTRIDE ${PIO_TF_C2_MAXSTRIDE}
+  TIMEOUT ${DEFAULT_TEST_TIMEOUT}
+  WILLFAIL)
+
+add_pio_test(ncdf_eh_one_test_intrnl_net4p
+  EXECUTABLE ${CMAKE_CURRENT_BINARY_DIR}/ncdf_eh_one_test
+  ARGUMENTS --pio-tf-err-handler=PIO_INTERNAL_ERROR --pio-tf-targ-iotype=NETCDF4P
+  MINNUMPROCS 4
+  MAXNUMPROCS ${PIO_TF_MAXNUMPROCS}
+  MINNUMIOPROCS 2
+  MAXNUMIOPROCS ${PIO_TF_C2_MAXNUMIOPROCS}
+  MINSTRIDE 1
+  MAXSTRIDE ${PIO_TF_C2_MAXSTRIDE}
+  TIMEOUT ${DEFAULT_TEST_TIMEOUT}
+  WILLFAIL)
+
+add_pio_test(ncdf_eh_one_test_intrnl_ad
+  EXECUTABLE ${CMAKE_CURRENT_BINARY_DIR}/ncdf_eh_one_test
+  ARGUMENTS --pio-tf-err-handler=PIO_INTERNAL_ERROR --pio-tf-targ-iotype=ADIOS
+  MINNUMPROCS 4
+  MAXNUMPROCS ${PIO_TF_MAXNUMPROCS}
+  MINNUMIOPROCS 2
+  MAXNUMIOPROCS ${PIO_TF_C2_MAXNUMIOPROCS}
+  MINSTRIDE 1
+  MAXSTRIDE ${PIO_TF_C2_MAXSTRIDE}
+  TIMEOUT ${DEFAULT_TEST_TIMEOUT}
+  WILLFAIL)
 
 #===== ncdf_inq =====
 add_executable (ncdf_inq EXCLUDE_FROM_ALL

--- a/tests/general/ncdf_eh_one_test.F90.in
+++ b/tests/general/ncdf_eh_one_test.F90.in
@@ -9,17 +9,32 @@ END MODULE ncdf_eh_tgv
 
 PIO_TF_AUTO_TEST_SUB_BEGIN test_clob_then_no_clob
   use ncdf_eh_tgv
+  use mpi
   Implicit none
   type(file_desc_t) :: pio_file
   character(len=PIO_TF_MAX_STR_LEN), parameter :: clob_fname = "pio_clob_test_file.nc"
-  integer :: ret
+  integer :: cur_err_handler
+  integer :: ret, ierr
 
   ret = PIO_createfile(pio_tf_iosystem_, pio_file, tgv_iotype, clob_fname, PIO_CLOBBER)
   PIO_TF_CHECK_ERR(ret, "Failed to create:" // trim(clob_fname))
 
   call PIO_closefile(pio_file)
 
+  ! Get the current error handler
+  call PIO_seterrorhandling(pio_tf_iosystem_, PIO_BCAST_ERROR, cur_err_handler)
+  call PIO_seterrorhandling(pio_tf_iosystem_, cur_err_handler)
+
   ret = PIO_createfile(pio_tf_iosystem_, pio_file, tgv_iotype, clob_fname, PIO_NOCLOBBER)
+  if(cur_err_handler == PIO_RETURN_ERROR) then
+    ! If the error handler is set to PIO_RETURN_ERROR the error code from the current process
+    ! is returned back to the user
+    ! So some processes, the non I/O processes, will not see the error code from other
+    ! processes, the I/O processes
+    ! Reduce the return value to find if any process received an error
+    call MPI_Allreduce(MPI_IN_PLACE, ret, 1, MPI_INTEGER, MPI_MIN, pio_tf_comm_, ierr)
+    PIO_TF_CHECK_ERR(ierr, "MPI Allreduce on return value failed (error handler = PIO_RETURN_ERROR)")
+  end if
   PIO_TF_PASSERT(ret /= PIO_NOERR, "Create file with clobber then no clobber did not fail as expected")
 
   ! No close since createfile should fail

--- a/tests/general/ncdf_eh_one_test.F90.in
+++ b/tests/general/ncdf_eh_one_test.F90.in
@@ -1,0 +1,80 @@
+MODULE ncdf_eh_tgv
+  use pio_tutil
+  implicit none
+
+  ! tgv = test global vars
+  character(len=PIO_TF_MAX_STR_LEN), parameter :: tgv_fname = "pio_ncdf_test_file.nc"
+  integer :: tgv_iotype
+END MODULE ncdf_eh_tgv
+
+PIO_TF_AUTO_TEST_SUB_BEGIN test_clob_then_no_clob
+  use ncdf_eh_tgv
+  Implicit none
+  type(file_desc_t) :: pio_file
+  character(len=PIO_TF_MAX_STR_LEN), parameter :: clob_fname = "pio_clob_test_file.nc"
+  integer :: ret
+
+  ret = PIO_createfile(pio_tf_iosystem_, pio_file, tgv_iotype, clob_fname, PIO_CLOBBER)
+  PIO_TF_CHECK_ERR(ret, "Failed to create:" // trim(clob_fname))
+
+  call PIO_closefile(pio_file)
+
+  ret = PIO_createfile(pio_tf_iosystem_, pio_file, tgv_iotype, clob_fname, PIO_NOCLOBBER)
+  PIO_TF_PASSERT(ret /= PIO_NOERR, "Create file with clobber then no clobber did not fail as expected")
+
+  ! No close since createfile should fail
+  call PIO_deletefile(pio_tf_iosystem_, clob_fname)
+
+PIO_TF_AUTO_TEST_SUB_END test_clob_then_no_clob
+
+PIO_TF_TEST_DRIVER_BEGIN
+  use ncdf_eh_tgv
+  Implicit none
+  type(file_desc_t) :: pio_file
+  integer :: ret, i
+  ! iotypes = valid NC types
+  integer, dimension(:), allocatable :: iotypes
+  character(len=PIO_TF_MAX_STR_LEN), dimension(:), allocatable :: iotype_descs
+  logical :: iotype_specified
+  character(len=PIO_TF_MAX_STR_LEN) :: user_iotype_str
+  integer :: user_iotype, num_iotypes
+
+  num_iotypes = 0
+
+  iotype_specified = PIO_TF_Get_test_arg("--pio-tf-targ-iotype", user_iotype_str)
+  ! If the user specified an iotype test it, otherwise test all supported iotypes
+  ! Note: The iotype specified by the user could be an unsupported iotype, however
+  ! since we are testing error handlers here using an unsupported iotype would
+  ! just generate another error
+  if(iotype_specified) then
+    num_iotypes = 1
+    allocate(iotypes(num_iotypes))
+    allocate(iotype_descs(num_iotypes))
+
+    user_iotype = PIO_TF_Iotype_from_str(user_iotype_str)
+    iotypes(1) = user_iotype
+    iotype_descs(1) = user_iotype_str
+  else
+    call PIO_TF_Get_nc_iotypes(iotypes, iotype_descs, num_iotypes)
+  end if
+
+  do i=1,num_iotypes
+    tgv_iotype = iotypes(i)
+    ret = PIO_createfile(pio_tf_iosystem_, pio_file, tgv_iotype, tgv_fname)
+    PIO_TF_CHECK_ERR(ret,&
+      "Failed to create:"//trim(iotype_descs(i))//":"//trim(tgv_fname))
+
+    call PIO_closefile(pio_file)
+
+    ! Make sure that global variables are set correctly before running the tests
+    PIO_TF_AUTO_TESTS_RUN(trim(iotype_descs(i)))
+
+    call PIO_deletefile(pio_tf_iosystem_, tgv_fname)
+  end do
+
+  if(allocated(iotypes)) then
+    deallocate(iotypes)
+    deallocate(iotype_descs)
+  end if
+
+PIO_TF_TEST_DRIVER_END

--- a/tests/general/util/pio_tutil.F90
+++ b/tests/general/util/pio_tutil.F90
@@ -78,6 +78,7 @@ MODULE pio_tutil
   PUBLIC  :: PIO_TF_Get_data_types
   PUBLIC  :: PIO_TF_Check_val_
   PUBLIC  :: PIO_TF_Get_test_arg
+  PUBLIC  :: PIO_TF_Iotype_from_str
   ! Private functions
   PRIVATE :: PIO_TF_Check_int_arr_arr_
   PRIVATE :: PIO_TF_Check_int_arr_val, PIO_TF_Check_int_arr_arr
@@ -1187,6 +1188,44 @@ CONTAINS
       PRINT *, "PIO_TF: Invalid error handler specified, resetting to PIO_BCAST_ERROR..."
     END IF
   END FUNCTION
+
+  ! Convert iotype string to internal type (integer)
+  INTEGER FUNCTION PIO_TF_Iotype_from_str(iotype_str)
+    CHARACTER(LEN=*), INTENT(IN) :: iotype_str
+    CHARACTER(LEN=PIO_TF_MAX_STR_LEN) :: str
+
+    str = trim(iotype_str)
+
+    PIO_TF_Iotype_from_str = PIO_IOTYPE_PNETCDF
+    IF((str == "PIO_IOTYPE_PNETCDF") .OR.&
+        (str == "pio_iotype_pnetcdf") .OR.&
+        (str == "pnetcdf") .OR.&
+        (str == "PNETCDF")) THEN
+      PIO_TF_Iotype_from_str = PIO_IOTYPE_PNETCDF
+    ELSE IF((str == "PIO_IOTYPE_NETCDF") .OR.&
+        (str == "pio_iotype_netcdf") .OR.&
+        (str == "netcdf") .OR.&
+        (str == "NETCDF")) THEN
+      PIO_TF_Iotype_from_str = PIO_IOTYPE_NETCDF
+    ELSE IF((str == "PIO_IOTYPE_NETCDF4C") .OR.&
+        (str == "pio_iotype_netcdf4c") .OR.&
+        (str == "netcdf4c") .OR.&
+        (str == "NETCDF4C")) THEN
+      PIO_TF_Iotype_from_str = PIO_IOTYPE_NETCDF4C
+    ELSE IF((str == "PIO_IOTYPE_NETCDF4P") .OR.&
+        (str == "pio_iotype_netcdf4p") .OR.&
+        (str == "netcdf4p") .OR.&
+        (str == "NETCDF4P")) THEN
+      PIO_TF_Iotype_from_str = PIO_IOTYPE_NETCDF4P
+    ELSE IF((str == "PIO_IOTYPE_ADIOS") .OR.&
+        (str == "pio_iotype_adios") .OR.&
+        (str == "adios") .OR.&
+        (str == "ADIOS")) THEN
+      PIO_TF_Iotype_from_str = PIO_IOTYPE_ADIOS
+    ELSE
+      PRINT *, "PIO_TF: Invalid iotype specified,", trim(iotype_str), "), resetting to PIO_IOTYPE_PNETCDF..."
+    END IF
+  END FUNCTION PIO_TF_Iotype_from_str
 
   ! This function is be used by unit tests to get args for the unit test
   ! All unit test args start with "--pio-tf-targ" e.g. "--pio-tf-targ-uarg1=uarg_val"

--- a/tests/general/util/pio_tutil.F90
+++ b/tests/general/util/pio_tutil.F90
@@ -15,16 +15,29 @@ MODULE pio_tutil
     ENUMERATOR  ::  IARG_NUM_AGGREGATORS_SIDX
     ENUMERATOR  ::  IARG_LOG_LEVEL_SIDX
     ENUMERATOR  ::  IARG_ERR_HANDLER_SIDX
+    ENUMERATOR  ::  IARG_NUM_TEST_ARGS_SIDX
     ! Unfortunately since fortran starts with index 1 we need the
     ! hack below. Don't forget to update when adding more argvs
-    ENUMERATOR  ::  NUM_IARGS = IARG_ERR_HANDLER_SIDX
+    ENUMERATOR  ::  NUM_IARGS = IARG_NUM_TEST_ARGS_SIDX
     ENUMERATOR  ::  IARG_MAX_SIDX = NUM_IARGS
   END ENUM
+
+  ! Misc constants
+  INTEGER, PARAMETER :: PIO_TF_MAX_STR_LEN=128
 
   ! PIO specific info
   INTEGER :: pio_tf_stride_, pio_tf_num_io_tasks_, pio_tf_num_aggregators_
   INTEGER :: pio_tf_err_handler_
   TYPE(iosystem_desc_t), save :: pio_tf_iosystem_
+
+  ! Arguments that start with "--pio-tf-targ" are cached and eventually
+  ! used by the unit tests
+  INTEGER, PARAMETER :: PIO_TF_MAX_CACHED_TEST_ARGS = 10
+  ! Caching arg in the ith index and the corresponding val in (i+1)
+  ! Packing the cached test args into a simple array (instead of a type) makes
+  ! it easy to send to other procs
+  CHARACTER(LEN=PIO_TF_MAX_STR_LEN) :: pio_tf_cached_test_args_(PIO_TF_MAX_CACHED_TEST_ARGS * 2)
+  INTEGER :: pio_tf_num_cached_test_args_
 
   ! MPI info
   INTEGER ::  pio_tf_world_rank_, pio_tf_world_sz_
@@ -34,9 +47,6 @@ MODULE pio_tutil
   ! REAL types
   INTEGER, PARAMETER, PUBLIC :: fc_real   = selected_real_kind(6)
   INTEGER, PARAMETER, PUBLIC :: fc_double = selected_real_kind(13)
-
-  ! Misc constants
-  INTEGER, PARAMETER :: PIO_TF_MAX_STR_LEN=128
 
   ! Logging
   INTEGER :: pio_tf_log_level_
@@ -67,6 +77,7 @@ MODULE pio_tutil
   PUBLIC  :: PIO_TF_Get_iotypes, PIO_TF_Get_undef_iotypes
   PUBLIC  :: PIO_TF_Get_data_types
   PUBLIC  :: PIO_TF_Check_val_
+  PUBLIC  :: PIO_TF_Get_test_arg
   ! Private functions
   PRIVATE :: PIO_TF_Check_int_arr_arr_
   PRIVATE :: PIO_TF_Check_int_arr_val, PIO_TF_Check_int_arr_arr
@@ -1177,12 +1188,36 @@ CONTAINS
     END IF
   END FUNCTION
 
+  ! This function is be used by unit tests to get args for the unit test
+  ! All unit test args start with "--pio-tf-targ" e.g. "--pio-tf-targ-uarg1=uarg_val"
+  LOGICAL FUNCTION PIO_TF_Get_test_arg(arg, val)
+    CHARACTER(LEN=*), INTENT(IN)  :: arg
+    CHARACTER(LEN=*), INTENT(OUT)  :: val
+    INTEGER :: i
+    LOGICAL :: ret = .FALSE.
+
+    DO i=1,pio_tf_num_cached_test_args_,2
+      ! pio_tf_cached_test_args_(i) contains the arg and
+      ! pio_tf_cached_test_args_(i+1) contains the corresponding
+      ! val
+      IF(trim(pio_tf_cached_test_args_(i)) == trim(arg)) THEN
+        val = pio_tf_cached_test_args_(i+1)
+        ret = .TRUE.
+        EXIT
+      END IF
+    END DO
+
+    PIO_TF_Get_test_arg = ret
+  END FUNCTION PIO_TF_Get_test_arg
+
   ! Parse and process input arguments like "--pio-tf-stride=2" passed
   ! to the unit tests - PRIVATE function
   ! FIXME: Do we need to move input argument processing to a new module?
   SUBROUTINE Parse_and_process_input(argv)
     CHARACTER(LEN=*), INTENT(IN)  :: argv
+
     CHARACTER(LEN=PIO_TF_MAX_STR_LEN) :: err_handler_str
+    CHARACTER(LEN=*), PARAMETER :: PIO_TF_TARG_PREFIX = "--pio-tf-targ"
     INTEGER :: pos
 
     ! All input arguments are of the form <INPUT_ARG_NAME>=<INPUT_ARG>
@@ -1190,10 +1225,13 @@ CONTAINS
     pos = INDEX(argv, "=")
     IF (pos == 0) THEN
       ! Ignore unrecognized args
-      RETURN
+      PRINT *, "PIO_TF: WARNING: Ignoring unrecognized arg (", trim(argv), ")"
     ELSE
       ! Check if it an input to PIO testing framework
-      IF (argv(:pos) == "--pio-tf-num-io-tasks=") THEN
+      IF (LEN_TRIM(argv(pos:)) == 1) THEN
+        ! Argument is of the form "--pio-tf-arg=" i.e., no value for the arg
+        PRINT *, "PIO_TF: WARNING: Ignoring unrecognized arg (", trim(argv), ")"
+      ELSE IF (argv(:pos) == "--pio-tf-num-io-tasks=") THEN
         READ(argv(pos+1:), *) pio_tf_num_io_tasks_
       ELSE IF (argv(:pos) == "--pio-tf-num-aggregators=") THEN
         READ(argv(pos+1:), *) pio_tf_num_aggregators_
@@ -1205,7 +1243,25 @@ CONTAINS
         READ(argv(pos+1:), *) err_handler_str
         pio_tf_err_handler_ = Error_handler_from_str(err_handler_str)
       ELSE IF (argv(:pos) == "--pio-tf-input-file=") THEN
-        PRINT *, "This option is not implemented yet"
+        PRINT *, "PIO_TF: WARNING: This option is not implemented yet"
+      ELSE IF (pos > LEN(PIO_TF_TARG_PREFIX)) THEN
+        IF (argv(:LEN(PIO_TF_TARG_PREFIX)) == PIO_TF_TARG_PREFIX) THEN
+          IF (pio_tf_num_cached_test_args_ < PIO_TF_MAX_CACHED_TEST_ARGS) THEN
+            pio_tf_num_cached_test_args_ = pio_tf_num_cached_test_args_ + 1
+            ! Argument value
+            READ(argv(pos+1:), *) pio_tf_cached_test_args_(pio_tf_num_cached_test_args_ * 2)
+            ! Argument
+            READ(argv(:pos-1), *) pio_tf_cached_test_args_(pio_tf_num_cached_test_args_ * 2 - 1)
+          ELSE
+            PRINT *, "PIO_TF: WARNING: Exceeded buffer space for caching args. Ignoring unrecognized arg (", trim(argv), ")"
+          END IF
+        ELSE
+          ! Ignore unrecognized args
+          PRINT *, "PIO_TF: WARNING: Ignoring unrecognized arg (", trim(argv), ")"
+        END IF
+      ELSE
+        ! Ignore unrecognized args
+        PRINT *, "PIO_TF: WARNING: Ignoring unrecognized arg (", trim(argv), ")"
       END IF
     END IF
 
@@ -1225,6 +1281,7 @@ CONTAINS
     ! Need to send pio_tf_stride_, pio_tf_num_io_tasks_, pio_tf_num_aggregators_
     INTEGER :: send_buf(NUM_IARGS)
 
+    pio_tf_num_cached_test_args_ = 0
     IF (pio_tf_world_rank_ == 0) THEN
       nargs = COMMAND_ARGUMENT_COUNT()
       DO i=1, nargs
@@ -1236,9 +1293,16 @@ CONTAINS
       send_buf(IARG_NUM_AGGREGATORS_SIDX) = pio_tf_num_aggregators_
       send_buf(IARG_LOG_LEVEL_SIDX) = pio_tf_log_level_
       send_buf(IARG_ERR_HANDLER_SIDX) = pio_tf_err_handler_
+      send_buf(IARG_NUM_TEST_ARGS_SIDX) = pio_tf_num_cached_test_args_
     END IF
     ! Make sure all processes get the input args
     CALL MPI_BCAST(send_buf, NUM_IARGS, MPI_INTEGER, 0, pio_tf_comm_, ierr)
+
+    pio_tf_num_cached_test_args_ = send_buf(IARG_NUM_TEST_ARGS_SIDX)
+    IF (pio_tf_num_cached_test_args_ > 0) THEN
+      CALL MPI_BCAST(pio_tf_cached_test_args_, PIO_TF_MAX_STR_LEN * pio_tf_num_cached_test_args_ * 2, MPI_CHARACTER, 0, pio_tf_comm_, ierr)
+    END IF
+
     pio_tf_stride_ = send_buf(IARG_STRIDE_SIDX)
     pio_tf_num_io_tasks_ = send_buf(IARG_NUM_IO_TASKS_SIDX)
     pio_tf_num_aggregators_ = send_buf(IARG_NUM_AGGREGATORS_SIDX)


### PR DESCRIPTION
Adding more tests for the different error handlers supported
by Scorpio.

Also adding the filename in the error message when a call
fails and the error handler is set to PIO_INTERNAL_ERROR

Fixes #427 