### PR TITLE
Updating the format in I/O performance summary expected files

### DIFF
--- a/src/clib/io_perf_summary.json_expected
+++ b/src/clib/io_perf_summary.json_expected
@@ -2,46 +2,56 @@
   "ScorpioIOSummaryStatistics" : {
     "OverallModelIOStatistics" : {
       "name" : "E3SM",
-      "avg_wtput" : 2.5,
-      "avg_rtput" : 1.5,
-      "tot_wb" : 1024,
-      "tot_rb" : 1024,
-      "tot_wtime" : 234
+      "avg_wtput(MB/s)" : 2.5,
+      "avg_rtput(MB/s)" : 1.5,
+      "tot_wb(bytes)" : 1024,
+      "tot_rb(bytes)" : 1024,
+      "tot_wtime(s)" : 0.4,
+      "tot_rtime(s)" : 0.67,
+      "tot_time(s)" : 1.07
     },
     "ModelComponentIOStatistics" : [
       {
-        "name" : "EAM",
-        "avg_wtput" : 2.5,
-        "avg_rtput" : 1.5,
-        "tot_wb" : 1024,
-        "tot_rb" : 1024,
-        "tot_wtime" : 234
+        "name" : "COMP_CPL: CPL",
+        "avg_wtput(MB/s)" : 2.5,
+        "avg_rtput(MB/s)" : 1.5,
+        "tot_wb(bytes)" : 512,
+        "tot_rb(bytes)" : 512,
+        "tot_wtime(s)" : 0.2,
+        "tot_rtime(s)" : 0.34,
+        "tot_time(s)" : 0.54
       },
       {
-        "name" : "LND",
-        "avg_wtput" : 2.5,
-        "avg_rtput" : 1.5,
-        "tot_wb" : 1024,
-        "tot_rb" : 1024,
-        "tot_wtime" : 234
+        "name" : "COMP_ATM: EAM",
+        "avg_wtput(MB/s)" : 2.5,
+        "avg_rtput(MB/s)" : 1.5,
+        "tot_wb(bytes)" : 512,
+        "tot_rb(bytes)" : 512,
+        "tot_wtime(s)" : 0.2,
+        "tot_rtime(s)" : 0.34,
+        "tot_time(s)" : 0.54
       }
     ],
     "FileIOStatistics" : [
       {
         "name" : "file1.nc",
-        "avg_wtput" : 2.5,
-        "avg_rtput" : 1.5,
-        "tot_wb" : 1024,
-        "tot_rb" : 1024,
-        "tot_wtime" : 234
+        "avg_wtput(MB/s)" : 2.5,
+        "avg_rtput(MB/s)" : 1.5,
+        "tot_wb(bytes)" : 512,
+        "tot_rb(bytes)" : 512,
+        "tot_wtime(s)" : 0.2,
+        "tot_rtime(s)" : 0.34,
+        "tot_time(s)" : 0.54
       },
       {
         "name" : "file2.nc",
-        "avg_wtput" : 2.5,
-        "avg_rtput" : 1.5,
-        "tot_wb" : 1024,
-        "tot_rb" : 1024,
-        "tot_wtime" : 234
+        "avg_wtput(MB/s)" : 2.5,
+        "avg_rtput(MB/s)" : 1.5,
+        "tot_wb(bytes)" : 512,
+        "tot_rb(bytes)" : 512,
+        "tot_wtime(s)" : 0.2,
+        "tot_rtime(s)" : 0.34,
+        "tot_time(s)" : 0.54
       }
     ]
   }

--- a/src/clib/io_perf_summary.text_expected
+++ b/src/clib/io_perf_summary.text_expected
@@ -5,42 +5,42 @@
       "avg_rtput(MB/s)" : 1.5,
       "tot_wb(bytes)" : 1024,
       "tot_rb(bytes)" : 1024,
-      "tot_wtime(s)" : 234
-      "tot_rtime(s)" : 234
-      "tot_time(s)" : 512
+      "tot_wtime(s)" : 0.4,
+      "tot_rtime(s)" : 0.67,
+      "tot_time(s)" : 1.07
     "ModelComponentIOStatistics":
-      "name" : "EAM",
+      "name" : "COMP_CPL: CPL",
       "avg_wtput(MB/s)" : 2.5,
       "avg_rtput(MB/s)" : 1.5,
-      "tot_wb(bytes)" : 1024,
-      "tot_rb(bytes)" : 1024,
-      "tot_wtime(s)" : 234
-      "tot_rtime(s)" : 234
-      "tot_time(s)" : 512
+      "tot_wb(bytes)" : 512,
+      "tot_rb(bytes)" : 512,
+      "tot_wtime(s)" : 0.2,
+      "tot_rtime(s)" : 0.34,
+      "tot_time(s)" : 0.54
     "ModelComponentIOStatistics":
-      "name" : "LND",
+      "name" : "COMP_ATM: EAM",
       "avg_wtput(MB/s)" : 2.5,
       "avg_rtput(MB/s)" : 1.5,
-      "tot_wb(bytes)" : 1024,
-      "tot_rb(bytes)" : 1024,
-      "tot_wtime(s)" : 234
-      "tot_rtime(s)" : 234
-      "tot_time(s)" : 512
+      "tot_wb(bytes)" : 512,
+      "tot_rb(bytes)" : 512,
+      "tot_wtime(s)" : 0.2,
+      "tot_rtime(s)" : 0.34,
+      "tot_time(s)" : 0.54
     "FileIOStatistics":
       "name" : "file1.nc",
       "avg_wtput(MB/s)" : 2.5,
       "avg_rtput(MB/s)" : 1.5,
-      "tot_wb(bytes)" : 1024,
-      "tot_rb(bytes)" : 1024,
-      "tot_wtime(s)" : 234
-      "tot_rtime(s)" : 234
-      "tot_time(s)" : 512
+      "tot_wb(bytes)" : 512,
+      "tot_rb(bytes)" : 512,
+      "tot_wtime(s)" : 0.2,
+      "tot_rtime(s)" : 0.34,
+      "tot_time(s)" : 0.54
     "FileIOStatistics":
       "name" : "file2.nc",
       "avg_wtput(MB/s)" : 2.5,
       "avg_rtput(MB/s)" : 1.5,
-      "tot_wb(bytes)" : 1024,
-      "tot_rb(bytes)" : 1024,
-      "tot_wtime(s)" : 234
-      "tot_rtime(s)" : 234
-      "tot_time(s)" : 512
+      "tot_wb(bytes)" : 512,
+      "tot_rb(bytes)" : 512,
+      "tot_wtime(s)" : 0.2,
+      "tot_rtime(s)" : 0.34,
+      "tot_time(s)" : 0.54

--- a/src/clib/io_perf_summary.xml_expected
+++ b/src/clib/io_perf_summary.xml_expected
@@ -5,48 +5,48 @@
     <avg_rtput(MB/s)>1.5</avg_rtput(MB/s)>
     <tot_wb(bytes)>1024</tot_wb(bytes)>
     <tot_rb(bytes)>1024</tot_rb(bytes)>
-    <tot_wtime(s)>234</tot_wtime(s)>
-    <tot_rtime(s)>234</tot_rtime(s)>
-    <tot_time(s)>512</tot_time(s)>
+    <tot_wtime(s)>0.4</tot_wtime(s)>
+    <tot_rtime(s)>0.67</tot_rtime(s)>
+    <tot_time(s)>1.07</tot_time(s)>
   </OverallModelIOStatistics>
   <ModelComponentIOStatistics>
-    <name>"EAM"</name>
+    <name>"COMP_CPL: CPL"</name>
     <avg_wtput(MB/s)>2.5</avg_wtput(MB/s)>
     <avg_rtput(MB/s)>1.5</avg_rtput(MB/s)>
-    <tot_wb(bytes)>1024</tot_wb(bytes)>
-    <tot_rb(bytes)>1024</tot_rb(bytes)>
-    <tot_wtime(s)>234</tot_wtime(s)>
-    <tot_rtime(s)>234</tot_rtime(s)>
-    <tot_time(s)>512</tot_time(s)>
+    <tot_wb(bytes)>512</tot_wb(bytes)>
+    <tot_rb(bytes)>512</tot_rb(bytes)>
+    <tot_wtime(s)>0.2</tot_wtime(s)>
+    <tot_rtime(s)>0.34</tot_rtime(s)>
+    <tot_time(s)>0.54</tot_time(s)>
   </ModelComponentIOStatistics>
   <ModelComponentIOStatistics>
-    <name>"LND"</name>
+    <name>"COMP_ATM: EAM"</name>
     <avg_wtput(MB/s)>2.5</avg_wtput(MB/s)>
     <avg_rtput(MB/s)>1.5</avg_rtput(MB/s)>
-    <tot_wb(bytes)>1024</tot_wb(bytes)>
-    <tot_rb(bytes)>1024</tot_rb(bytes)>
-    <tot_wtime(s)>234</tot_wtime(s)>
-    <tot_rtime(s)>234</tot_rtime(s)>
-    <tot_time(s)>512</tot_time(s)>
+    <tot_wb(bytes)>512</tot_wb(bytes)>
+    <tot_rb(bytes)>512</tot_rb(bytes)>
+    <tot_wtime(s)>0.2</tot_wtime(s)>
+    <tot_rtime(s)>0.34</tot_rtime(s)>
+    <tot_time(s)>0.54</tot_time(s)>
   </ModelComponentIOStatistics>
   <FileIOStatistics>
     <name>"file1.nc"</name>
     <avg_wtput(MB/s)>2.5</avg_wtput(MB/s)>
     <avg_rtput(MB/s)>1.5</avg_rtput(MB/s)>
-    <tot_wb(bytes)>1024</tot_wb(bytes)>
-    <tot_rb(bytes)>1024</tot_rb(bytes)>
-    <tot_wtime(s)>234</tot_wtime(s)>
-    <tot_rtime(s)>234</tot_rtime(s)>
-    <tot_time(s)>512</tot_time(s)>
+    <tot_wb(bytes)>512</tot_wb(bytes)>
+    <tot_rb(bytes)>512</tot_rb(bytes)>
+    <tot_wtime(s)>0.2</tot_wtime(s)>
+    <tot_rtime(s)>0.34</tot_rtime(s)>
+    <tot_time(s)>0.54</tot_time(s)>
   </FileIOStatistics>
   <FileIOStatistics>
     <name>"file2.nc"</name>
     <avg_wtput(MB/s)>2.5</avg_wtput(MB/s)>
     <avg_rtput(MB/s)>1.5</avg_rtput(MB/s)>
-    <tot_wb(bytes)>1024</tot_wb(bytes)>
-    <tot_rb(bytes)>1024</tot_rb(bytes)>
-    <tot_wtime(s)>234</tot_wtime(s)>
-    <tot_rtime(s)>234</tot_rtime(s)>
-    <tot_time(s)>512</tot_time(s)>
+    <tot_wb(bytes)>512</tot_wb(bytes)>
+    <tot_rb(bytes)>512</tot_rb(bytes)>
+    <tot_wtime(s)>0.2</tot_wtime(s)>
+    <tot_rtime(s)>0.34</tot_rtime(s)>
+    <tot_time(s)>0.54</tot_time(s)>
   </FileIOStatistics>
 </ScorpioIOSummaryStatistics>


### PR DESCRIPTION
Updating the I/O performance summary files that includes the
expected output with the latest format (updating format
from v1.2.1 to v1.2.2, see PR #416 for more information).