### PR TITLE
Porting to gcc11

### DIFF
--- a/src/clib/pioc_support.c
+++ b/src/clib/pioc_support.c
@@ -345,6 +345,11 @@ void pio_log(int severity, const char *fmt, ...)
     rem_len = MAX_LOG_MSG - strlen(msg);
     strncpy(ptr, "\n\0", (rem_len > 0) ? rem_len : 0);
 
+    /* Add string delimiter to handle the case where the buffer
+     * is completely filled up
+     */
+    msg[MAX_LOG_MSG - 1] = '\0';
+
     /* Send message to log file. */
     if (LOG_FILE)
     {

--- a/tests/cunit/pio_tests.h
+++ b/tests/cunit/pio_tests.h
@@ -66,11 +66,11 @@
 /** Global err buffer for MPI. When there is an MPI error, this buffer
  * is used to store the error message that is associated with the MPI
  * error. */
-char err_buffer[MPI_MAX_ERROR_STRING];
+static char err_buffer[MPI_MAX_ERROR_STRING];
 
 /** This is the length of the most recent MPI error message, stored
  * int the global error string. */
-int resultlen;
+static int resultlen;
 
 /* Function prototypes. */
 int pio_test_init(int argc, char **argv, int *my_rank, int *ntasks, int target_ntasks, MPI_Comm *test_comm);

--- a/tests/cunit/test_spio_ltimer.cpp
+++ b/tests/cunit/test_spio_ltimer.cpp
@@ -1,4 +1,5 @@
 #include <vector>
+#include <string>
 #include <thread>
 #include <chrono>
 #include <algorithm>

--- a/tests/cunit/test_spio_tree.cpp
+++ b/tests/cunit/test_spio_tree.cpp
@@ -1,4 +1,5 @@
 #include <vector>
+#include <string>
 #include <thread>
 #include <chrono>
 #include <algorithm>

--- a/tests/general/ncdf_eh_one_test.F90.in
+++ b/tests/general/ncdf_eh_one_test.F90.in
@@ -9,8 +9,13 @@ END MODULE ncdf_eh_tgv
 
 PIO_TF_AUTO_TEST_SUB_BEGIN test_clob_then_no_clob
   use ncdf_eh_tgv
+#ifndef NO_MPIMOD
   use mpi
   Implicit none
+#else
+  Implicit none
+  include 'mpif.h'
+#endif
   type(file_desc_t) :: pio_file
   character(len=PIO_TF_MAX_STR_LEN), parameter :: clob_fname = "pio_clob_test_file.nc"
   integer :: cur_err_handler

--- a/tests/general/pio_async_copy_tests.F90.in
+++ b/tests/general/pio_async_copy_tests.F90.in
@@ -4,9 +4,14 @@
 ! Note: The function assumes that there are atleast ncomms
 ! procs
 SUBROUTINE split_world_ncomms(ncomms, new_comm, new_rank, new_size, gcomm_idx)
-  use mpi
   use pio_tutil
+#ifndef NO_MPIMOD
+  use mpi
   implicit none
+#else
+  implicit none
+  include 'mpif.h'
+#endif
   integer, intent(inout) :: ncomms
   integer, intent(inout) :: new_comm
   integer, intent(inout) :: new_rank
@@ -50,9 +55,14 @@ END SUBROUTINE split_world_ncomms
 
 ! Create union comm of all the procs that set join flag true
 SUBROUTINE create_ucomm(gcomm, join_ucomm, ucomm)
-  use mpi
   use pio_tutil
+#ifndef NO_MPIMOD
+  use mpi
   implicit none
+#else
+  implicit none
+  include 'mpif.h'
+#endif
   integer, intent(in) :: gcomm
   logical, intent(in) :: join_ucomm
   integer, intent(out) :: ucomm
@@ -97,8 +107,13 @@ END SUBROUTINE create_ucomm
 ! i.e., comp(i) verifies attributes copied by comp(n-i+1)
 PIO_TF_TEMPLATE<PIO_TF_PREDEF_TYPENAME PIO_TF_DATA_TYPE, PIO_TF_PREDEF_TYPENAME PIO_TF_FC_DATA_TYPE>
 PIO_TF_AUTO_TEST_SUB_BEGIN async_copy_att
+#ifndef NO_MPIMOD
   use mpi
   implicit none
+#else
+  implicit none
+  include 'mpif.h'
+#endif
   ! Number of compute components
   integer, parameter :: NUM_COMPONENTS = 2
   ! Total number of comms = comms for each of NUM_COMPONENTS + io comm

--- a/tests/general/pio_async_decomp_tests.F90.in
+++ b/tests/general/pio_async_decomp_tests.F90.in
@@ -4,9 +4,14 @@
 ! Note: The function assumes that there are atleast ncomms
 ! procs
 SUBROUTINE split_world_ncomms(ncomms, new_comm, new_rank, new_size, gcomm_idx)
-  use mpi
   use pio_tutil
+#ifndef NO_MPIMOD
+  use mpi
   implicit none
+#else
+  implicit none
+  include 'mpif.h'
+#endif
   integer, intent(inout) :: ncomms
   integer, intent(inout) :: new_comm
   integer, intent(inout) :: new_rank
@@ -52,8 +57,13 @@ END SUBROUTINE split_world_ncomms
 ! The test creates 1d decomps for each of the compute procs
 PIO_TF_TEMPLATE<PIO_TF_PREDEF_TYPENAME PIO_TF_DATA_TYPE, PIO_TF_PREDEF_TYPENAME PIO_TF_FC_DATA_TYPE>
 PIO_TF_AUTO_TEST_SUB_BEGIN async_2comp_iodesc_1d
+#ifndef NO_MPIMOD
   use mpi
   implicit none
+#else
+  implicit none
+  include 'mpif.h'
+#endif
   ! Number of compute components
   integer, parameter :: NUM_COMPONENTS = 2
   ! Total number of comms = comms for each of NUM_COMPONENTS + io comm

--- a/tests/general/pio_async_decomp_tests_1d.F90.in
+++ b/tests/general/pio_async_decomp_tests_1d.F90.in
@@ -4,9 +4,14 @@
 ! Note: The function assumes that there are atleast ncomms
 ! procs
 SUBROUTINE split_world_ncomms(ncomms, new_comm, new_rank, new_size, gcomm_idx)
-  use mpi
   use pio_tutil
+#ifndef NO_MPIMOD
+  use mpi
   implicit none
+#else
+  implicit none
+  include 'mpif.h'
+#endif
   integer, intent(inout) :: ncomms
   integer, intent(inout) :: new_comm
   integer, intent(inout) :: new_rank
@@ -55,8 +60,13 @@ END SUBROUTINE split_world_ncomms
 ! 2nd compute comm. Both compute comms share a single io comm
 PIO_TF_TEMPLATE<PIO_TF_PREDEF_TYPENAME PIO_TF_DATA_TYPE, PIO_TF_PREDEF_TYPENAME PIO_TF_FC_DATA_TYPE>
 PIO_TF_AUTO_TEST_SUB_BEGIN async_2comp_wr_1d
+#ifndef NO_MPIMOD
   use mpi
   implicit none
+#else
+  implicit none
+  include 'mpif.h'
+#endif
   ! Number of compute components
   integer, parameter :: NUM_COMPONENTS = 2
   ! Total number of comms = comms for each of NUM_COMPONENTS + io comm

--- a/tests/general/pio_async_file_tests.F90.in
+++ b/tests/general/pio_async_file_tests.F90.in
@@ -4,9 +4,14 @@
 ! Note: The function assumes that there are atleast ncomms
 ! procs
 SUBROUTINE split_world_ncomms(ncomms, new_comm, new_rank, new_size, gcomm_idx)
-  use mpi
   use pio_tutil
+#ifndef NO_MPIMOD
+  use mpi
   implicit none
+#else
+  implicit none
+  include 'mpif.h'
+#endif
   integer, intent(inout) :: ncomms
   integer, intent(inout) :: new_comm
   integer, intent(inout) :: new_rank
@@ -53,8 +58,13 @@ END SUBROUTINE split_world_ncomms
 ! reopens it and reads the header info
 PIO_TF_TEMPLATE<PIO_TF_PREDEF_TYPENAME PIO_TF_DATA_TYPE, PIO_TF_PREDEF_TYPENAME PIO_TF_FC_DATA_TYPE>
 PIO_TF_AUTO_TEST_SUB_BEGIN async_nc_inq_var
+#ifndef NO_MPIMOD
   use mpi
   implicit none
+#else
+  implicit none
+  include 'mpif.h'
+#endif
   ! Number of compute components
   integer, parameter :: NUM_COMPONENTS = 2
   ! Total number of comms = comms for each of NUM_COMPONENTS + io comm

--- a/tests/general/pio_async_init_finalize.F90.in
+++ b/tests/general/pio_async_init_finalize.F90.in
@@ -1,9 +1,14 @@
 ! Split comm world into two comms (one with even procs and the other
 ! with odd procs
 SUBROUTINE split_world_odd_even(new_comm, new_rank, new_size, is_even)
-  use mpi
   use pio_tutil
+#ifndef NO_MPIMOD
+  use mpi
   implicit none
+#else
+  implicit none
+  include 'mpif.h'
+#endif
   integer, intent(inout) :: new_comm
   integer, intent(inout) :: new_rank
   integer, intent(inout) :: new_size
@@ -36,9 +41,14 @@ END SUBROUTINE split_world_odd_even
 ! Note: The function assumes that there are atleast ncomms
 ! procs
 SUBROUTINE split_world_ncomms(ncomms, new_comm, new_rank, new_size, gcomm_idx)
-  use mpi
   use pio_tutil
+#ifndef NO_MPIMOD
+  use mpi
   implicit none
+#else
+  implicit none
+  include 'mpif.h'
+#endif
   integer, intent(inout) :: ncomms
   integer, intent(inout) :: new_comm
   integer, intent(inout) :: new_rank
@@ -82,8 +92,13 @@ END SUBROUTINE split_world_ncomms
 
 ! Async I/O as service test with 1 compute comm and an io comm
 PIO_TF_AUTO_TEST_SUB_BEGIN async_1comp_init_finalize
+#ifndef NO_MPIMOD
   use mpi
   implicit none
+#else
+  implicit none
+  include 'mpif.h'
+#endif
   integer, parameter :: NUM_COMPONENTS = 1
   integer :: comp_comms(NUM_COMPONENTS)
   type(iosystem_desc_t) :: iosys(NUM_COMPONENTS)
@@ -132,8 +147,13 @@ PIO_TF_AUTO_TEST_SUB_END async_1comp_init_finalize
 ! This test uses a different interface (from the test above)
 ! to init the iosystems
 PIO_TF_AUTO_TEST_SUB_BEGIN async_1comp_init_finalize_v2
+#ifndef NO_MPIMOD
   use mpi
   implicit none
+#else
+  implicit none
+  include 'mpif.h'
+#endif
   integer, parameter :: NUM_COMPONENTS = 1
   integer :: comp_comms(NUM_COMPONENTS)
   type(iosystem_desc_t) :: iosys(NUM_COMPONENTS)
@@ -180,8 +200,13 @@ PIO_TF_AUTO_TEST_SUB_END async_1comp_init_finalize_v2
 ! Multiple calls to PIO_init() with alternating compute and
 ! I/O procs
 PIO_TF_AUTO_TEST_SUB_BEGIN async_loop_init_finalize
+#ifndef NO_MPIMOD
   use mpi
   implicit none
+#else
+  implicit none
+  include 'mpif.h'
+#endif
   integer, parameter :: NUM_LOOPS = 5
   integer, parameter :: NUM_COMPONENTS = 1
   integer :: comp_comms(NUM_COMPONENTS)
@@ -237,8 +262,13 @@ PIO_TF_AUTO_TEST_SUB_END async_loop_init_finalize
 
 ! Async I/O as service test with 2 compute comms and 1 io comm
 PIO_TF_AUTO_TEST_SUB_BEGIN async_2comp_init_finalize
+#ifndef NO_MPIMOD
   use mpi
   implicit none
+#else
+  implicit none
+  include 'mpif.h'
+#endif
   ! Number of compute components
   integer, parameter :: NUM_COMPONENTS = 2
   ! Total number of comms = comms for each of NUM_COMPONENTS + io comm

--- a/tests/general/pio_iosystem_tests.F90.in
+++ b/tests/general/pio_iosystem_tests.F90.in
@@ -1,9 +1,14 @@
 ! Split comm world into two comms (one with even procs and the other
 ! with odd procs
 SUBROUTINE split_world_odd_even(new_comm, new_rank, new_size, is_even)
-  use mpi
   use pio_tutil
+#ifndef NO_MPIMOD
+  use mpi
   implicit none
+#else
+  implicit none
+  include 'mpif.h'
+#endif
   integer, intent(inout) :: new_comm
   integer, intent(inout) :: new_rank
   integer, intent(inout) :: new_size
@@ -31,9 +36,14 @@ SUBROUTINE split_world_odd_even(new_comm, new_rank, new_size, is_even)
 END SUBROUTINE split_world_odd_even
 
 SUBROUTINE split_world_only_even(new_comm, new_rank, new_size, is_even)
-  use mpi
   use pio_tutil
+#ifndef NO_MPIMOD
+  use mpi
   implicit none
+#else
+  implicit none
+  include 'mpif.h'
+#endif
   integer, intent(inout) :: new_comm
   integer, intent(inout) :: new_rank
   integer, intent(inout) :: new_size

--- a/tests/general/pio_iosystem_tests2.F90.in
+++ b/tests/general/pio_iosystem_tests2.F90.in
@@ -1,9 +1,14 @@
 ! Split comm world into two comms (one with even procs and the other
 ! with odd procs
 SUBROUTINE split_world_odd_even(new_comm, new_rank, new_size, is_even)
-  use mpi
   use pio_tutil
+#ifndef NO_MPIMOD
+  use mpi
   implicit none
+#else
+  implicit none
+  include 'mpif.h'
+#endif
   integer, intent(inout) :: new_comm
   integer, intent(inout) :: new_rank
   integer, intent(inout) :: new_size
@@ -31,9 +36,14 @@ SUBROUTINE split_world_odd_even(new_comm, new_rank, new_size, is_even)
 END SUBROUTINE split_world_odd_even
 
 SUBROUTINE split_world_only_even(new_comm, new_rank, new_size, is_even)
-  use mpi
   use pio_tutil
+#ifndef NO_MPIMOD
+  use mpi
   implicit none
+#else
+  implicit none
+  include 'mpif.h'
+#endif
   integer, intent(inout) :: new_comm
   integer, intent(inout) :: new_rank
   integer, intent(inout) :: new_size

--- a/tests/general/pio_iosystem_tests3.F90.in
+++ b/tests/general/pio_iosystem_tests3.F90.in
@@ -1,9 +1,14 @@
 ! Split comm world into two comms (even procs and odd procs) and
 ! rank == overlapped_rank included in both comms
 SUBROUTINE split_world_two_with_overlap(new_comms, new_ranks, new_sizes, overlapped_rank)
-  use mpi
   use pio_tutil
+#ifndef NO_MPIMOD
+  use mpi
   implicit none
+#else
+  implicit none
+  include 'mpif.h'
+#endif
   integer, parameter :: NUM_COMMS = 2
   integer, dimension(NUM_COMMS), intent(inout) :: new_comms
   integer, dimension(NUM_COMMS), intent(inout) :: new_ranks
@@ -174,8 +179,13 @@ END SUBROUTINE open_and_check_file
 ! two different iosystems - subset (odd/even) of procs
 ! The two iosystems created overlap at rank=0 (and are disjoint otherwise)
 PIO_TF_AUTO_TEST_SUB_BEGIN three_files_two_iosystems_with_overlap
+#ifndef NO_MPIMOD
   use mpi
   implicit none
+#else
+  implicit none
+  include 'mpif.h'
+#endif
 
   character(len=PIO_TF_MAX_STR_LEN), target :: fname0 = "pio_iosys_test_file0.nc"
   character(len=PIO_TF_MAX_STR_LEN), target :: fname1 = "pio_iosys_test_file1.nc"


### PR DESCRIPTION
Fixing bugs identified while testing with gcc 11.1.0

Also adding support for MPI headers in fortran tests
when MPI modules are not usable/available