### PR TITLE
Disable redef tests for NetCDF4 types

### DIFF
--- a/tests/general/ncdf_fail.F90.in
+++ b/tests/general/ncdf_fail.F90.in
@@ -49,22 +49,41 @@ PIO_TF_AUTO_TEST_SUB_BEGIN test_redef_twice
   use ncdf_fail_tgv
   Implicit none
   type(file_desc_t) :: pio_file
-  integer :: ret
+  integer :: i, ret
+  ! iotypes = valid NC4 types
+  integer, dimension(:), allocatable :: nc4_iotypes
+  character(len=PIO_TF_MAX_STR_LEN), dimension(:), allocatable :: nc4_iotype_descs
+  integer :: num_nc4_iotypes
+  logical :: is_nc4_iotype
 
-  ret = PIO_openfile(pio_tf_iosystem_, pio_file, tgv_iotype, tgv_fname, PIO_write)
-  PIO_TF_CHECK_ERR(ret, "Failed to open:" // trim(tgv_fname))
+  is_nc4_iotype = .false.
+  num_nc4_iotypes = 0
+  call PIO_TF_Get_nc4_iotypes(nc4_iotypes, nc4_iotype_descs, num_nc4_iotypes)
+  do i=1,num_nc4_iotypes
+    if(tgv_iotype == nc4_iotypes(i)) then
+      is_nc4_iotype = .true.
+      exit
+    end if
+  end do
 
-  ! A simple redef and then enddef
-  ret = PIO_redef(pio_file)
-  PIO_TF_CHECK_ERR(ret, "Failed to enter redef mode" // trim(tgv_fname))
+  ! NetCDF4 iotypes do not require an explicit enddef before redef or other calls
+  ! The enddef is implicitly done for the NetCDF4 iotypes.
+  if (.not. is_nc4_iotype) then
+    ret = PIO_openfile(pio_tf_iosystem_, pio_file, tgv_iotype, tgv_fname, PIO_write)
+    PIO_TF_CHECK_ERR(ret, "Failed to open:" // trim(tgv_fname))
 
-  ret = PIO_redef(pio_file)
-  PIO_TF_PASSERT(ret /= PIO_NOERR, "Entering redef twice did not fail as expected")
+    ! A simple redef and then enddef
+    ret = PIO_redef(pio_file)
+    PIO_TF_CHECK_ERR(ret, "Failed to enter redef mode" // trim(tgv_fname))
 
-  ret = PIO_enddef(pio_file)
-  PIO_TF_CHECK_ERR(ret, "Failed to end redef mode" // trim(tgv_fname))
+    ret = PIO_redef(pio_file)
+    PIO_TF_PASSERT(ret /= PIO_NOERR, "Entering redef twice did not fail as expected")
 
-  call PIO_closefile(pio_file)
+    ret = PIO_enddef(pio_file)
+    PIO_TF_CHECK_ERR(ret, "Failed to end redef mode" // trim(tgv_fname))
+
+    call PIO_closefile(pio_file)
+  end if
 
 PIO_TF_AUTO_TEST_SUB_END test_redef_twice
 

--- a/tests/general/util/pio_tutil.F90
+++ b/tests/general/util/pio_tutil.F90
@@ -73,7 +73,8 @@ MODULE pio_tutil
   ! Public functions
   PUBLIC  :: PIO_TF_Init_, PIO_TF_Finalize_, PIO_TF_Passert_
   PUBLIC  :: PIO_TF_Is_netcdf
-  PUBLIC  :: PIO_TF_Get_nc_iotypes, PIO_TF_Get_undef_nc_iotypes
+  PUBLIC  :: PIO_TF_Get_nc_iotypes, PIO_TF_Get_nc4_iotypes
+  PUBLIC  :: PIO_TF_Get_undef_nc_iotypes
   PUBLIC  :: PIO_TF_Get_iotypes, PIO_TF_Get_undef_iotypes
   PUBLIC  :: PIO_TF_Get_data_types
   PUBLIC  :: PIO_TF_Check_val_
@@ -367,6 +368,42 @@ CONTAINS
       ! netcdf
       iotypes(i) = PIO_iotype_netcdf
       iotype_descs(i) = "NETCDF"
+      i = i + 1
+#endif
+  END SUBROUTINE
+
+  ! Returns a list of defined netcdf4 iotypes
+  ! iotypes : After the routine returns contains a list of defined
+  !             netcdf4 types
+  ! iotype_descs : After the routine returns contains description of
+  !                 the netcdf4 types returned in iotypes
+  ! num_iotypes : After the routine returns contains the number of
+  !                 of defined netcdf4 types, i.e., size of iotypes and
+  !                 iotype_descs arrays
+  SUBROUTINE PIO_TF_Get_nc4_iotypes(iotypes, iotype_descs, num_iotypes)
+    INTEGER, DIMENSION(:), ALLOCATABLE, INTENT(OUT) :: iotypes
+    CHARACTER(LEN=*), DIMENSION(:), ALLOCATABLE, INTENT(OUT) :: iotype_descs
+    INTEGER, INTENT(OUT) :: num_iotypes
+    INTEGER :: i
+
+    num_iotypes = 0
+    ! First find the number of io types
+#ifdef _NETCDF4
+      ! netcdf4p, netcdf4c
+      num_iotypes = num_iotypes + 2
+#endif
+
+    ALLOCATE(iotypes(num_iotypes))
+    ALLOCATE(iotype_descs(num_iotypes))
+
+    i = 1
+#ifdef _NETCDF4
+      ! netcdf4p, netcdf4c
+      iotypes(i) = PIO_iotype_netcdf4c
+      iotype_descs(i) = "NETCDF4C"
+      i = i + 1
+      iotypes(i) = PIO_iotype_netcdf4p
+      iotype_descs(i) = "NETCDF4P"
       i = i + 1
 #endif
   END SUBROUTINE

--- a/tests/unit/driver.F90
+++ b/tests/unit/driver.F90
@@ -169,10 +169,11 @@ Program pio_unit_test_driver
         call mpi_barrier(mpi_comm_world,ierr)
         ! netcdf-specific tests
         if (is_netcdf(iotypes(test_id))) then
-
-           if (master_task) write(*,"(3x,A,1x)", advance="no") "testing PIO_redef..."
-           call test_redef(test_id, err_msg)
-           call parse(err_msg, fail_cnt)
+            if (.not. is_netcdf4(iotypes(test_id))) then
+                 if (master_task) write(*,"(3x,A,1x)", advance="no") "testing PIO_redef..."
+                 call test_redef(test_id, err_msg)
+                 call parse(err_msg, fail_cnt)
+            end if
 
            if (master_task) write(*,"(3x,A,1x)", advance="no") "testing PIO_enddef..."
            call test_enddef(test_id, err_msg)

--- a/tests/unit/global_vars.F90
+++ b/tests/unit/global_vars.F90
@@ -54,4 +54,15 @@ module global_vars
 
     End Function is_netcdf
 
+    Function is_netcdf4(iotype)
+
+      integer, intent(in) :: iotype
+      logical             :: is_netcdf4
+
+      is_netcdf4 =  &
+           (iotype.eq.PIO_iotype_netcdf4p) .or. &
+           (iotype.eq.PIO_iotype_netcdf4c)
+
+    End Function is_netcdf4
+
 end module global_vars


### PR DESCRIPTION
For NetCDF4 file iotypes the NetCDF library transparently switches
between define and data modes. So disabling redef tests for
NetCDF4 iotypes