### PR TITLE
Remove some warnings in the C unit tests

### DIFF
--- a/tests/cunit/pio_tests.h
+++ b/tests/cunit/pio_tests.h
@@ -49,6 +49,9 @@
 /** Handle MPI errors. This should only be used with MPI library
  * function calls. */
 #define MPIERR(e) do {                                                  \
+        char err_buffer[MPI_MAX_ERROR_STRING];                          \
+        int resultlen;                                                  \
+                                                                        \
         MPI_Error_string(e, err_buffer, &resultlen);                    \
         fprintf(stderr, "MPI error, line %d, file %s: %s\n", __LINE__, __FILE__, err_buffer); \
         MPI_Finalize();                                                 \
@@ -62,15 +65,6 @@
         MPI_Finalize();                                                 \
         return e;                                                       \
     } while (0)
-
-/** Global err buffer for MPI. When there is an MPI error, this buffer
- * is used to store the error message that is associated with the MPI
- * error. */
-static char err_buffer[MPI_MAX_ERROR_STRING];
-
-/** This is the length of the most recent MPI error message, stored
- * int the global error string. */
-static int resultlen;
 
 /* Function prototypes. */
 int pio_test_init(int argc, char **argv, int *my_rank, int *ntasks, int target_ntasks, MPI_Comm *test_comm);

--- a/tests/cunit/test_decomps.c
+++ b/tests/cunit/test_decomps.c
@@ -321,7 +321,7 @@ int test_decomp_read_write(int iosysid, int ioid, int num_flavors, int *flavor, 
                         return ERR_WRONG;
                 if (iodesc->dimlen[0] != X_DIM_LEN || iodesc->dimlen[1] != Y_DIM_LEN)
                     return ERR_WRONG;
-                printf("%d in my test iodesc->maxiobuflen = %d\n", my_rank, iodesc->maxiobuflen);
+                printf("%d in my test iodesc->maxiobuflen = %lld\n", my_rank, (unsigned long long) (iodesc->maxiobuflen));
             }
         
 

--- a/tests/cunit/test_rearr.c
+++ b/tests/cunit/test_rearr.c
@@ -347,7 +347,7 @@ int test_compute_maxIObuffersize(MPI_Comm test_comm, int my_rank)
         /* Run the function. */
         if ((ret = compute_maxIObuffersize(test_comm, &iodesc)))
             return ret;
-        printf("iodesc.maxiobuflen = %d\n", iodesc.maxiobuflen);
+        printf("iodesc.maxiobuflen = %lld\n", (unsigned long long) (iodesc.maxiobuflen));
         if (iodesc.maxiobuflen != 520)
             return ERR_WRONG;
 

--- a/tests/cunit/test_req_block_wait.c
+++ b/tests/cunit/test_req_block_wait.c
@@ -498,7 +498,6 @@ int test_misc_file_req_blocks(MPI_Comm comm, int rank, int sz)
   int *req_block_ranges = NULL;
   int nreq_blocks = 0;
   int enreq_blocks = 0;
-  int ereq_one_block_ranges[1 * 2];
   int ereq_two_block_ranges[2 * 2];
   int ereq_three_block_ranges[3 * 2];
   int ereq_four_block_ranges[4 * 2];


### PR DESCRIPTION
Remove some warnings in the C unit tests.

* Change scope to avoid unused var warnings
* Remove unused variables
* Use appropriate printf format