### PR TITLE
Migrate nightly builds into ANL CELS General Compute Environment (GCE)

### DIFF
--- a/CTestScript.cmake
+++ b/CTestScript.cmake
@@ -87,6 +87,10 @@ elseif (HOSTNAME MATCHES "^compute001" OR
         HOSTNAME MATCHES "^thrash" OR
         HOSTNAME MATCHES "^vanquish")
     set (HOSTNAME_ID "anlworkstation")
+# Argonne General Compute Environment (GCE)
+elseif (HOSTNAME MATCHES "^compute-240" OR
+        HOSTNAME MATCHES "^compute-386")
+    set (HOSTNAME_ID "anlgce")
 else ()
      if (CMAKE_SYSTEM_NAME MATCHES "Catamount")
         set (HOSTNAME_ID "ncsa")

--- a/ctest/CTestEnvironment-anlgce.cmake
+++ b/ctest/CTestEnvironment-anlgce.cmake
@@ -1,0 +1,85 @@
+#==============================================================================
+#
+#  This file sets the environment variables needed to configure and build
+#  on Argonne General Compute Environment (GCE)
+#
+#==============================================================================
+
+# Assume all package locations (NetCDF, PnetCDF, HDF5, etc) are already
+# set with existing environment variables: NETCDF, PNETCDF, HDF5, etc.
+
+# Define the extra CMake configure options
+set (CTEST_CONFIGURE_OPTIONS "-Wno-dev -DCMAKE_VERBOSE_MAKEFILE=TRUE")
+if (NOT DEFINED ENV{DISABLE_NETCDF})
+    set (CTEST_CONFIGURE_OPTIONS "${CTEST_CONFIGURE_OPTIONS} -DNetCDF_PATH=$ENV{NETCDFROOT}")
+    set (CTEST_CONFIGURE_OPTIONS "${CTEST_CONFIGURE_OPTIONS} -DHDF5_PATH=$ENV{HDF5ROOT}")
+    set (CTEST_CONFIGURE_OPTIONS "${CTEST_CONFIGURE_OPTIONS} -DLIBZ_PATH=$ENV{ZLIBROOT}")
+endif ()
+if (NOT DEFINED ENV{DISABLE_PNETCDF})
+    set (CTEST_CONFIGURE_OPTIONS "${CTEST_CONFIGURE_OPTIONS} -DPnetCDF_PATH=$ENV{PNETCDFROOT}")
+endif ()
+
+# If ENABLE_COVERAGE environment variable is set, then enable code coverage
+if (DEFINED ENV{ENABLE_COVERAGE})
+    set (CTEST_CONFIGURE_OPTIONS "${CTEST_CONFIGURE_OPTIONS} -DPIO_ENABLE_COVERAGE=ON")
+endif ()
+
+# If VALGRIND_CHECK environment variable is set, then enable memory leak check using Valgrind
+if (DEFINED ENV{VALGRIND_CHECK})
+    set (CTEST_CONFIGURE_OPTIONS "${CTEST_CONFIGURE_OPTIONS} -DPIO_VALGRIND_CHECK=ON")
+endif ()
+
+# If USE_MALLOC environment variable is set, then use native malloc (instead of bget package)
+if (DEFINED ENV{USE_MALLOC})
+    set (CTEST_CONFIGURE_OPTIONS "${CTEST_CONFIGURE_OPTIONS} -DPIO_USE_MALLOC=ON")
+endif ()
+
+# If ENABLE_LARGE_TESTS environment variable is set, then enable large (file, processes) tests
+if (DEFINED ENV{ENABLE_LARGE_TESTS})
+    set (CTEST_CONFIGURE_OPTIONS "${CTEST_CONFIGURE_OPTIONS} -DPIO_ENABLE_LARGE_TESTS=ON")
+endif ()
+
+# If DISABLE_PNETCDF environment variable is set, then configure PIO without PnetCDF
+if (DEFINED ENV{DISABLE_PNETCDF})
+    set (CTEST_CONFIGURE_OPTIONS "${CTEST_CONFIGURE_OPTIONS} -DWITH_PNETCDF=OFF")
+endif ()
+
+# If DISABLE_NETCDF environment variable is set, then configure PIO without NetCDF
+if (DEFINED ENV{DISABLE_NETCDF})
+    set (CTEST_CONFIGURE_OPTIONS "${CTEST_CONFIGURE_OPTIONS} -DWITH_NETCDF=OFF")
+endif ()
+
+# If ENABLE_ADIOS environment variable is set, then enable the use of ADIOS type
+if (DEFINED ENV{ENABLE_ADIOS})
+    set (CTEST_CONFIGURE_OPTIONS "${CTEST_CONFIGURE_OPTIONS} -DWITH_ADIOS2=ON")
+endif ()
+
+# If ENABLE_INTERNAL_TIMING environment variable is set, then gather and print GPTL timing stats
+if (DEFINED ENV{ENABLE_INTERNAL_TIMING})
+    set (CTEST_CONFIGURE_OPTIONS "${CTEST_CONFIGURE_OPTIONS} -DPIO_ENABLE_INTERNAL_TIMING=ON")
+endif ()
+
+# If ENABLE_LOGGING environment variable is set, then enable debug logging (large output possible)
+if (DEFINED ENV{ENABLE_LOGGING})
+    set (CTEST_CONFIGURE_OPTIONS "${CTEST_CONFIGURE_OPTIONS} -DPIO_ENABLE_LOGGING=ON")
+endif ()
+
+# If USE_MPISERIAL environment variable is set, then enable mpi-serial support (instead of MPI)
+if (DEFINED ENV{USE_MPISERIAL})
+    set (CTEST_CONFIGURE_OPTIONS "${CTEST_CONFIGURE_OPTIONS} -DPIO_USE_MPISERIAL=ON")
+endif ()
+
+# If MICRO_TIMING environment variable is set, then enable internal micro timers
+if (DEFINED ENV{MICRO_TIMING})
+    set (CTEST_CONFIGURE_OPTIONS "${CTEST_CONFIGURE_OPTIONS} -DPIO_MICRO_TIMING=ON")
+endif ()
+
+# If ENABLE_ADIOS_BP2NC_TEST environment variable is set, then enable testing of BP to NetCDF conversion
+if (DEFINED ENV{ENABLE_ADIOS_BP2NC_TEST})
+    set (CTEST_CONFIGURE_OPTIONS "${CTEST_CONFIGURE_OPTIONS} -DADIOS_BP2NC_TEST=ON")
+endif ()
+
+# If ENABLE_TESTS environment variable is set, then enable the testing builds
+if (DEFINED ENV{ENABLE_TESTS})
+    set (CTEST_CONFIGURE_OPTIONS "${CTEST_CONFIGURE_OPTIONS} -DPIO_ENABLE_TESTS=ON")
+endif ()

--- a/ctest/runcdash-anlgce.sh
+++ b/ctest/runcdash-anlgce.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+
+# Get/Generate the Dashboard Model
+if [ $# -eq 0 ]; then
+	model=Experimental
+else
+	model=$1
+fi
+
+module load gcc/11.1.0-5ikoznk
+module load cmake/3.20.5-yjp2hz6
+
+export PATH=/nfs/gce/projects/climate/software/mpich/3.4.2/gcc-11.1.0/bin:$PATH
+
+export PNETCDFROOT=/nfs/gce/projects/climate/software/pnetcdf/1.12.2/mpich-3.4.2/gcc-11.1.0
+export NETCDFROOT=/nfs/gce/projects/climate/software/netcdf/4.8.1c-4.3.1cxx-4.5.3f-parallel/mpich-3.4.2/gcc-11.1.0
+export HDF5ROOT=/nfs/gce/projects/climate/software/hdf5/1.12.1/mpich-3.4.2/gcc-11.1.0
+export ZLIBROOT=/nfs/gce/software/spack/opt/spack/linux-ubuntu18.04-x86_64/gcc-7.5.0/zlib-1.2.11-smoyzzo
+
+export USE_MALLOC=ON
+export ENABLE_TESTS=ON
+
+export CFLAGS="-fsanitize=address -fno-omit-frame-pointer -O2 -g"
+export CXXFLAGS="-fsanitize=address -fno-omit-frame-pointer -O2 -g"
+export FFLAGS="-fsanitize=address -fno-omit-frame-pointer -O2 -g -fbacktrace -fcheck=bounds -ffpe-trap=invalid,zero,overflow"
+
+export CC=mpicc
+export CXX=mpicxx
+export FC=mpif90
+
+export PIO_DASHBOARD_PROJECT_NAME=ACME_PIO
+export PIO_DASHBOARD_SITE=anlgce-`hostname`
+export PIO_DASHBOARD_ROOT=${PWD}
+export CTEST_SCRIPT_DIRECTORY=${PIO_DASHBOARD_ROOT}/src
+export PIO_DASHBOARD_SOURCE_DIR=${CTEST_SCRIPT_DIRECTORY}
+export PIO_COMPILER_ID=gcc-`gcc --version | head -n 1 | cut -d' ' -f4`
+
+echo "CTEST_SCRIPT_DIRECTORY="${CTEST_SCRIPT_DIRECTORY}
+echo "PIO_DASHBOARD_SOURCE_DIR="${PIO_DASHBOARD_SOURCE_DIR}
+
+if [ ! -d src ]; then
+  git clone --branch develop https://github.com/E3SM-Project/scorpio src
+fi
+cd src
+
+ctest -S CTestScript.cmake,${model} -VV

--- a/ctest/runctest-anlgce.sh
+++ b/ctest/runctest-anlgce.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+#==============================================================================
+#
+#  This script defines how to run CTest on the Argonne General Compute Environment.
+#
+#  This assumes the CTest model name (e.g., "Nightly") is passed to it when
+#  run.
+#
+#==============================================================================
+
+# Get the CTest script directory
+scrdir=$1
+
+# Get the CTest model name
+model=$2
+
+# Run the "ctest" command in another process
+ctest -S ${scrdir}/CTestScript-Test.cmake,${model} -V


### PR DESCRIPTION
The legacy ANL workstations are planned to be retired and we need
to move nightly builds to the newer GCE environment.