### PR TITLE
Use a new CDash site drop location for SCORPIO nightly tests

### DIFF
--- a/CTestConfig.cmake
+++ b/CTestConfig.cmake
@@ -6,7 +6,7 @@
 ##   ENABLE_TESTING()
 ##   INCLUDE(CTest)
 
-set (CTEST_PROJECT_NAME "PIO")
+set (CTEST_PROJECT_NAME "SCORPIO")
 set (CTEST_NIGHTLY_START_TIME "00:00:00 EST")
 
 set (CTEST_DROP_METHOD "http")
@@ -18,7 +18,7 @@ endif ()
 if (DEFINED ENV{PIO_DASHBOARD_PROJECT_NAME})
     set (CTEST_DROP_LOCATION "/submit.php?project=$ENV{PIO_DASHBOARD_PROJECT_NAME}")
 else ()
-    set (CTEST_DROP_LOCATION "/submit.php?project=PIO")
+    set (CTEST_DROP_LOCATION "/submit.php?project=E3SM_SCORPIO")
 endif ()
 set (CTEST_DROP_SITE_CDASH TRUE)
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ For complete documentation, see the HTML documentation in the docs/html director
 ## Nightly Tests
 
 The results of our nightly tests on multiple platforms can be found on our
-cdash site at [http://my.cdash.org/index.php?project=ACME_PIO](http://my.cdash.org/index.php?project=ACME_PIO).
+cdash site at [http://my.cdash.org/index.php?project=E3SM_SCORPIO](http://my.cdash.org/index.php?project=E3SM_SCORPIO).
 
 ## Dependencies
 


### PR DESCRIPTION
Change the default CDash site drop location from PIO to E3SM_SCORPIO.

Also update the URL of submitted nightly tests results in the README file.