### PR TITLE
Fix HAVE_MPI redefinition warning

### DIFF
--- a/src/gptl/gptl.h
+++ b/src/gptl/gptl.h
@@ -19,6 +19,7 @@
 #endif
 
 #ifdef SPMD
+#undef HAVE_MPI
 #define HAVE_MPI
 #endif
 


### PR DESCRIPTION
Undefining HAVE_MPI before defining it (to avoid the
redefinition compiler warning), similar to share/timings/gptl.h
in the E3SM repo