### PR TITLE
Adding version to Scorpio performance summary output files

### DIFF
--- a/src/clib/io_perf_summary.json_expected
+++ b/src/clib/io_perf_summary.json_expected
@@ -2,6 +2,7 @@
   "ScorpioIOSummaryStatistics" : {
     "OverallModelIOStatistics" : {
       "name" : "E3SM",
+      "spio_stats_version" : "1.0.0",
       "avg_wtput(MB/s)" : 2.5,
       "avg_rtput(MB/s)" : 1.5,
       "tot_wb(bytes)" : 1024,

--- a/src/clib/io_perf_summary.schema.json
+++ b/src/clib/io_perf_summary.schema.json
@@ -12,6 +12,10 @@
           "description": "The name of the Model/Component/File",
           "type": "string"
         },
+        "spio_stats_version": {
+          "description": "The version number for the Scorpio I/O performance statistics file format",
+          "type": "string"
+        },
         "avg_wtput(MB/s)": {
           "description": "The average write throughput (MB/s)",
           "type": "number",

--- a/src/clib/io_perf_summary.text_expected
+++ b/src/clib/io_perf_summary.text_expected
@@ -1,6 +1,7 @@
   "ScorpioIOSummaryStatistics":
     "OverallModelIOStatistics":
       "name" : "E3SM",
+      "spio_stats_version" : "1.0.0",
       "avg_wtput(MB/s)" : 2.5,
       "avg_rtput(MB/s)" : 1.5,
       "tot_wb(bytes)" : 1024,

--- a/src/clib/io_perf_summary.xml_expected
+++ b/src/clib/io_perf_summary.xml_expected
@@ -1,6 +1,7 @@
 <ScorpioIOSummaryStatistics>
   <OverallModelIOStatistics>
     <name>"E3SM"</name>
+    <spio_stats_version>"1.0.0"</spio_stats_version>
     <avg_wtput(MB/s)>2.5</avg_wtput(MB/s)>
     <avg_rtput(MB/s)>1.5</avg_rtput(MB/s)>
     <tot_wb(bytes)>1024</tot_wb(bytes)>

--- a/src/clib/spio_io_summary.cpp
+++ b/src/clib/spio_io_summary.cpp
@@ -430,6 +430,7 @@ static int cache_or_print_stats(iosystem_desc_t *ios, int root_proc,
    */
   if((niosys == 1) && (cached_ios_gio_sstats.size() > 0)){
     const std::string model_name = "Scorpio";
+    const std::string spio_stats_version = "1.0.0";
     const std::size_t ONE_MB = 1024 * 1024;
     long long int pid = static_cast<long long int>(getpid());
     /* The summary file name is : "io_perf_summary_<PID>.[txt|json]" */
@@ -453,6 +454,7 @@ static int cache_or_print_stats(iosystem_desc_t *ios, int root_proc,
     /* Add Overall I/O performance statistics */
     std::vector<std::pair<std::string, std::string> > overall_comp_vals;
     PIO_Util::Serializer_Utils::serialize_pack("name", model_name, overall_comp_vals);
+    PIO_Util::Serializer_Utils::serialize_pack("spio_stats_version", spio_stats_version, overall_comp_vals);
     PIO_Util::Serializer_Utils::serialize_pack("avg_wtput(MB/s)",
       (cached_overall_gio_sstats.wtime_max > 0.0) ?
       (cached_overall_gio_sstats.wb_total / (ONE_MB * cached_overall_gio_sstats.wtime_max)) : 0.0,


### PR DESCRIPTION
Adding a version number for the file format used by Scorpio
I/O performance summary files in the output file