### PR TITLE
Reserve some extra space in the header when creating NetCDF files

### DIFF
--- a/cmake/FindNetCDF.cmake
+++ b/cmake/FindNetCDF.cmake
@@ -80,6 +80,9 @@ foreach (NCDFcomp IN LISTS NetCDF_FIND_VALID_COMPONENTS)
 		 set(CMAKE_REQUIRED_LIBRARIES ${NetCDF_C_LIBRARIES})
 		 CHECK_FUNCTION_EXISTS(nc_set_log_level NetCDF_C_LOGGING_ENABLED)
 
+                 # Check if nc__enddef is still available on future NetCDF implementations
+                 CHECK_FUNCTION_EXISTS(nc__enddef NetCDF_C_NC__ENDDEF_EXISTS)
+
             endif ()
 
             # Dependencies

--- a/cmake/FindNetCDF.cmake
+++ b/cmake/FindNetCDF.cmake
@@ -75,14 +75,6 @@ foreach (NCDFcomp IN LISTS NetCDF_FIND_VALID_COMPONENTS)
                              DEFINITIONS -I${NetCDF_C_INCLUDE_DIR}
                              COMMENT "whether NetCDF has parallel support")
 
-                 # Check if logging enabled
-		 set(CMAKE_REQUIRED_INCLUDES ${NetCDF_C_INCLUDE_DIR})
-		 set(CMAKE_REQUIRED_LIBRARIES ${NetCDF_C_LIBRARIES})
-		 CHECK_FUNCTION_EXISTS(nc_set_log_level NetCDF_C_LOGGING_ENABLED)
-
-                 # Check if nc__enddef is still available on future NetCDF implementations
-                 CHECK_FUNCTION_EXISTS(nc__enddef NetCDF_C_NC__ENDDEF_EXISTS)
-
             endif ()
 
             # Dependencies
@@ -141,6 +133,18 @@ foreach (NCDFcomp IN LISTS NetCDF_FIND_VALID_COMPONENTS)
                     list (APPEND NetCDF_Fortran_LIBRARIES ${NetCDF_C_LIBRARIES})
                 endif ()
 
+            endif ()
+
+            # Additional checks after all dependencies are appended
+            if (NCDFcomp STREQUAL C)
+                set(CMAKE_REQUIRED_INCLUDES ${NetCDF_C_INCLUDE_DIR})
+                set(CMAKE_REQUIRED_LIBRARIES ${NetCDF_C_LIBRARIES})
+
+                # Check if logging enabled
+                CHECK_FUNCTION_EXISTS(nc_set_log_level NetCDF_C_LOGGING_ENABLED)
+
+                # Check if nc__enddef is still available on future NetCDF implementations
+                CHECK_FUNCTION_EXISTS(nc__enddef NetCDF_C_NC__ENDDEF_EXISTS)
             endif ()
 
         endif ()

--- a/src/clib/CMakeLists.txt
+++ b/src/clib/CMakeLists.txt
@@ -75,6 +75,10 @@ if (WITH_NETCDF)
       target_compile_definitions (pioc
         PUBLIC LOGGING)
     endif()
+    if (${NetCDF_C_NC__ENDDEF_EXISTS})
+      target_compile_definitions (pioc
+        PUBLIC NETCDF_C_NC__ENDDEF_EXISTS)
+    endif()
   else ()
     message(STATUS "Could not find NetCDF C library, disabling support for NetCDF")
     set(PIO_USE_NETCDF 0)

--- a/src/clib/pioc_support.c
+++ b/src/clib/pioc_support.c
@@ -3375,11 +3375,38 @@ int pioc_change_def(int ncid, int is_enddef)
     {
         LOG((3, "pioc_change_def calling netcdf function file->fh = %d file->do_io = %d iotype = %d",
              file->fh, file->do_io, file->iotype));
+
+        /* NetCDF and PnetCDF by default do not reserve any extra space in
+         * the NetCDF file headers (compactness etc). However this can be a
+         * problem (performance related) when renaming variables etc since
+         * this information is stored in the NetCDF header. Adding more
+         * information into the header requires the libraries to resize the
+         * file, extend the header space and copy the contents of the file
+         * (similar to realloc).
+         *
+         * The solution for the performance issue is to reserve some extra
+         * space in the header when creating NetCDF files. The current calls
+         * to nc_enddef()/ncmpi_enddef() need to be replaced with nc__enddef
+         * ()/ncmpi__enddef() (note the double underscore).
+         */
 #ifdef _PNETCDF
         if (file->iotype == PIO_IOTYPE_PNETCDF)
         {
             if (is_enddef)
-                ierr = ncmpi_enddef(file->fh);
+            {
+                /* Sets the pad at the end of the "header" section. */
+                const MPI_Offset h_minfree = 10 * 1024; /* The recommended size by Charlie Zender (NCO developer) is 10 KB */
+
+                /* Controls the alignment of the beginning of the data section for fixed-size/record variables. */
+                const MPI_Offset v_align = 4; /* For fixed-size variables, needs to be left as the default (4 bytes) */
+                const MPI_Offset r_align = 4; /* For record variables, needs to be left as the default (4 bytes) */
+
+                /* Sets the pad at the end of the data section for fixed-size variables. */
+                const MPI_Offset v_minfree = 0; /* This can be left as default (0) */
+
+                /* ncmpi__enddef has been available since PnetCDF 1.5.0 (PNETCDF_MIN_VER_REQD is currently 1.8.1) */
+                ierr = ncmpi__enddef(file->fh, h_minfree, v_align, v_minfree, r_align);
+            }
             else
                 ierr = ncmpi_redef(file->fh);
         }
@@ -3390,7 +3417,28 @@ int pioc_change_def(int ncid, int is_enddef)
             if (is_enddef)
             {
                 LOG((3, "pioc_change_def calling nc_enddef file->fh = %d", file->fh));
-                ierr = nc_enddef(file->fh);
+                if (file->iotype == PIO_IOTYPE_NETCDF)
+                {
+                    /* Sets the pad at the end of the "header" section. */
+                    const size_t h_minfree = 10 * 1024; /* The recommended size by Charlie Zender (NCO developer) is 10 KB */
+
+                    /* Controls the alignment of the beginning of the data section for fixed-size/record variables. */
+                    const size_t v_align = 4; /* For fixed-size variables, needs to be left as the default (4 bytes) */
+                    const size_t r_align = 4; /* For record variables, needs to be left as the default (4 bytes) */
+
+                    /* Sets the pad at the end of the data section for fixed-size variables. */
+                    const size_t v_minfree = 0; /* This can be left as default (0) */
+
+                    /* nc__enddef has been available since NetCDF 3.x (NETCDF_C_MIN_VER_REQD is currently 4.3.3) */
+                    ierr = nc__enddef(file->fh, h_minfree, v_align, v_minfree, r_align);
+                }
+                else
+                {
+                    /* We still call nc_enddef for NetCDF4 type. According to NCO user guide, nc__enddef will improve speed of
+                     * future metadata expansion with classic and 64bit NetCDF files, though not necessarily with NetCDF4 files.
+                     */
+                    ierr = nc_enddef(file->fh);
+                }
             }
             else
                 ierr = nc_redef(file->fh);

--- a/src/clib/pioc_support.c
+++ b/src/clib/pioc_support.c
@@ -193,7 +193,7 @@ int PIOc_set_log_level(int level)
     /* Set the log level. */
     pio_log_level = level;
 
-#if NETCDF_C_LOGGING_ENABLED
+#ifdef NETCDF_C_LOGGING_ENABLED
     int ret;
     
     /* If netcdf logging is available turn it on starting at level = 4. */
@@ -3419,6 +3419,7 @@ int pioc_change_def(int ncid, int is_enddef)
                 LOG((3, "pioc_change_def calling nc_enddef file->fh = %d", file->fh));
                 if (file->iotype == PIO_IOTYPE_NETCDF)
                 {
+#ifdef NETCDF_C_NC__ENDDEF_EXISTS
                     /* Sets the pad at the end of the "header" section. */
                     const size_t h_minfree = 10 * 1024; /* The recommended size by Charlie Zender (NCO developer) is 10 KB */
 
@@ -3431,6 +3432,10 @@ int pioc_change_def(int ncid, int is_enddef)
 
                     /* nc__enddef has been available since NetCDF 3.x (NETCDF_C_MIN_VER_REQD is currently 4.3.3) */
                     ierr = nc__enddef(file->fh, h_minfree, v_align, v_minfree, r_align);
+#else
+                    /* CAUTION: nc__enddef may not be available on future NetCDF implementations, switch back to nc_enddef. */
+                    ierr = nc_enddef(file->fh);
+#endif
                 }
                 else
                 {

--- a/tools/adios2pio-nm/CMakeLists.txt
+++ b/tools/adios2pio-nm/CMakeLists.txt
@@ -144,6 +144,10 @@ if (NetCDF_C_FOUND)
     target_compile_definitions (adios2pio-nm-lib
       PUBLIC LOGGING)
   endif()
+  if (${NetCDF_C_NC__ENDDEF_EXISTS})
+    target_compile_definitions (pioc
+      PUBLIC NETCDF_C_NC__ENDDEF_EXISTS)
+  endif()
 else ()
   target_compile_definitions (adios2pio-nm-lib
     PUBLIC _NONETCDF)


### PR DESCRIPTION
Reserving extra space (padding) in the NetCDF file header.

NetCDF and PnetCDF by default do not reserve any extra space in
the NetCDF file headers (file compactness). However this can cause
poor performance when renaming variables etc since metadata for
the variables is stored in the NetCDF header. Adding more
information into the header requires the libraries to resize the
file, extend the header space and copy the contents of the file
(similar to realloc).

Fixes #436