### PR TITLE
Remove upper bound on I/O decomposition descriptor ids

### DIFF
--- a/src/clib/CMakeLists.txt
+++ b/src/clib/CMakeLists.txt
@@ -14,7 +14,7 @@ add_library (pioc topology.c pio_mpi_timer.c pio_timer.c pio_file.c
   pioc.c pioc_sc.c pio_spmd.c pio_rearrange.c pio_nc4.c bget.c
   pio_nc.c pio_put_nc.c pio_get_nc.c pio_getput_int.c pio_msg.c pio_varm.c
   pio_darray.c pio_darray_int.c pio_sdecomps_regex.cpp spio_io_summary.cpp
-  spio_ltimer.cpp spio_serializer.cpp)
+  spio_ltimer.cpp spio_serializer.cpp spio_file_mvcache.cpp)
 
 #==============================================================================
 #  FIND EXTERNAL LIBRARIES/DEPENDENCIES

--- a/src/clib/pio.h
+++ b/src/clib/pio.h
@@ -945,7 +945,10 @@ typedef struct file_desc_t
     PIO_Offset wb_pend;
 
     /** Data buffer per IO decomposition for this file. */
-    void *iobuf[PIO_IODESC_MAX_IDS];
+    /** Cache for storing data corresponding to multiple
+     * variables binned on the I/O decomposition used by
+     * the variable */
+    void *mvcache;
 
     /** I/O statistics associated with this file */
     struct spio_io_fstats_summary *io_fstats;

--- a/src/clib/pio_lists.c
+++ b/src/clib/pio_lists.c
@@ -10,6 +10,7 @@
 #endif
 #include <string.h>
 #include <stdio.h>
+#include "spio_file_mvcache.h"
 
 static io_desc_t *pio_iodesc_list = NULL;
 static io_desc_t *current_iodesc = NULL;
@@ -161,6 +162,7 @@ int pio_delete_file_from_list(int ncid)
 
             free(cfile->unlim_dimids);
             free(cfile->io_fstats);
+            spio_file_mvcache_finalize(cfile);
             /* Free the memory used for this file. */
             free(cfile);
             

--- a/src/clib/pioc.c
+++ b/src/clib/pioc.c
@@ -755,19 +755,6 @@ int PIOc_InitDecomp(int iosysid, int pio_type, int ndims, const int *gdimlen, in
     }
     *ioidp = pio_add_to_iodesc_list(iodesc, comm);
 
-    /* Check whether we have exceeded the maximum number of ioids (PIO_IODESC_MAX_IDS).
-     * This limit is necessary since each file uses a sparse pointer array (with a fixed
-     * size of PIO_IODESC_MAX_IDS) to look up a data buffer per ioid.
-     * FIXME: Replace the sparse array with a map or hash map to get rid of this limit
-     */
-    if (*ioidp - PIO_IODESC_START_ID + 1 > PIO_IODESC_MAX_IDS)
-    {
-        GPTLstop("PIO:PIOc_initdecomp");
-        spio_ltimer_stop(ios->io_fstats->tot_timer_name);
-        return pio_err(ios, NULL, PIO_EINTERNAL, __FILE__, __LINE__,
-                       "Initializing the PIO decomposition failed. Maximum number of ioids (limit = %d) has been reached", PIO_IODESC_MAX_IDS);
-    }
-
 #if PIO_SAVE_DECOMPS
     if(pio_save_decomps_regex_match(*ioidp, NULL, NULL))
     {

--- a/src/clib/pioc_support.c
+++ b/src/clib/pioc_support.c
@@ -17,6 +17,7 @@
 #include <dirent.h>
 #endif
 #include "spio_io_summary.h"
+#include "spio_file_mvcache.h"
 
 #define VERSNO 2001
 
@@ -2324,9 +2325,6 @@ int PIOc_createfile_int(int iosysid, int *ncidp, int *iotype, const char *filena
 
     LOG((2, "file->do_io = %d ios->async = %d", file->do_io, ios->async));
 
-    for (int i = 0; i < PIO_IODESC_MAX_IDS; i++)
-        file->iobuf[i] = NULL;
-
     /* If async is in use, and this is not an IO task, bcast the
      * parameters. */
     if (ios->async)
@@ -2759,6 +2757,12 @@ int PIOc_createfile_int(int iosysid, int *ncidp, int *iotype, const char *filena
          */
         comm = ios->union_comm;
     }
+
+    /* Initialize the multi-variable cache in the file that is used to cache
+     * data from multiple variables before writing it out to the output file
+     */
+    spio_file_mvcache_init(file);
+
     *ncidp = pio_add_to_file_list(file, comm);
 
     LOG((2, "Created file %s file->fh = %d file->pio_ncid = %d", filename,
@@ -2994,9 +2998,6 @@ int PIOc_openfile_retry(int iosysid, int *ncidp, int *iotype, const char *filena
         ios->io_rank == 0)
         file->do_io = 1;
 
-    for (int i = 0; i < PIO_IODESC_MAX_IDS; i++)
-        file->iobuf[i] = NULL;
-
     /* If async is in use, bcast the parameters from compute to I/O procs. */
     if(ios->async)
     {
@@ -3187,6 +3188,12 @@ int PIOc_openfile_retry(int iosysid, int *ncidp, int *iotype, const char *filena
          */
         comm = ios->union_comm;
     }
+
+    /* Initialize the multi-variable cache used to cache data for
+     * multiple variables before writing it to the output file
+     */
+    spio_file_mvcache_init(file);
+
     *ncidp = pio_add_to_file_list(file, comm);
 
     LOG((2, "Opened file %s file->pio_ncid = %d file->fh = %d ierr = %d",
@@ -3202,6 +3209,7 @@ int PIOc_openfile_retry(int iosysid, int *ncidp, int *iotype, const char *filena
         ierr = PIOc_inq_unlimdims(*ncidp, &(file->num_unlim_dimids), NULL);
         if(ierr != PIO_NOERR)
         {
+            spio_file_mvcache_finalize(file);
             return pio_err(ios, file, ierr, __FILE__, __LINE__,
                               "Opening file (%s) failed. Although the file was opened successfully, querying the number of unlimited dimensions in the file failed", filename);
         }
@@ -3210,12 +3218,14 @@ int PIOc_openfile_retry(int iosysid, int *ncidp, int *iotype, const char *filena
             file->unlim_dimids = (int *)malloc(file->num_unlim_dimids * sizeof(int));
             if(!file->unlim_dimids)
             {
+                spio_file_mvcache_finalize(file);
                 return pio_err(ios, file, PIO_ENOMEM, __FILE__, __LINE__,
                                 "Opening file (%s) failed. Out of memory allocating %lld bytes for caching the unlimited dimension ids", filename, (unsigned long long) (file->num_unlim_dimids * sizeof(int)));
             }
             ierr = PIOc_inq_unlimdims(*ncidp, NULL, file->unlim_dimids);
             if(ierr != PIO_NOERR)
             {
+                spio_file_mvcache_finalize(file);
                 return pio_err(ios, file, ierr, __FILE__, __LINE__,
                                 "Opening file (%s) failed. Although the file was opened successfully, querying the unlimited dimensions in the file failed", filename);
             }

--- a/src/clib/pioc_support.c
+++ b/src/clib/pioc_support.c
@@ -2760,6 +2760,7 @@ int PIOc_createfile_int(int iosysid, int *ncidp, int *iotype, const char *filena
 
     /* Initialize the multi-variable cache in the file that is used to cache
      * data from multiple variables before writing it out to the output file
+     * Note: The MVCache is not used by ADIOS
      */
     spio_file_mvcache_init(file);
 
@@ -3191,6 +3192,8 @@ int PIOc_openfile_retry(int iosysid, int *ncidp, int *iotype, const char *filena
 
     /* Initialize the multi-variable cache used to cache data for
      * multiple variables before writing it to the output file
+     * Note: The MVCache is not used by ADIOS or a file opened
+     *       as "read only"
      */
     spio_file_mvcache_init(file);
 

--- a/src/clib/pioc_support.c
+++ b/src/clib/pioc_support.c
@@ -2907,7 +2907,7 @@ int PIOc_openfile_retry(int iosysid, int *ncidp, int *iotype, const char *filena
          iosysid, *iotype, filename, mode, retry));
 
     /* Allocate space for the file info. */
-    if (!(file = calloc(sizeof(*file), 1)))
+    if (!(file = calloc(sizeof(file_desc_t), 1)))
     {
         spio_ltimer_stop(ios->io_fstats->rd_timer_name);
         spio_ltimer_stop(ios->io_fstats->tot_timer_name);

--- a/src/clib/spio_file_mvcache.cpp
+++ b/src/clib/spio_file_mvcache.cpp
@@ -12,18 +12,48 @@ extern "C"{
 
 namespace SPIO_Util{
   namespace File_Util{
+    /* Multi-variable cache used to cache data from multiple variables
+     * while writing it out to the output file
+     * - Each file uses a single MVCache to cache the output data.
+     * - An MVCache caches data based on the I/O decomposition
+     * - Each buffer in the MVCache contains data from multiple variables
+     *   with the same I/O decomposition
+     * e.g. Writing out variables v1, v2 with decomp d1 and v3, v4 with
+     *      decomp d2 to the same file f1. The MVCache for f1 contains two
+     *      elements,
+     *      First element : Contains data from v1 and v2 (corresponding to d1)
+     *      Second element : Contains data from v3 and v4 (corresponding to d2)
+     * Also look at file_desc_t for information on how its used
+     */
     class MVCache{
       public:
         MVCache() : valid_mvbufs_(0) {}
+        /* Get multi-variable buffer associated with ioid */
         void *get(int ioid);
+        /* Allocate a multi-variable buffer of size, sz, for ioid */
         void *alloc(int ioid, std::size_t sz);
+        /* Reallocate a multi-variable buffer of size, sz, for ioid.
+         * Assumes that a multi-variable buffer was already allocated
+         * using alloc() for this ioid
+         */
         void *realloc(int ioid, std::size_t sz);
+        /* Free the multi-variable buffer associated with ioid */
         void free(int ioid);
+        /* Clear the multi-variable cache
+         * All multi-variable buffers associated with all ioids for this
+         * cache is freed
+         */
         void clear(void );
 
+        /* Returns true if the multi-variable cache is empty (has no
+         * valid, non-NULL, multi-variable buffers associated with any
+         * ioid). Returns false otherwise
+         */
         bool is_empty(void ) const { return (valid_mvbufs_ == 0); }
       private:
+        /* The number of valid multi-variable buffers in this cache */
         int valid_mvbufs_;
+        /* Internal map to associate the multi-variable buffer with ioid */
         std::map<int, void *> ioid2mvbuf_;
     };
 
@@ -64,6 +94,7 @@ namespace SPIO_Util{
 
     void MVCache::clear(void )
     {
+      /* First free all valid multi-variable buffers in this cache */
       for(std::map<int, void *>::iterator iter = ioid2mvbuf_.begin();
             iter != ioid2mvbuf_.end(); ++iter){
         if(iter->second){
@@ -73,11 +104,13 @@ namespace SPIO_Util{
       }
 
       assert(this->is_empty());
+      /* Clear the internal map */
       ioid2mvbuf_.clear();
     }
   } // namespace File_Util
 } // namespace SPIO_Util
 
+/* C interfaces for accessing the Multi-variable cache */
 void spio_file_mvcache_init(file_desc_t *file)
 {
   assert(file != NULL);
@@ -118,6 +151,9 @@ void spio_file_mvcache_finalize(file_desc_t *file)
 {
   if(file && file->mvcache){
     SPIO_Util::File_Util::MVCache *mvcache = static_cast<SPIO_Util::File_Util::MVCache *>(file->mvcache);
+    /* An MVCache needs to be "clear"ed before finalize. Also, an MVCache can be cleared multiple times
+     * but once finalized needs to be re"init"ed before using it
+     */
     assert(mvcache->is_empty());
     delete mvcache;
     file->mvcache = NULL;

--- a/src/clib/spio_file_mvcache.cpp
+++ b/src/clib/spio_file_mvcache.cpp
@@ -10,105 +10,58 @@ extern "C"{
 #include "spio_file_mvcache.h"
 }
 
-namespace SPIO_Util{
-  namespace File_Util{
-    /* Multi-variable cache used to cache data from multiple variables
-     * while writing it out to the output file
-     * - Each file uses a single MVCache to cache the output data.
-     * - An MVCache caches data based on the I/O decomposition
-     * - Each buffer in the MVCache contains data from multiple variables
-     *   with the same I/O decomposition
-     * e.g. Writing out variables v1, v2 with decomp d1 and v3, v4 with
-     *      decomp d2 to the same file f1. The MVCache for f1 contains two
-     *      elements,
-     *      First element : Contains data from v1 and v2 (corresponding to d1)
-     *      Second element : Contains data from v3 and v4 (corresponding to d2)
-     * Also look at file_desc_t for information on how its used
-     */
-    class MVCache{
-      public:
-        MVCache() : valid_mvbufs_(0) {}
-        /* Get multi-variable buffer associated with ioid */
-        void *get(int ioid);
-        /* Allocate a multi-variable buffer of size, sz, for ioid */
-        void *alloc(int ioid, std::size_t sz);
-        /* Reallocate a multi-variable buffer of size, sz, for ioid.
-         * Assumes that a multi-variable buffer was already allocated
-         * using alloc() for this ioid
-         */
-        void *realloc(int ioid, std::size_t sz);
-        /* Free the multi-variable buffer associated with ioid */
-        void free(int ioid);
-        /* Clear the multi-variable cache
-         * All multi-variable buffers associated with all ioids for this
-         * cache is freed
-         */
-        void clear(void );
+#include "spio_file_mvcache.hpp"
 
-        /* Returns true if the multi-variable cache is empty (has no
-         * valid, non-NULL, multi-variable buffers associated with any
-         * ioid). Returns false otherwise
-         */
-        bool is_empty(void ) const { return (valid_mvbufs_ == 0); }
-      private:
-        /* The number of valid multi-variable buffers in this cache */
-        int valid_mvbufs_;
-        /* Internal map to associate the multi-variable buffer with ioid */
-        std::map<int, void *> ioid2mvbuf_;
-    };
+void *SPIO_Util::File_Util::MVCache::get(int ioid)
+{
+  try{
+    return ioid2mvbuf_.at(ioid);
+  }
+  catch(std::out_of_range &e){
+    /* Multi-variable cache has not been allocated for ioid */
+    return NULL;
+  }
+}
 
-    void *MVCache::get(int ioid)
-    {
-      try{
-        return ioid2mvbuf_.at(ioid);
-      }
-      catch(std::out_of_range &e){
-        /* Multi-variable cache has not been allocated for ioid */
-        return NULL;
-      }
-    }
-    
-    void *MVCache::alloc(int ioid, std::size_t sz)
-    {
-      void *buf = bget(sz);
-      ioid2mvbuf_[ioid] = buf;
-      valid_mvbufs_++;
-      return buf;
-    }
+void *SPIO_Util::File_Util::MVCache::alloc(int ioid, std::size_t sz)
+{
+  void *buf = bget(sz);
+  ioid2mvbuf_[ioid] = buf;
+  valid_mvbufs_++;
+  return buf;
+}
 
-    void *MVCache::realloc(int ioid, std::size_t sz)
-    {
-      void *buf = ioid2mvbuf_.at(ioid);
-      buf = bgetr(buf, sz);
-      ioid2mvbuf_[ioid] = buf;
-      /* Note: Number of valid mvbufs remains the same */
-      return buf;
-    }
+void *SPIO_Util::File_Util::MVCache::realloc(int ioid, std::size_t sz)
+{
+  void *buf = ioid2mvbuf_.at(ioid);
+  buf = bgetr(buf, sz);
+  ioid2mvbuf_[ioid] = buf;
+  /* Note: Number of valid mvbufs remains the same */
+  return buf;
+}
 
-    void MVCache::free(int ioid)
-    {
-      brel(ioid2mvbuf_.at(ioid));
-      ioid2mvbuf_[ioid] = NULL;
+void SPIO_Util::File_Util::MVCache::free(int ioid)
+{
+  brel(ioid2mvbuf_.at(ioid));
+  ioid2mvbuf_[ioid] = NULL;
+  valid_mvbufs_--;
+}
+
+void SPIO_Util::File_Util::MVCache::clear(void )
+{
+  /* First free all valid multi-variable buffers in this cache */
+  for(std::map<int, void *>::iterator iter = ioid2mvbuf_.begin();
+        iter != ioid2mvbuf_.end(); ++iter){
+    if(iter->second){
+      brel(iter->second);
       valid_mvbufs_--;
     }
+  }
 
-    void MVCache::clear(void )
-    {
-      /* First free all valid multi-variable buffers in this cache */
-      for(std::map<int, void *>::iterator iter = ioid2mvbuf_.begin();
-            iter != ioid2mvbuf_.end(); ++iter){
-        if(iter->second){
-          brel(iter->second);
-          valid_mvbufs_--;
-        }
-      }
-
-      assert(this->is_empty());
-      /* Clear the internal map */
-      ioid2mvbuf_.clear();
-    }
-  } // namespace File_Util
-} // namespace SPIO_Util
+  assert(this->is_empty());
+  /* Clear the internal map */
+  ioid2mvbuf_.clear();
+}
 
 /* C interfaces for accessing the Multi-variable cache */
 void spio_file_mvcache_init(file_desc_t *file)

--- a/src/clib/spio_file_mvcache.cpp
+++ b/src/clib/spio_file_mvcache.cpp
@@ -1,0 +1,125 @@
+#include <iostream>
+#include <map>
+#include <stdexcept>
+#include <cassert>
+
+extern "C"{
+#include "pio_config.h"
+#include "pio.h"
+#include "pio_internal.h"
+#include "spio_file_mvcache.h"
+}
+
+namespace SPIO_Util{
+  namespace File_Util{
+    class MVCache{
+      public:
+        MVCache() : valid_mvbufs_(0) {}
+        void *get(int ioid);
+        void *alloc(int ioid, std::size_t sz);
+        void *realloc(int ioid, std::size_t sz);
+        void free(int ioid);
+        void clear(void );
+
+        bool is_empty(void ) const { return (valid_mvbufs_ == 0); }
+      private:
+        int valid_mvbufs_;
+        std::map<int, void *> ioid2mvbuf_;
+    };
+
+    void *MVCache::get(int ioid)
+    {
+      try{
+        return ioid2mvbuf_.at(ioid);
+      }
+      catch(std::out_of_range &e){
+        /* Multi-variable cache has not been allocated for ioid */
+        return NULL;
+      }
+    }
+    
+    void *MVCache::alloc(int ioid, std::size_t sz)
+    {
+      void *buf = bget(sz);
+      ioid2mvbuf_[ioid] = buf;
+      valid_mvbufs_++;
+      return buf;
+    }
+
+    void *MVCache::realloc(int ioid, std::size_t sz)
+    {
+      void *buf = ioid2mvbuf_.at(ioid);
+      buf = bgetr(buf, sz);
+      ioid2mvbuf_[ioid] = buf;
+      /* Note: Number of valid mvbufs remains the same */
+      return buf;
+    }
+
+    void MVCache::free(int ioid)
+    {
+      brel(ioid2mvbuf_.at(ioid));
+      ioid2mvbuf_[ioid] = NULL;
+      valid_mvbufs_--;
+    }
+
+    void MVCache::clear(void )
+    {
+      for(std::map<int, void *>::iterator iter = ioid2mvbuf_.begin();
+            iter != ioid2mvbuf_.end(); ++iter){
+        if(iter->second){
+          brel(iter->second);
+          valid_mvbufs_--;
+        }
+      }
+
+      assert(this->is_empty());
+      ioid2mvbuf_.clear();
+    }
+  } // namespace File_Util
+} // namespace SPIO_Util
+
+void spio_file_mvcache_init(file_desc_t *file)
+{
+  assert(file != NULL);
+  file->mvcache = static_cast<void *>(new SPIO_Util::File_Util::MVCache());
+}
+
+void *spio_file_mvcache_get(file_desc_t *file, int ioid)
+{
+  assert((file != NULL) && (file->mvcache != NULL) && (ioid >= 0));
+  return (static_cast<SPIO_Util::File_Util::MVCache *>(file->mvcache))->get(ioid);
+}
+
+void *spio_file_mvcache_alloc(file_desc_t *file, int ioid, std::size_t sz)
+{
+  assert((file != NULL) && (file->mvcache != NULL) && (ioid >= 0) && (sz > 0));
+  return (static_cast<SPIO_Util::File_Util::MVCache *>(file->mvcache))->alloc(ioid, sz);
+}
+
+void *spio_file_mvcache_realloc(file_desc_t *file, int ioid, std::size_t sz)
+{
+  assert((file != NULL) && (file->mvcache != NULL) && (ioid >= 0) && (sz > 0));
+  return (static_cast<SPIO_Util::File_Util::MVCache *>(file->mvcache))->realloc(ioid, sz);
+}
+
+void spio_file_mvcache_free(file_desc_t *file, int ioid)
+{
+  assert((file != NULL) && (file->mvcache != NULL) && (ioid >= 0));
+  (static_cast<SPIO_Util::File_Util::MVCache *>(file->mvcache))->free(ioid);
+}
+
+void spio_file_mvcache_clear(file_desc_t *file)
+{
+  assert((file != NULL) && (file->mvcache != NULL));
+  (static_cast<SPIO_Util::File_Util::MVCache *>(file->mvcache))->clear();
+}
+
+void spio_file_mvcache_finalize(file_desc_t *file)
+{
+  if(file && file->mvcache){
+    SPIO_Util::File_Util::MVCache *mvcache = static_cast<SPIO_Util::File_Util::MVCache *>(file->mvcache);
+    assert(mvcache->is_empty());
+    delete mvcache;
+    file->mvcache = NULL;
+  }
+}

--- a/src/clib/spio_file_mvcache.h
+++ b/src/clib/spio_file_mvcache.h
@@ -5,11 +5,20 @@
 #include "pio.h"
 #include "pio_internal.h"
 
+/* C interface for accessing the Multi-Variable Cache */
+
+/* Initialize the MVCache. The MVCache needs to init before using it */
 void spio_file_mvcache_init(file_desc_t *file);
+/* Get the MVCache associated with this ioid on this file */
 void *spio_file_mvcache_get(file_desc_t *file, int ioid);
+/* Allocate MVCache buffer for this ioid on this file */
 void *spio_file_mvcache_alloc(file_desc_t *file, int ioid, size_t sz);
+/* Reallocate MVCache buffer for this ioid on this file */
 void *spio_file_mvcache_realloc(file_desc_t *file, int ioid, size_t sz);
+/* Free MVCache buffer associated with this ioid on this file */
 void spio_file_mvcache_free(file_desc_t *file, int ioid);
+/* Clear all MVCache buffers associated with this file */
 void spio_file_mvcache_clear(file_desc_t *file);
+/* Finalize the MVCache */
 void spio_file_mvcache_finalize(file_desc_t *file);
 #endif // __SPIO_FILE_MVCACHE_H__

--- a/src/clib/spio_file_mvcache.h
+++ b/src/clib/spio_file_mvcache.h
@@ -1,0 +1,15 @@
+#ifndef __SPIO_FILE_MVCACHE_H__
+#define __SPIO_FILE_MVCACHE_H__
+
+#include "pio_config.h"
+#include "pio.h"
+#include "pio_internal.h"
+
+void spio_file_mvcache_init(file_desc_t *file);
+void *spio_file_mvcache_get(file_desc_t *file, int ioid);
+void *spio_file_mvcache_alloc(file_desc_t *file, int ioid, size_t sz);
+void *spio_file_mvcache_realloc(file_desc_t *file, int ioid, size_t sz);
+void spio_file_mvcache_free(file_desc_t *file, int ioid);
+void spio_file_mvcache_clear(file_desc_t *file);
+void spio_file_mvcache_finalize(file_desc_t *file);
+#endif // __SPIO_FILE_MVCACHE_H__

--- a/src/clib/spio_file_mvcache.hpp
+++ b/src/clib/spio_file_mvcache.hpp
@@ -1,0 +1,62 @@
+#ifndef __SPIO_FILE_MVCACHE_HPP__
+#define __SPIO_FILE_MVCACHE_HPP__
+
+#include <map>
+
+extern "C"{
+#include "pio_config.h"
+#include "pio.h"
+#include "pio_internal.h"
+#include "spio_file_mvcache.h"
+}
+
+namespace SPIO_Util{
+  namespace File_Util{
+    /* Multi-variable cache used to cache data from multiple variables
+     * while writing it out to the output file
+     * - Each file uses a single MVCache to cache the output data.
+     * - An MVCache caches data based on the I/O decomposition
+     * - Each buffer in the MVCache contains data from multiple variables
+     *   with the same I/O decomposition
+     * e.g. Writing out variables v1, v2 with decomp d1 and v3, v4 with
+     *      decomp d2 to the same file f1. The MVCache for f1 contains two
+     *      elements,
+     *      First element : Contains data from v1 and v2 (corresponding to d1)
+     *      Second element : Contains data from v3 and v4 (corresponding to d2)
+     * Also look at file_desc_t for information on how its used
+     */
+    class MVCache{
+      public:
+        MVCache() : valid_mvbufs_(0) {}
+        /* Get multi-variable buffer associated with ioid */
+        void *get(int ioid);
+        /* Allocate a multi-variable buffer of size, sz, for ioid */
+        void *alloc(int ioid, std::size_t sz);
+        /* Reallocate a multi-variable buffer of size, sz, for ioid.
+         * Assumes that a multi-variable buffer was already allocated
+         * using alloc() for this ioid
+         */
+        void *realloc(int ioid, std::size_t sz);
+        /* Free the multi-variable buffer associated with ioid */
+        void free(int ioid);
+        /* Clear the multi-variable cache
+         * All multi-variable buffers associated with all ioids for this
+         * cache is freed
+         */
+        void clear(void );
+
+        /* Returns true if the multi-variable cache is empty (has no
+         * valid, non-NULL, multi-variable buffers associated with any
+         * ioid). Returns false otherwise
+         */
+        bool is_empty(void ) const { return (valid_mvbufs_ == 0); }
+      private:
+        /* The number of valid multi-variable buffers in this cache */
+        int valid_mvbufs_;
+        /* Internal map to associate the multi-variable buffer with ioid */
+        std::map<int, void *> ioid2mvbuf_;
+    };
+  } // namespace File_Util
+} // namespace SPIO_Util
+
+#endif // __SPIO_FILE_MVCACHE_HPP__

--- a/tests/cunit/CMakeLists.txt
+++ b/tests/cunit/CMakeLists.txt
@@ -102,10 +102,11 @@ add_spio_executable (test_spmd TRUE "" test_spmd.c test_common.c)
 add_spio_executable (test_spio_ltimer TRUE "" test_spio_ltimer.cpp)
 add_spio_executable (test_spio_serializer TRUE "" test_spio_serializer.cpp)
 add_spio_executable (test_spio_tree TRUE "" test_spio_tree.cpp)
+add_spio_executable (test_spio_file_mvcache TRUE "" test_spio_file_mvcache.cpp)
 add_spio_executable (test_sdecomp_regex TRUE "" test_sdecomp_regex.cpp test_common.c)
 add_spio_executable(test_req_block_wait TRUE "" test_req_block_wait.c test_common.c)
 add_dependencies (tests test_spmd test_spio_ltimer test_spio_serializer test_spio_tree
-                  test_sdecomp_regex test_req_block_wait)
+                  test_spio_file_mvcache test_sdecomp_regex test_req_block_wait)
 
 # Test Timeout in seconds.
 if (PIO_VALGRIND_CHECK)
@@ -124,6 +125,7 @@ set (AT_LEAST_FOUR_TASKS 5)
 add_test(NAME test_spio_ltimer COMMAND test_spio_ltimer)
 add_test(NAME test_spio_serializer COMMAND test_spio_serializer)
 add_test(NAME test_spio_tree COMMAND test_spio_tree)
+add_test(NAME test_spio_file_mvcache COMMAND test_spio_file_mvcache)
 add_test(NAME test_sdecomp_regex COMMAND test_sdecomp_regex)
 
 if (PIO_USE_MPISERIAL)

--- a/tests/cunit/test_req_block_wait.c
+++ b/tests/cunit/test_req_block_wait.c
@@ -186,9 +186,7 @@ int test_setup(MPI_Comm comm, int rank, int sz,
   /* Write multibuffer is not used by this test */
   file->rb_pend = 0;
   file->wb_pend = 0;
-  for(int i = 0; i < PIO_IODESC_MAX_IDS; i++){
-    file->iobuf[i] = NULL;
-  }
+  file->mvcache = NULL;
   file->next = NULL;
   file->do_io = true;
 

--- a/tests/cunit/test_spio_file_mvcache.cpp
+++ b/tests/cunit/test_spio_file_mvcache.cpp
@@ -1,0 +1,319 @@
+#include <iostream>
+#include <vector>
+#include <string>
+#include <cassert>
+
+extern "C"{
+#include "pio_config.h"
+#include "pio.h"
+#include "pio_tests.h"
+}
+#include "spio_file_mvcache.hpp"
+
+#define LOG_RANK0(rank, ...)                     \
+            do{                                   \
+                if(rank == 0)                     \
+                {                                 \
+                    fprintf(stderr, __VA_ARGS__); \
+                }                                 \
+            }while(0);
+
+static const int FAIL = -1;
+
+/* Test creating an MVCache with no multi-variable buffers */
+int test_empty_mvcache(int wrank)
+{
+  SPIO_Util::File_Util::MVCache empty_mvcache;
+
+  if(!empty_mvcache.is_empty()){
+    LOG_RANK0(wrank, "test_empty_mvcache() failed : MVCache not empty when created for the first time, expected MVCache to be empty\n");
+    return PIO_EINTERNAL;
+  }
+
+  return PIO_NOERR;
+}
+
+/* Test creating an MVCache with one multi-variable buffer */
+int test_one_mvbuf_mvcache(int wrank)
+{
+  SPIO_Util::File_Util::MVCache mvcache;
+
+  if(!mvcache.is_empty()){
+    LOG_RANK0(wrank, "test_one_mvbuf_mvcache() failed : MVCache not empty when created for the first time, expected MVCache to be empty\n");
+    return PIO_EINTERNAL;
+  }
+
+  const int ioid = 1;
+  /* Use multi-variable buffers of 16 bytes each */
+  const int mvbuf_sz = 16;
+  void *mvbuf = mvcache.alloc(ioid, mvbuf_sz);
+  if(!mvbuf){
+    LOG_RANK0(wrank, "test_one_mvbuf_mvcache() failed : Could not allocate multi-variable buffer in the MVCache\n");
+    return PIO_EINTERNAL;
+  }
+
+  mvcache.clear();
+
+  if(!mvcache.is_empty()){
+    LOG_RANK0(wrank, "test_one_mvbuf_mvcache() failed : MVCache not empty after clear(), expected MVCache to be empty\n");
+    return PIO_EINTERNAL;
+  }
+
+  return PIO_NOERR;
+}
+
+/* Test reusing an MVCache with one multi-variable buffer */
+int test_reuse_mvbuf_mvcache(int wrank)
+{
+  SPIO_Util::File_Util::MVCache mvcache;
+
+  if(!mvcache.is_empty()){
+    LOG_RANK0(wrank, "test_reuse_mvbuf_mvcache() failed : MVCache not empty when created for the first time, expected MVCache to be empty\n");
+    return PIO_EINTERNAL;
+  }
+
+  const int ioid = 1;
+  /* Use multi-variable buffers of 16 bytes each */
+  const int mvbuf_sz = 16;
+  void *mvbuf = mvcache.alloc(ioid, mvbuf_sz);
+  if(!mvbuf){
+    LOG_RANK0(wrank, "test_reuse_mvbuf_mvcache() failed : Could not allocate multi-variable buffer in the MVCache \n");
+    return PIO_EINTERNAL;
+  }
+
+  /* Reallocate the multi-variable buffer to reuse it - typically used to expand the buffer */
+  mvbuf = mvcache.realloc(ioid, mvbuf_sz);
+  if(!mvbuf){
+    LOG_RANK0(wrank, "test_reuse_mvbuf_mvcache() failed : Could not reallocate multi-variable buffer in the MVCache \n");
+    return PIO_EINTERNAL;
+  }
+
+  mvcache.free(ioid);
+
+  if(!mvcache.is_empty()){
+    LOG_RANK0(wrank, "test_reuse_mvbuf_mvcache() failed : MVCache not empty after free(), expected MVCache to be empty\n");
+    return PIO_EINTERNAL;
+  }
+
+  /* Since the multi-variable buffer is freed, alloc() it again to reuse it */
+  mvbuf = mvcache.alloc(ioid, mvbuf_sz);
+  if(!mvbuf){
+    LOG_RANK0(wrank, "test_reuse_mvbuf_mvcache() failed : Could not allocate multi-variable buffer after freeing it in the MVCache \n");
+    return PIO_EINTERNAL;
+  }
+
+  mvcache.clear();
+
+  if(!mvcache.is_empty()){
+    LOG_RANK0(wrank, "test_reuse_mvbuf_mvcache() failed : MVCache not empty after clear(), expected MVCache to be empty\n");
+    return PIO_EINTERNAL;
+  }
+
+  return PIO_NOERR;
+}
+
+/* Test using an MVCache with multiple I/O decomposition ids */
+int test_multi_ioid_mvcache(int wrank)
+{
+  SPIO_Util::File_Util::MVCache mvcache;
+
+  if(!mvcache.is_empty()){
+    LOG_RANK0(wrank, "test_multi_ioid_mvcache() failed : MVCache not empty when created for the first time, expected MVCache to be empty\n");
+    return PIO_EINTERNAL;
+  }
+
+  const std::vector<int> ioids = {1, 2, 4, 8, 9, 10, 512, 1024};
+  std::vector<void *> mvbufs;
+  /* Use multi-variable buffers of 16 bytes each */
+  const int mvbuf_sz = 16;
+
+  /* Check that no multi-variable buffer is associated with the ioids */
+  for(std::vector<int>::const_iterator citer = ioids.cbegin(); citer != ioids.cend(); ++citer){
+    void *mvbuf = mvcache.get(*citer);
+    if(mvbuf){
+      LOG_RANK0(wrank, "test_multi_ioid_mvcache() failed : Unallocated Multi-variable buffer for ioid (%d) is not NULL, expected buffer to be NULL since its not allocated yet \n", *citer);
+      return PIO_EINTERNAL;
+    }
+  }
+
+  /* Allocate multi-variable buffer for the different ioids */
+  for(std::vector<int>::const_iterator citer = ioids.cbegin(); citer != ioids.cend(); ++citer){
+    void *mvbuf = mvcache.alloc(*citer, mvbuf_sz);
+    if(!mvbuf){
+      LOG_RANK0(wrank, "test_multi_ioid_mvcache() failed : Could not allocate multi-variable buffer in the MVCache \n");
+      return PIO_EINTERNAL;
+    }
+    mvbufs.push_back(mvbuf);
+  }
+
+  /* Get multi-variable buffer for the different ioids */
+  assert(mvbufs.size() == ioids.size());
+  int i = 0;
+  for(std::vector<int>::const_iterator citer = ioids.cbegin(); citer != ioids.cend(); ++citer){
+    void *mvbuf = mvcache.get(*citer);
+    if(!mvbuf){
+      LOG_RANK0(wrank, "test_multi_ioid_mvcache() failed : Could not get multi-variable buffer associated with ioid (%d) in the MVCache \n", *citer);
+      return PIO_EINTERNAL;
+    }
+
+    if(mvbuf != mvbufs[i]){
+      LOG_RANK0(wrank, "test_multi_ioid_mvcache() failed : Multi-variable buffer associated with ioid (%d) retrieved using get (%p) is different from the one allocated using alloc (%p)\n", *citer, mvbuf, mvbufs[i]);
+      return PIO_EINTERNAL;
+    }
+    i++;
+  }
+
+  /* Free the multi-variable buffers associated with the ioids */
+  for(std::vector<int>::const_iterator citer = ioids.cbegin(); citer != ioids.cend(); ++citer){
+    if(mvcache.is_empty()){
+      LOG_RANK0(wrank, "test_multi_ioid_mvcache() failed : MVCache empty after freeing multi-variable cache for some ioids, expected MVCache to be not empty\n");
+      return PIO_EINTERNAL;
+    }
+    mvcache.free(*citer);
+  }
+
+  if(!mvcache.is_empty()){
+    LOG_RANK0(wrank, "test_multi_ioid_mvcache() failed : MVCache not empty after freeing multi-variable buffers for all ioids, expected MVCache to be empty\n");
+    return PIO_EINTERNAL;
+  }
+
+  /* Clearing an empty MVCache should not fail */
+  mvcache.clear();
+
+  if(!mvcache.is_empty()){
+    LOG_RANK0(wrank, "test_multi_ioid_mvcache() failed : MVCache not empty after clear(), expected MVCache to be empty\n");
+    return PIO_EINTERNAL;
+  }
+
+  return PIO_NOERR;
+}
+
+int test_driver(MPI_Comm comm, int wrank, int wsz, int *num_errors)
+{
+  int nerrs = 0, ret = PIO_NOERR;
+  assert((comm != MPI_COMM_NULL) && (wrank >= 0) && (wsz > 0) && num_errors);
+  
+  /* Test creating an empty MVCache */
+  try{
+    ret = test_empty_mvcache(wrank);
+  }
+  catch(...){
+    ret = PIO_EINTERNAL;
+  }
+  if(ret != PIO_NOERR){
+    LOG_RANK0(wrank, "test_empty_mvcache() FAILED, ret = %d\n", ret);
+    nerrs++;
+  }
+  else{
+    LOG_RANK0(wrank, "test_empty_mvcache() PASSED\n");
+  }
+
+  /* Test creating an MVCache with one multi-variable buffer */
+  try{
+    ret = test_one_mvbuf_mvcache(wrank);
+  }
+  catch(...){
+    ret = PIO_EINTERNAL;
+  }
+  if(ret != PIO_NOERR){
+    LOG_RANK0(wrank, "test_one_mvbuf_mvcache() FAILED, ret = %d\n", ret);
+    nerrs++;
+  }
+  else{
+    LOG_RANK0(wrank, "test_one_mvbuf_mvcache() PASSED\n");
+  }
+
+  /* Test reusing an MVCache with one multi-variable buffer */
+  try{
+    ret = test_reuse_mvbuf_mvcache(wrank);
+  }
+  catch(...){
+    ret = PIO_EINTERNAL;
+  }
+  if(ret != PIO_NOERR){
+    LOG_RANK0(wrank, "test_reuse_mvbuf_mvcache() FAILED, ret = %d\n", ret);
+    nerrs++;
+  }
+  else{
+    LOG_RANK0(wrank, "test_reuse_mvbuf_mvcache() PASSED\n");
+  }
+
+  /* Test using an MVCache with multiple I/O decomposition ids */
+  try{
+    ret = test_multi_ioid_mvcache(wrank);
+  }
+  catch(...){
+    ret = PIO_EINTERNAL;
+  }
+  if(ret != PIO_NOERR){
+    LOG_RANK0(wrank, "test_multi_ioid_mvcache() FAILED, ret = %d\n", ret);
+    nerrs++;
+  }
+  else{
+    LOG_RANK0(wrank, "test_multi_ioid_mvcache() PASSED\n");
+  }
+
+  *num_errors += nerrs;
+  return nerrs;
+}
+
+int main(int argc, char *argv[])
+{
+  int ret;
+  int wrank, wsz;
+  int num_errors;
+#ifdef TIMING
+#ifndef TIMING_INTERNAL
+  ret = GPTLinitialize();
+  if(ret != 0){
+    LOG_RANK0(wrank, "GPTLinitialize() FAILED, ret = %d\n", ret);
+    return ret;
+  }
+#endif /* TIMING_INTERNAL */
+#endif /* TIMING */
+
+  ret = MPI_Init(&argc, &argv);
+  if(ret != MPI_SUCCESS){
+    LOG_RANK0(wrank, "MPI_Init() FAILED, ret = %d\n", ret);
+    return ret;
+  }
+
+  ret = MPI_Comm_rank(MPI_COMM_WORLD, &wrank);
+  if(ret != MPI_SUCCESS){
+    LOG_RANK0(wrank, "MPI_Comm_rank() FAILED, ret = %d\n", ret);
+    return ret;
+  }
+  ret = MPI_Comm_size(MPI_COMM_WORLD, &wsz);
+  if(ret != MPI_SUCCESS){
+    LOG_RANK0(wrank, "MPI_Comm_rank() FAILED, ret = %d\n", ret);
+    return ret;
+  }
+
+  num_errors = 0;
+  ret = test_driver(MPI_COMM_WORLD, wrank, wsz, &num_errors);
+  if(ret != 0){
+    LOG_RANK0(wrank, "Test driver FAILED\n");
+    return FAIL;
+  }
+  else{
+    LOG_RANK0(wrank, "All tests PASSED\n");
+  }
+
+  MPI_Finalize();
+
+#ifdef TIMING
+#ifndef TIMING_INTERNAL
+  ret = GPTLfinalize();
+  if(ret != 0){
+    LOG_RANK0(wrank, "GPTLinitialize() FAILED, ret = %d\n", ret);
+    return ret;
+  }
+#endif /* TIMING_INTERNAL */
+#endif /* TIMING */
+
+  if(num_errors != 0){
+    LOG_RANK0(wrank, "Total errors = %d\n", num_errors);
+    return FAIL;
+  }
+  return 0;
+}

--- a/tests/general/CMakeLists.txt
+++ b/tests/general/CMakeLists.txt
@@ -23,6 +23,7 @@ SET(GENERATED_SRCS pio_file_simple_tests.F90
   pio_fail.F90
   pio_file_fail.F90
   pio_large_file_tests.F90
+  pio_decomp_large_tests.F90
   ncdf_simple_tests.F90
   ncdf_get_put.F90
   ncdf_fail.F90
@@ -248,13 +249,27 @@ add_pio_test(pio_file_simple_tests
   MAXSTRIDE 1
   TIMEOUT ${DEFAULT_TEST_TIMEOUT})
 
-#===== pio_large_file_tests =====
 if (PIO_ENABLE_LARGE_TESTS)
+  #===== pio_large_file_tests =====
   add_spio_test_executable(pio_large_file_tests FALSE ${PIO_LINKER_LANGUAGE} pio_large_file_tests.F90)
 
   # Costly test only test with 2 I/O procs
   add_pio_test(pio_large_file_tests
     EXECUTABLE ${CMAKE_CURRENT_BINARY_DIR}/pio_large_file_tests
+    MINNUMPROCS 2
+    MAXNUMPROCS ${PIO_TF_MAXNUMPROCS}
+    MINNUMIOPROCS 2
+    MAXNUMIOPROCS 2
+    MINSTRIDE 1
+    MAXSTRIDE 1
+    TIMEOUT ${DEFAULT_TEST_TIMEOUT})
+
+  #===== pio_decomp_large_tests =====
+  add_spio_test_executable(pio_decomp_large_tests FALSE ${PIO_LINKER_LANGUAGE} pio_decomp_large_tests.F90)
+
+  # Costly test only test with 2 I/O procs
+  add_pio_test(pio_decomp_large_tests
+    EXECUTABLE ${CMAKE_CURRENT_BINARY_DIR}/pio_decomp_large_tests
     MINNUMPROCS 2
     MAXNUMPROCS ${PIO_TF_MAXNUMPROCS}
     MINNUMIOPROCS 2

--- a/tests/general/pio_decomp_large_tests.F90.in
+++ b/tests/general/pio_decomp_large_tests.F90.in
@@ -1,0 +1,23 @@
+PIO_TF_AUTO_TEST_SUB_BEGIN create_many_decomps
+  implicit none
+  integer, parameter :: VEC_LOCAL_SZ = 7
+  ! Try > 64K decomps
+  integer, parameter :: MAX_DECOMPS = 64 * 1024 + 1
+  type(io_desc_t) :: iodesc
+  integer, dimension(VEC_LOCAL_SZ) :: compdof, compdof_rel_disps
+  integer, dimension(1) :: dims
+  integer :: i, ierr
+
+  do i=1,VEC_LOCAL_SZ
+    compdof_rel_disps(i) = i
+  end do
+  dims(1) = VEC_LOCAL_SZ * pio_tf_world_sz_
+  compdof = VEC_LOCAL_SZ * pio_tf_world_rank_ + compdof_rel_disps
+
+  do i=1,MAX_DECOMPS
+    call PIO_initdecomp(pio_tf_iosystem_, PIO_int, dims, compdof, iodesc)
+
+    call PIO_freedecomp(pio_tf_iosystem_, iodesc)
+  end do
+PIO_TF_AUTO_TEST_SUB_END create_many_decomps
+


### PR DESCRIPTION
Replacing the linear cache for multi-variable cache buffers with a map.

This removes the restriction (upper bound) on the I/O decomposition
descriptor ids.

Fixes #449 