### PR TITLE
Include file stats on files not closed by user

### DIFF
--- a/src/clib/io_perf_summary.json_expected
+++ b/src/clib/io_perf_summary.json_expected
@@ -36,6 +36,7 @@
     "FileIOStatistics" : [
       {
         "name" : "file1.nc",
+        "model_component_name" : "COMP_CPL: CPL",
         "avg_wtput(MB/s)" : 2.5,
         "avg_rtput(MB/s)" : 1.5,
         "tot_wb(bytes)" : 512,
@@ -46,6 +47,7 @@
       },
       {
         "name" : "file2.nc",
+        "model_component_name" : "COMP_ATM: EAM",
         "avg_wtput(MB/s)" : 2.5,
         "avg_rtput(MB/s)" : 1.5,
         "tot_wb(bytes)" : 512,

--- a/src/clib/io_perf_summary.schema.json
+++ b/src/clib/io_perf_summary.schema.json
@@ -54,6 +54,17 @@
       },
 
       "required": ["name", "avg_wtput(MB/s)", "avg_rtput(MB/s)", "tot_wb(bytes)", "tot_rb(bytes)", "tot_wtime(s)", "tot_rtime(s)", "tot_time(s)"]
+    },
+    "fio_stats":{
+      "type": "object",
+      "allof":[{"$ref": "$/definitions/iostats"}],
+      "properties": {
+        "model_component_name": {
+          "description": "The name of the Model Component that opened/created the file",
+          "type": "string"
+        }
+      },
+      "required": ["model_component_name"]
     }
   },
 
@@ -74,7 +85,7 @@
         "FileIOStatistics": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/io_stats"
+            "$ref": "#/definitions/fio_stats"
           }
         }
       },
@@ -83,4 +94,3 @@
   },
   "required": ["ScorpioIOSummaryStatistics"]
 }
-

--- a/src/clib/io_perf_summary.text_expected
+++ b/src/clib/io_perf_summary.text_expected
@@ -29,6 +29,7 @@
       "tot_time(s)" : 0.54
     "FileIOStatistics":
       "name" : "file1.nc",
+      "model_component_name" : "COMP_CPL: CPL",
       "avg_wtput(MB/s)" : 2.5,
       "avg_rtput(MB/s)" : 1.5,
       "tot_wb(bytes)" : 512,
@@ -38,6 +39,7 @@
       "tot_time(s)" : 0.54
     "FileIOStatistics":
       "name" : "file2.nc",
+      "model_component_name" : "COMP_ATM: EAM",
       "avg_wtput(MB/s)" : 2.5,
       "avg_rtput(MB/s)" : 1.5,
       "tot_wb(bytes)" : 512,

--- a/src/clib/io_perf_summary.xml_expected
+++ b/src/clib/io_perf_summary.xml_expected
@@ -32,6 +32,7 @@
   </ModelComponentIOStatistics>
   <FileIOStatistics>
     <name>"file1.nc"</name>
+    <model_component_name>"COMP_CPL: CPL"</model_component_name>
     <avg_wtput(MB/s)>2.5</avg_wtput(MB/s)>
     <avg_rtput(MB/s)>1.5</avg_rtput(MB/s)>
     <tot_wb(bytes)>512</tot_wb(bytes)>
@@ -42,6 +43,7 @@
   </FileIOStatistics>
   <FileIOStatistics>
     <name>"file2.nc"</name>
+    <model_component_name>"COMP_ATM: EAM"</model_component_name>
     <avg_wtput(MB/s)>2.5</avg_wtput(MB/s)>
     <avg_rtput(MB/s)>1.5</avg_rtput(MB/s)>
     <tot_wb(bytes)>512</tot_wb(bytes)>

--- a/src/clib/pio_internal.h
+++ b/src/clib/pio_internal.h
@@ -283,6 +283,9 @@ extern "C" {
     /* Allocation memory for a data region. */
     int alloc_region2(iosystem_desc_t *ios, int ndims, io_region **region);
 
+    /* Write I/O performance statistics on all files in the I/O system */
+    int spio_write_all_file_iostats(iosystem_desc_t *iosysp);
+
     /* Delete an entry from the lost of open IO systems. */
     int pio_delete_iosystem_from_list(int piosysid);
 

--- a/src/clib/pio_lists.c
+++ b/src/clib/pio_lists.c
@@ -175,6 +175,37 @@ int pio_delete_file_from_list(int ncid)
     return PIO_EBADID;
 }
 
+/** Print I/O stats for all files in the iosystem
+ *
+ * This call can be expensive when a lot of files are open
+ * (and not expensive when called during I/O system finalize,
+ * when all the I/O systems finalize at the same time and the
+ * user is careful about closing all open files before the
+ * I/O systems are finalized)
+ * This call can be used to force writing out file I/O stats
+ * for all the files in an I/O system (e.g. not all files
+ * are closed and we need the file I/O stats of these files)
+ * @param iosysp Pointer to the I/O system, iosystem_desc_t
+ * @returns PIO_NOERR on success, error code otherwise
+ */
+int spio_write_all_file_iostats(iosystem_desc_t *iosysp)
+{
+    int ret = PIO_NOERR;
+    for(file_desc_t *pf = pio_file_list; pf; pf = pf->next)
+    {
+        if(pf->iosystem == iosysp)
+        {
+            assert(pf->iosystem->iosysid == iosysp->iosysid);
+            ret = spio_write_file_io_summary(pf);
+            if(ret != PIO_NOERR)
+            {
+                return ret;
+            }
+        }
+    }
+    return ret;
+}
+
 /** 
  * Delete iosystem info from list.
  *

--- a/src/clib/spio_io_summary.cpp
+++ b/src/clib/spio_io_summary.cpp
@@ -630,6 +630,14 @@ int spio_write_io_summary(iosystem_desc_t *ios)
 
   assert(ios);
 
+  /* Ensure that we have stats from all files (including files that
+   * were not closed) in the I/O system */
+  ierr = spio_write_all_file_iostats(ios);
+  if(ierr != PIO_NOERR){
+    /* Not a fatal error, log the error and continue */
+    LOG((1, "An error occured writing file I/O stats on the I/O system (iosysid= %d), ret = %d", ios->iosysid, ierr));
+  }
+
   /* For async I/O only collect statistics from the I/O processes */
   if(ios->async && !(ios->ioproc)){
     return PIO_NOERR;

--- a/src/clib/spio_io_summary.cpp
+++ b/src/clib/spio_io_summary.cpp
@@ -562,6 +562,7 @@ static int cache_or_print_stats(iosystem_desc_t *ios, int root_proc,
         const std::size_t ONE_MB = 1024 * 1024;
 
         PIO_Util::Serializer_Utils::serialize_pack("name", cached_file_names[i][j], file_vals);
+        PIO_Util::Serializer_Utils::serialize_pack("model_component_name", cached_ios_names[i], file_vals);
         PIO_Util::Serializer_Utils::serialize_pack("avg_wtput(MB/s)",
           (cached_file_gio_sstats[i][j].wtime_max > 0.0) ?
           (cached_file_gio_sstats[i][j].wb_total / (ONE_MB * cached_file_gio_sstats[i][j].wtime_max)) : 0.0,


### PR DESCRIPTION
Making sure that we capture file I/O stats for files that were
not closed (e.g. read only files) by the user

Also adding the model component name in the file I/O
statistics