### PR TITLE
Make initialize_path append to the input PATHLIST rather than overwrite

### DIFF
--- a/cmake/LibFind.cmake
+++ b/cmake/LibFind.cmake
@@ -138,7 +138,8 @@ function (initialize_paths PATHLIST)
     set (multiValueArgs INCLUDE_DIRECTORIES LIBRARIES)
     cmake_parse_arguments (INIT "" "" "${multiValueArgs}" ${ARGN})
     
-    set (paths)
+    # Initialize the paths with whatever the user may have already specified
+    set (paths ${${PATHLIST}})
     foreach (inc IN LISTS INIT_INCLUDE_DIRECTORIES)
         list (APPEND paths ${inc})
         get_filename_component (dname ${inc} NAME)


### PR DESCRIPTION
See #456 for an explanation of the problem. In short, ensure that user-provided hints via `<LIBNAME>_<COMP>_PATHS` cache var are not discarded.

Closes #456 