### PR TITLE
Always specify components when requesting to find MPI

### DIFF
--- a/src/clib/CMakeLists.txt
+++ b/src/clib/CMakeLists.txt
@@ -28,7 +28,7 @@ if (PIO_USE_MPISERIAL)
     message(WARNING "Unable to find the MPI serial library (SCORPIO was configured to use the MPI serial library)")
   endif ()
 else ()
-  find_package (MPI REQUIRED)
+  find_package (MPI REQUIRED COMPONENTS C)
 endif ()
 
 #===== GPTL =====

--- a/src/flib/CMakeLists.txt
+++ b/src/flib/CMakeLists.txt
@@ -127,7 +127,7 @@ if (PIO_USE_MPISERIAL)
     message(WARNING "Could not find MPI serial library")
   endif ()
 else ()
-  find_package (MPI REQUIRED)
+  find_package (MPI REQUIRED COMPONENTS Fortran)
 endif ()
 
 # Check for MPI Fortran module

--- a/src/gptl/CMakeLists.txt
+++ b/src/gptl/CMakeLists.txt
@@ -118,7 +118,7 @@ if (PIO_USE_MPISERIAL)
     set (MPI_Fortran_INCLUDE_PATH ${MPISERIAL_Fortran_INCLUDE_DIRS})
   endif ()
 else ()
-  find_package (MPI REQUIRED)
+  find_package (MPI REQUIRED COMPONENTS C Fortran)
   if (MPI_C_FOUND AND MPI_Fortran_FOUND)
     target_compile_definitions (gptl
       PUBLIC HAVE_MPI)


### PR DESCRIPTION
This change ensures that the MPI Component (C, Fortran) is explicitly
specified when finding MPI libraries. Without this fix SCORPIO CXX
compiler check fails inside FindMPI module, when building SCREAM
with GPU code.

If COMPONENTS is not specified when finding the MPI library using the
find_package() call, cmake will proceed to look for the corresponding
component for each language that has a compiler enabled. On GPU
machines, this is causing issues, likely related with the fact that
GPU/CUDA flags are used for building GPU code but the MPI finding
process is not picking up the kokkos compile launcher (which takes
care of separating nvcc flags from host compiler flags). So the
compiler check fails since CUDA flags are not recognized.