### PR TITLE
avoid PnetCDF independent data mode

### DIFF
--- a/src/clib/pio_varm.c
+++ b/src/clib/pio_varm.c
@@ -1116,16 +1116,7 @@ int PIOc_get_varm_uchar (int ncid, int varid, const PIO_Offset start[], const PI
 #endif
 #ifdef _PNETCDF
         case PIO_IOTYPE_PNETCDF:
-#ifdef PNET_READ_AND_BCAST
-            ncmpi_begin_indep_data(file->fh);
-            if (ios->iomaster == MPI_ROOT){
-                ierr = ncmpi_get_varm_uchar(file->fh, varid, start, count, stride, imap,  buf);;
-            };
-            ncmpi_end_indep_data(file->fh);
-            bcast=true;
-#else
             ierr = ncmpi_get_varm_uchar_all(file->fh, varid, start, count, stride, imap,  buf);;
-#endif
             break;
 #endif
         default:
@@ -1194,16 +1185,7 @@ int PIOc_get_varm_schar (int ncid, int varid, const PIO_Offset start[], const PI
 #endif
 #ifdef _PNETCDF
         case PIO_IOTYPE_PNETCDF:
-#ifdef PNET_READ_AND_BCAST
-            ncmpi_begin_indep_data(file->fh);
-            if (ios->iomaster == MPI_ROOT){
-                ierr = ncmpi_get_varm_schar(file->fh, varid, start, count, stride, imap,  buf);;
-            };
-            ncmpi_end_indep_data(file->fh);
-            bcast=true;
-#else
             ierr = ncmpi_get_varm_schar_all(file->fh, varid, start, count, stride, imap,  buf);;
-#endif
             break;
 #endif
         default:
@@ -1272,16 +1254,7 @@ int PIOc_get_varm_double (int ncid, int varid, const PIO_Offset start[], const P
 #endif
 #ifdef _PNETCDF
         case PIO_IOTYPE_PNETCDF:
-#ifdef PNET_READ_AND_BCAST
-            ncmpi_begin_indep_data(file->fh);
-            if (ios->iomaster == MPI_ROOT){
-                ierr = ncmpi_get_varm_double(file->fh, varid, start, count, stride, imap,  buf);;
-            };
-            ncmpi_end_indep_data(file->fh);
-            bcast=true;
-#else
             ierr = ncmpi_get_varm_double_all(file->fh, varid, start, count, stride, imap,  buf);;
-#endif
             break;
 #endif
         default:
@@ -1350,16 +1323,7 @@ int PIOc_get_varm_text (int ncid, int varid, const PIO_Offset start[], const PIO
 #endif
 #ifdef _PNETCDF
         case PIO_IOTYPE_PNETCDF:
-#ifdef PNET_READ_AND_BCAST
-            ncmpi_begin_indep_data(file->fh);
-            if (ios->iomaster == MPI_ROOT){
-                ierr = ncmpi_get_varm_text(file->fh, varid, start, count, stride, imap,  buf);;
-            };
-            ncmpi_end_indep_data(file->fh);
-            bcast=true;
-#else
             ierr = ncmpi_get_varm_text_all(file->fh, varid, start, count, stride, imap,  buf);;
-#endif
             break;
 #endif
         default:
@@ -1428,16 +1392,7 @@ int PIOc_get_varm_int (int ncid, int varid, const PIO_Offset start[], const PIO_
 #endif
 #ifdef _PNETCDF
         case PIO_IOTYPE_PNETCDF:
-#ifdef PNET_READ_AND_BCAST
-            ncmpi_begin_indep_data(file->fh);
-            if (ios->iomaster == MPI_ROOT){
-                ierr = ncmpi_get_varm_int(file->fh, varid, start, count, stride, imap,  buf);;
-            };
-            ncmpi_end_indep_data(file->fh);
-            bcast=true;
-#else
             ierr = ncmpi_get_varm_int_all(file->fh, varid, start, count, stride, imap,  buf);;
-#endif
             break;
 #endif
         default:
@@ -1506,16 +1461,7 @@ int PIOc_get_varm_uint (int ncid, int varid, const PIO_Offset start[], const PIO
 #endif
 #ifdef _PNETCDF
         case PIO_IOTYPE_PNETCDF:
-#ifdef PNET_READ_AND_BCAST
-            ncmpi_begin_indep_data(file->fh);
-            if (ios->iomaster == MPI_ROOT){
-                ierr = ncmpi_get_varm_uint(file->fh, varid, start, count, stride, imap,  buf);;
-            };
-            ncmpi_end_indep_data(file->fh);
-            bcast=true;
-#else
             ierr = ncmpi_get_varm_uint_all(file->fh, varid, start, count, stride, imap,  buf);;
-#endif
             break;
 #endif
         default:
@@ -1579,16 +1525,7 @@ int PIOc_get_varm (int ncid, int varid, const PIO_Offset start[], const PIO_Offs
 #endif
 #ifdef _PNETCDF
         case PIO_IOTYPE_PNETCDF:
-#ifdef PNET_READ_AND_BCAST
-            ncmpi_begin_indep_data(file->fh);
-            if (ios->iomaster == MPI_ROOT){
-                ierr = ncmpi_get_varm(file->fh, varid, start, count, stride, imap, buf, bufcount, buftype);;
-            };
-            ncmpi_end_indep_data(file->fh);
-            bcast=true;
-#else
             ierr = ncmpi_get_varm_all(file->fh, varid, start, count, stride, imap, buf, bufcount, buftype);;
-#endif
             break;
 #endif
         default:
@@ -1657,16 +1594,7 @@ int PIOc_get_varm_float (int ncid, int varid, const PIO_Offset start[], const PI
 #endif
 #ifdef _PNETCDF
         case PIO_IOTYPE_PNETCDF:
-#ifdef PNET_READ_AND_BCAST
-            ncmpi_begin_indep_data(file->fh);
-            if (ios->iomaster == MPI_ROOT){
-                ierr = ncmpi_get_varm_float(file->fh, varid, start, count, stride, imap,  buf);;
-            };
-            ncmpi_end_indep_data(file->fh);
-            bcast=true;
-#else
             ierr = ncmpi_get_varm_float_all(file->fh, varid, start, count, stride, imap,  buf);;
-#endif
             break;
 #endif
         default:
@@ -1735,16 +1663,7 @@ int PIOc_get_varm_long (int ncid, int varid, const PIO_Offset start[], const PIO
 #endif
 #ifdef _PNETCDF
         case PIO_IOTYPE_PNETCDF:
-#ifdef PNET_READ_AND_BCAST
-            ncmpi_begin_indep_data(file->fh);
-            if (ios->iomaster == MPI_ROOT){
-                ierr = ncmpi_get_varm_long(file->fh, varid, start, count, stride, imap,  buf);;
-            };
-            ncmpi_end_indep_data(file->fh);
-            bcast=true;
-#else
             ierr = ncmpi_get_varm_long_all(file->fh, varid, start, count, stride, imap,  buf);;
-#endif
             break;
 #endif
         default:
@@ -1813,16 +1732,7 @@ int PIOc_get_varm_ushort (int ncid, int varid, const PIO_Offset start[], const P
 #endif
 #ifdef _PNETCDF
         case PIO_IOTYPE_PNETCDF:
-#ifdef PNET_READ_AND_BCAST
-            ncmpi_begin_indep_data(file->fh);
-            if (ios->iomaster == MPI_ROOT){
-                ierr = ncmpi_get_varm_ushort(file->fh, varid, start, count, stride, imap,  buf);;
-            };
-            ncmpi_end_indep_data(file->fh);
-            bcast=true;
-#else
             ierr = ncmpi_get_varm_ushort_all(file->fh, varid, start, count, stride, imap,  buf);;
-#endif
             break;
 #endif
         default:
@@ -1891,16 +1801,7 @@ int PIOc_get_varm_longlong (int ncid, int varid, const PIO_Offset start[], const
 #endif
 #ifdef _PNETCDF
         case PIO_IOTYPE_PNETCDF:
-#ifdef PNET_READ_AND_BCAST
-            ncmpi_begin_indep_data(file->fh);
-            if (ios->iomaster == MPI_ROOT){
-                ierr = ncmpi_get_varm_longlong(file->fh, varid, start, count, stride, imap,  buf);;
-            };
-            ncmpi_end_indep_data(file->fh);
-            bcast=true;
-#else
             ierr = ncmpi_get_varm_longlong_all(file->fh, varid, start, count, stride, imap,  buf);;
-#endif
             break;
 #endif
         default:
@@ -1969,16 +1870,7 @@ int PIOc_get_varm_short (int ncid, int varid, const PIO_Offset start[], const PI
 #endif
 #ifdef _PNETCDF
         case PIO_IOTYPE_PNETCDF:
-#ifdef PNET_READ_AND_BCAST
-            ncmpi_begin_indep_data(file->fh);
-            if (ios->iomaster == MPI_ROOT){
-                ierr = ncmpi_get_varm_short(file->fh, varid, start, count, stride, imap,  buf);;
-            };
-            ncmpi_end_indep_data(file->fh);
-            bcast=true;
-#else
             ierr = ncmpi_get_varm_short_all(file->fh, varid, start, count, stride, imap,  buf);;
-#endif
             break;
 #endif
         default:
@@ -2047,16 +1939,7 @@ int PIOc_get_varm_ulonglong (int ncid, int varid, const PIO_Offset start[], cons
 #endif
 #ifdef _PNETCDF
         case PIO_IOTYPE_PNETCDF:
-#ifdef PNET_READ_AND_BCAST
-            ncmpi_begin_indep_data(file->fh);
-            if (ios->iomaster == MPI_ROOT){
-                ierr = ncmpi_get_varm_ulonglong(file->fh, varid, start, count, stride, imap,  buf);;
-            };
-            ncmpi_end_indep_data(file->fh);
-            bcast=true;
-#else
             ierr = ncmpi_get_varm_ulonglong_all(file->fh, varid, start, count, stride, imap,  buf);;
-#endif
             break;
 #endif
         default:


### PR DESCRIPTION
Entering and leaving PnetCDF independent data mode is expensive.
This PR avoids that by making non-root processes do zero-sized reads while still in collective mode.