### PR TITLE
Workaround for ADIOS 2.8.0 with SST builds

### DIFF
--- a/src/clib/CMakeLists.txt
+++ b/src/clib/CMakeLists.txt
@@ -121,7 +121,11 @@ endif ()
 
 #===== ADIOS-C =====
 if (WITH_ADIOS2)
+  # ADIOS 2.8.0 overwrites/resets CMAKE_MODULE_PATH, so cache and restore it after
+  # finding ADIOS
+  set(SPIO_CMAKE_MODULE_PATH_BACKUP ${CMAKE_MODULE_PATH})
   find_package (ADIOS2 ${ADIOS_MIN_VER_REQD})
+  set(CMAKE_MODULE_PATH ${SPIO_CMAKE_MODULE_PATH_BACKUP})
   if (ADIOS2_FOUND)
     message(STATUS "Found ADIOS library")
     set(PIO_USE_ADIOS 1)

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -3,7 +3,11 @@
 ###-------------------------------------------------------------------------###
 
 if (WITH_ADIOS2)
+  # ADIOS 2.8.0 overwrites/resets CMAKE_MODULE_PATH, so cache and restore it
+  # after finding ADIOS
+  set(SPIO_CMAKE_MODULE_PATH_BACKUP ${CMAKE_MODULE_PATH})
   find_package (ADIOS2 ${ADIOS_MIN_VER_REQD})
+  set(CMAKE_MODULE_PATH ${SPIO_CMAKE_MODULE_PATH_BACKUP})
   if (ADIOS2_FOUND)
     ADD_SUBDIRECTORY(adios2pio-nm)
   endif (ADIOS2_FOUND)

--- a/tools/adios2pio-nm/CMakeLists.txt
+++ b/tools/adios2pio-nm/CMakeLists.txt
@@ -48,7 +48,11 @@ endif ()
 
 #===== ADIOS-C =====
 if ((WITH_ADIOS2) AND (NOT ADIOS2_FOUND))
+  # ADIOS 2.8.0 overwrites/resets CMAKE_MODULE_PATH, so cache and restore it after
+  # finding ADIOS
+  set(SPIO_CMAKE_MODULE_PATH_BACKUP ${CMAKE_MODULE_PATH})
   find_package (ADIOS2 ${ADIOS_MIN_VER_REQD})
+  set(CMAKE_MODULE_PATH ${SPIO_CMAKE_MODULE_PATH_BACKUP})
 endif ()
 
 # We assume that either PnetCDF or NetCDF is available

--- a/tools/spio_finfo/CMakeLists.txt
+++ b/tools/spio_finfo/CMakeLists.txt
@@ -42,7 +42,11 @@ if (WITH_PNETCDF)
 endif ()
 #===== ADIOS-C =====
 if (WITH_ADIOS)
+  # ADIOS 2.8.0 overwrites/resets CMAKE_MODULE_PATH, so cache and restore it
+  # after finding ADIOS
+  set(SPIO_CMAKE_MODULE_PATH_BACKUP ${CMAKE_MODULE_PATH})
   find_package (ADIOS ${ADIOS_MIN_VER_REQD})
+  set(CMAKE_MODULE_PATH ${SPIO_CMAKE_MODULE_PATH_BACKUP})
 endif ()
 
 #==============================================================================


### PR DESCRIPTION
ADIOS (2.5.0/2.8.0 with SST enabled) overwrites the CMake module
path when finding the package. So as a workaround caching and
restoring the CMake module path when finding ADIOS.

Fixes #468