### PR TITLE
Add missing write_total GPTL timers for ADIOS type

### DIFF
--- a/src/clib/pio_file.c
+++ b/src/clib/pio_file.c
@@ -1069,23 +1069,34 @@ int PIOc_sync(int ncid)
     int ierr = PIO_NOERR;  /* Return code from function calls. */
 
     GPTLstart("PIO:PIOc_sync");
-    GPTLstart("PIO:write_total");
     LOG((1, "PIOc_sync ncid = %d", ncid));
 
     /* Get the file info from the ncid. */
     if ((ierr = pio_get_file(ncid, &file)))
     {
         GPTLstop("PIO:PIOc_sync");
-        GPTLstop("PIO:write_total");
         return pio_err(NULL, NULL, ierr, __FILE__, __LINE__,
                         "Syncing file (ncid=%d) failed. Invalid file id. Unable to find internal structure associated with the file id", ncid);
     }
     assert(file);
 
+    if (file->mode & PIO_WRITE)
+    {
+        GPTLstart("PIO:write_total");
+        if (file->iotype == PIO_IOTYPE_ADIOS)
+            GPTLstart("PIO:write_total_adios");
+    }
+
     ierr = sync_file(ncid);
 
+    if (file->mode & PIO_WRITE)
+    {
+        GPTLstop("PIO:write_total");
+        if (file->iotype == PIO_IOTYPE_ADIOS)
+            GPTLstop("PIO:write_total_adios");
+    }
+
     GPTLstop("PIO:PIOc_sync");
-    GPTLstop("PIO:write_total");
 
     return ierr;
 }

--- a/src/clib/pioc.c
+++ b/src/clib/pioc.c
@@ -259,6 +259,8 @@ int PIOc_setframe(int ncid, int varid, int frame)
             {
                 spio_ltimer_start(ios->io_fstats->wr_timer_name);
                 spio_ltimer_start(file->io_fstats->wr_timer_name);
+                GPTLstart("PIO:write_total");
+                GPTLstart("PIO:write_total_adios");
             }
             spio_ltimer_start(ios->io_fstats->tot_timer_name);
             spio_ltimer_start(file->io_fstats->tot_timer_name);
@@ -269,6 +271,8 @@ int PIOc_setframe(int ncid, int varid, int frame)
             {
                 spio_ltimer_stop(ios->io_fstats->wr_timer_name);
                 spio_ltimer_stop(file->io_fstats->wr_timer_name);
+                GPTLstop("PIO:write_total");
+                GPTLstop("PIO:write_total_adios");
             }
             spio_ltimer_stop(ios->io_fstats->tot_timer_name);
             spio_ltimer_stop(file->io_fstats->tot_timer_name);


### PR DESCRIPTION
After ADIOS file format is upgraded from BP3 to BP4, PIOc_sync and
PIOc_setframe might flush data to BP files.

This PR adds missing write_total GPTL timers to these functions for
ADIOS type.