### PR TITLE
Add consts to parameters of some SCORPIO C APIs

### DIFF
--- a/src/clib/pio.h
+++ b/src/clib/pio.h
@@ -1100,7 +1100,7 @@ extern "C" {
     int PIOc_readmap_from_f90(const char *file,int *ndims, int **gdims, PIO_Offset *maplen,
                               PIO_Offset **map, int f90_comm);
     int PIOc_writemap(const char *file, int ioid, int ndims, const int *gdims, PIO_Offset maplen,
-                      PIO_Offset *map, MPI_Comm comm);
+                      const PIO_Offset *map, MPI_Comm comm);
     int PIOc_writemap_from_f90(const char *file, int ioid, int ndims, const int *gdims,
                                PIO_Offset maplen, const PIO_Offset *map, int f90_comm);
 
@@ -1109,15 +1109,15 @@ extern "C" {
 
     /* Write a decomposition file using netCDF. */
     int PIOc_write_nc_decomp(int iosysid, const char *filename, int cmode, int ioid,
-                             char *title, char *history, int fortran_order);
+                             const char *title, const char *history, int fortran_order);
 
     /* Read a netCDF decomposition file. */
     int PIOc_read_nc_decomp(int iosysid, const char *filename, int *ioid, MPI_Comm comm,
                             int pio_type, char *title, char *history, int *fortran_order);
 
     /* Initializing IO system for async. */
-    int PIOc_init_async(MPI_Comm world, int num_io_procs, int *io_proc_list, int component_count,
-                        int *num_procs_per_comp, int **proc_list, MPI_Comm *io_comm, MPI_Comm *comp_comm,
+    int PIOc_init_async(MPI_Comm world, int num_io_procs, const int *io_proc_list, int component_count,
+                        const int *num_procs_per_comp, const int **proc_list, MPI_Comm *io_comm, MPI_Comm *comp_comm,
                         int rearranger, int *iosysidp);
     
     int PIOc_Init_Intercomm(int component_count, MPI_Comm peer_comm, MPI_Comm *comp_comms,
@@ -1145,10 +1145,10 @@ extern "C" {
     /* Distributed data. */
     int PIOc_advanceframe(int ncid, int varid);
     int PIOc_setframe(int ncid, int varid, int frame);
-    int PIOc_write_darray(int ncid, int varid, int ioid, PIO_Offset arraylen, void *array,
-                          void *fillvalue);
+    int PIOc_write_darray(int ncid, int varid, int ioid, PIO_Offset arraylen, const void *array,
+                          const void *fillvalue);
     int PIOc_write_darray_multi(int ncid, const int *varids, int ioid, int nvars, PIO_Offset arraylen,
-                                void *array, const int *frame, void **fillvalue, bool flushtodisk);
+                                const void *array, const int *frame, const void **fillvalue, bool flushtodisk);
     int PIOc_read_darray(int ncid, int varid, int ioid, PIO_Offset arraylen, void *array);
     int PIOc_get_local_array_size(int ioid);
 
@@ -1157,7 +1157,7 @@ extern "C" {
     int PIOc_enddef(int ncid);
     int PIOc_sync(int ncid);
     int PIOc_deletefile(int iosysid, const char *filename);
-    int PIOc_createfile(int iosysid, int *ncidp,  int *iotype, const char *fname, int mode);
+    int PIOc_createfile(int iosysid, int *ncidp, const int *iotype, const char *fname, int mode);
     int PIOc_create(int iosysid, const char *path, int cmode, int *ncidp);
     int PIOc_openfile(int iosysid, int *ncidp, int *iotype, const char *fname, int mode);
     int PIOc_openfile2(int iosysid, int *ncidp, int *iotype, const char *fname, int mode);

--- a/src/clib/pio_darray.c
+++ b/src/clib/pio_darray.c
@@ -109,8 +109,8 @@ PIO_Offset PIOc_set_buffer_size_limit(PIO_Offset limit)
  * @author Jim Edwards, Ed Hartnett
  */
 int PIOc_write_darray_multi(int ncid, const int *varids, int ioid, int nvars,
-                            PIO_Offset arraylen, void *array, const int *frame,
-                            void **fillvalue, bool flushtodisk)
+                            PIO_Offset arraylen, const void *array, const int *frame,
+                            const void **fillvalue, bool flushtodisk)
 {
     iosystem_desc_t *ios;  /* Pointer to io system information. */
     file_desc_t *file;     /* Pointer to file information. */
@@ -1850,8 +1850,8 @@ static int PIOc_write_darray_adios(file_desc_t *file, int varid, int ioid,
  * @ingroup PIO_write_darray
  * @author Jim Edwards, Ed Hartnett
  */
-int PIOc_write_darray(int ncid, int varid, int ioid, PIO_Offset arraylen, void *array,
-                      void *fillvalue)
+int PIOc_write_darray(int ncid, int varid, int ioid, PIO_Offset arraylen, const void *array,
+                      const void *fillvalue)
 {
     iosystem_desc_t *ios;  /* Pointer to io system information. */
     file_desc_t *file;     /* Info about file we are writing to. */

--- a/src/clib/pio_file.c
+++ b/src/clib/pio_file.c
@@ -127,7 +127,7 @@ int PIOc_open(int iosysid, const char *path, int mode, int *ncidp)
  * @ingroup PIO_createfile
  * @author Jim Edwards, Ed Hartnett
  */
-int PIOc_createfile(int iosysid, int *ncidp, int *iotype, const char *filename,
+int PIOc_createfile(int iosysid, int *ncidp, const int *iotype, const char *filename,
                     int mode)
 {
     iosystem_desc_t *ios;  /* Pointer to io system information. */

--- a/src/clib/pio_internal.h
+++ b/src/clib/pio_internal.h
@@ -129,7 +129,7 @@ extern "C" {
     void pio_push_request(file_desc_t *file, int request);
 
     /* Create a file (internal function). */
-    int PIOc_createfile_int(int iosysid, int *ncidp, int *iotype, const char *filename, int mode);
+    int PIOc_createfile_int(int iosysid, int *ncidp, const int *iotype, const char *filename, int mode);
 
     /* Open a file and learn about metadata. */
     int openfile_int(int iosysid, int *ncidp, int *iotype, const char *filename,
@@ -188,9 +188,9 @@ extern "C" {
     void CheckMPIReturn(int ierr, const char *file, int line);
 
     /* Like MPI_Alltoallw(), but with flow control. */
-    int pio_swapm(void *sendbuf, int *sendcounts, int *sdispls, MPI_Datatype *sendtypes,
-                  void *recvbuf, int *recvcounts, int *rdispls, MPI_Datatype *recvtypes,
-                  MPI_Comm comm, rearr_comm_fc_opt_t *fc);
+    int pio_swapm(const void *sendbuf, const int *sendcounts, const int *sdispls, const MPI_Datatype *sendtypes,
+                  void *recvbuf, const int *recvcounts, const int *rdispls, const MPI_Datatype *recvtypes,
+                  MPI_Comm comm, const rearr_comm_fc_opt_t *fc);
 
     long long lgcd_array(int nain, long long* ain);
 
@@ -245,10 +245,10 @@ extern "C" {
 
 
     /* Move data from IO tasks to compute tasks. */
-    int rearrange_io2comp(iosystem_desc_t *ios, io_desc_t *iodesc, void *sbuf, void *rbuf);
+    int rearrange_io2comp(iosystem_desc_t *ios, io_desc_t *iodesc, const void *sbuf, void *rbuf);
 
     /* Move data from compute tasks to IO tasks. */
-    int rearrange_comp2io(iosystem_desc_t *ios, io_desc_t *iodesc, void *sbuf, void *rbuf,
+    int rearrange_comp2io(iosystem_desc_t *ios, io_desc_t *iodesc, const void *sbuf, void *rbuf,
                           int nvars);
 
     /* Allocate and initialize storage for decomposition information. */
@@ -375,7 +375,7 @@ extern "C" {
 
     /* Write a netCDF decomp file. */
     int pioc_write_nc_decomp_int(iosystem_desc_t *ios, const char *filename, int cmode, int ndims,
-                                 int *global_dimlen, int num_tasks, int *task_maplen, int *map,
+                                 const int *global_dimlen, int num_tasks, const int *task_maplen, const int *map,
                                  const char *title, const char *history, int fortran_order);
 
     /* Read a netCDF decomp file. */

--- a/src/clib/pio_rearrange.c
+++ b/src/clib/pio_rearrange.c
@@ -847,7 +847,7 @@ int compute_counts(iosystem_desc_t *ios, io_desc_t *iodesc,
  * @returns 0 on success, error code otherwise.
  * @author Jim Edwards
  */
-int rearrange_comp2io(iosystem_desc_t *ios, io_desc_t *iodesc, void *sbuf,
+int rearrange_comp2io(iosystem_desc_t *ios, io_desc_t *iodesc, const void *sbuf,
                       void *rbuf, int nvars)
 {
     int ntasks;       /* Number of tasks in communicator. */
@@ -1086,7 +1086,7 @@ int rearrange_comp2io(iosystem_desc_t *ios, io_desc_t *iodesc, void *sbuf,
  * @returns 0 on success, error code otherwise.
  * @author Jim Edwards
  */
-int rearrange_io2comp(iosystem_desc_t *ios, io_desc_t *iodesc, void *sbuf,
+int rearrange_io2comp(iosystem_desc_t *ios, io_desc_t *iodesc, const void *sbuf,
                       void *rbuf)
 {
     MPI_Comm mycomm;

--- a/src/clib/pio_spmd.c
+++ b/src/clib/pio_spmd.c
@@ -73,9 +73,9 @@ int pair(int np, int p, int k)
  * @returns 0 for success, error code otherwise.
  * @author Jim Edwards
  */
-int pio_swapm(void *sendbuf, int *sendcounts, int *sdispls, MPI_Datatype *sendtypes,
-              void *recvbuf, int *recvcounts, int *rdispls, MPI_Datatype *recvtypes,
-              MPI_Comm comm, rearr_comm_fc_opt_t *fc)
+int pio_swapm(const void *sendbuf, const int *sendcounts, const int *sdispls, const MPI_Datatype *sendtypes,
+              void *recvbuf, const int *recvcounts, const int *rdispls, const MPI_Datatype *recvtypes,
+              MPI_Comm comm, const rearr_comm_fc_opt_t *fc)
 {
     int ntasks;  /* Number of tasks in communicator comm. */
     int my_rank; /* Rank of this task in comm. */

--- a/src/clib/pioc_support.c
+++ b/src/clib/pioc_support.c
@@ -1661,7 +1661,7 @@ int PIOc_readmap_from_f90(const char *file, int *ndims, int **gdims, PIO_Offset 
  * @returns 0 for success, error code otherwise.
  */
 int PIOc_write_nc_decomp(int iosysid, const char *filename, int cmode, int ioid,
-                         char *title, char *history, int fortran_order)
+                         const char *title, const char *history, int fortran_order)
 {
     iosystem_desc_t *ios; /* IO system info. */
     io_desc_t *iodesc;    /* Decomposition info. */
@@ -1887,7 +1887,7 @@ int PIOc_read_nc_decomp(int iosysid, const char *filename, int *ioidp, MPI_Comm 
  * @returns 0 for success, error code otherwise.
  */
 int pioc_write_nc_decomp_int(iosystem_desc_t *ios, const char *filename, int cmode, int ndims,
-                             int *global_dimlen, int num_tasks, int *task_maplen, int *map,
+                             const int *global_dimlen, int num_tasks, const int *task_maplen, const int *map,
                              const char *title, const char *history, int fortran_order)
 {
     int max_maplen = 0;
@@ -2430,7 +2430,7 @@ int PIOc_write_decomp(const char *file, int iosysid, int ioid, MPI_Comm comm)
  * @returns 0 for success, error code otherwise.
  */
 int PIOc_writemap(const char *file, int ioid, int ndims, const int *gdims, PIO_Offset maplen,
-                  PIO_Offset *map, MPI_Comm comm)
+                  const PIO_Offset *map, MPI_Comm comm)
 {
     int npes, myrank;
     PIO_Offset *nmaplen = NULL;
@@ -2619,7 +2619,7 @@ int PIO_get_avail_iotypes(char *buf, size_t sz)
  * @returns 0 for success, error code otherwise.
  * @ingroup PIO_createfile
  */
-int PIOc_createfile_int(int iosysid, int *ncidp, int *iotype, const char *filename,
+int PIOc_createfile_int(int iosysid, int *ncidp, const int *iotype, const char *filename,
                         int mode)
 {
     char tname[SPIO_TIMER_MAX_NAME];

--- a/tests/cunit/test_async_simple.c
+++ b/tests/cunit/test_async_simple.c
@@ -74,7 +74,7 @@ int main(int argc, char **argv)
 
         /* Initialize the IO system. */
         if ((ret = PIOc_init_async(test_comm, NUM_IO_PROCS, io_proc_list, COMPONENT_COUNT,
-                                   num_procs, (int **)proc_list, NULL, NULL, PIO_REARR_BOX, iosysid)))
+                                   num_procs, (const int **)proc_list, NULL, NULL, PIO_REARR_BOX, iosysid)))
             ERR(ERR_INIT);
 
         /* All the netCDF calls are only executed on the computation


### PR DESCRIPTION
This PR fixes some SCORPIO C APIs that have missing consts in their
parameters, such as PIOc_write_darray() function.

Fixes #483