### PR TITLE
Reserve some extra space in the header only once when creating NetCDF files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -195,6 +195,20 @@ else()
   endif()
 endif()
 
+# Reserve some extra space in the header when creating NetCDF files. The recommended size by Charlie Zender (NCO developer) is 10 KB
+set(DEF_SPIO_RESERVED_FILE_HDR_SZ 10240)
+if(DEFINED PIO_RESERVED_FILE_HEADER_SIZE)
+  if(PIO_RESERVED_FILE_HEADER_SIZE GREATER_EQUAL 0)
+    message(STATUS "Reserving some extra space in the header when creating NetCDF files, requested bytes = " ${PIO_RESERVED_FILE_HEADER_SIZE})
+  else()
+    message(WARNING "User-defined PIO_RESERVED_FILE_HEADER_SIZE is invalid, setting it to " ${DEF_SPIO_RESERVED_FILE_HDR_SZ} " (default)")
+    set(PIO_RESERVED_FILE_HEADER_SIZE ${DEF_SPIO_RESERVED_FILE_HDR_SZ})
+  endif()
+else()
+  set(PIO_RESERVED_FILE_HEADER_SIZE ${DEF_SPIO_RESERVED_FILE_HDR_SZ})
+  message(STATUS "Reserving some extra space in the header when creating NetCDF files, requested bytes = " ${PIO_RESERVED_FILE_HEADER_SIZE} " (default)")
+endif()
+
 #==============================================================================
 #  DETECT SYSTEM/COMPILERS (and set compiler specific options)
 #==============================================================================

--- a/src/clib/pio.h
+++ b/src/clib/pio.h
@@ -1089,6 +1089,10 @@ typedef struct file_desc_t
     /** True if this task should participate in IO (only true for one
      * task with netcdf serial files. */
     int do_io;
+
+    /** True if we need reserve some extra space in the header when
+     * creating NetCDF files to accommodate anticipated changes. */
+    bool reserve_extra_header_space;
 } file_desc_t;
 
 /**

--- a/src/clib/pio_config.h.in
+++ b/src/clib/pio_config.h.in
@@ -52,6 +52,9 @@
 /** Striping unit hint in bytes for a Lustre or GPFS file system. */
 #define PIO_STRIPING_UNIT @PIO_STRIPING_UNIT@
 
+/** Extra bytes reserved in the header when creating NetCDF files. */
+#define PIO_RESERVED_FILE_HEADER_SIZE @PIO_RESERVED_FILE_HEADER_SIZE@
+
 /** Set to 1 if the library is configured to use the PnetCDF library,
  *  0 otherwise */
 #define PIO_USE_PNETCDF @PIO_USE_PNETCDF@

--- a/src/clib/pioc_support.c
+++ b/src/clib/pioc_support.c
@@ -4060,8 +4060,10 @@ int pioc_change_def(int ncid, int is_enddef)
             {
                 if (file->reserve_extra_header_space)
                 {
-                    /* Sets the pad at the end of the "header" section. */
-                    const MPI_Offset h_minfree = 10 * 1024; /* The recommended size by Charlie Zender (NCO developer) is 10 KB */
+                    /* Sets the pad at the end of the "header" section.
+                     * The recommended size by Charlie Zender (NCO developer) is 10 KB */
+                    assert(PIO_RESERVED_FILE_HEADER_SIZE >= 0);
+                    const MPI_Offset h_minfree = PIO_RESERVED_FILE_HEADER_SIZE;
 
                     /* Controls the alignment of the beginning of the data section for fixed-size/record variables. */
                     const MPI_Offset v_align = 4; /* For fixed-size variables, needs to be left as the default (4 bytes) */
@@ -4093,8 +4095,10 @@ int pioc_change_def(int ncid, int is_enddef)
 #ifdef NETCDF_C_NC__ENDDEF_EXISTS
                     if (file->reserve_extra_header_space)
                     {
-                        /* Sets the pad at the end of the "header" section. */
-                        const size_t h_minfree = 10 * 1024; /* The recommended size by Charlie Zender (NCO developer) is 10 KB */
+                        /* Sets the pad at the end of the "header" section.
+                         * The recommended size by Charlie Zender (NCO developer) is 10 KB */
+                        assert(PIO_RESERVED_FILE_HEADER_SIZE >= 0);
+                        const MPI_Offset h_minfree = PIO_RESERVED_FILE_HEADER_SIZE;
 
                         /* Controls the alignment of the beginning of the data section for fixed-size/record variables. */
                         const size_t v_align = 4; /* For fixed-size variables, needs to be left as the default (4 bytes) */


### PR DESCRIPTION
Avoid reserving extra space (padding) in the output NetCDF file
header more than once.

After the header section is expanded (even with sufficient free
space), a new reservation (with the same request as before) may
involve moving (shifting) data, which can be very expensive if
the data sections are huge (this is very common for output files
of some ultra-high-resolution E3SM/scream cases).

Follows up PR #448