### PR TITLE
Add declaration of function used to write I/O summary

### DIFF
--- a/src/clib/pio_lists.c
+++ b/src/clib/pio_lists.c
@@ -11,6 +11,7 @@
 #include <string.h>
 #include <stdio.h>
 #include "spio_file_mvcache.h"
+#include "spio_io_summary.h"
 
 static io_desc_t *pio_iodesc_list = NULL;
 static io_desc_t *current_iodesc = NULL;


### PR DESCRIPTION
Adding the appropriate header with declaration for function to write I/O
performance summary statistics for a file.

Some compilers, like the Intel OneAPI, fail to compile sources with
implicit function declarations (ISO C99 and later do not support
implicit function declarations)

Fixes #492 