### PR TITLE
Simplify PIOc_inq_type with less MPI_Bcast calls for PnetCDF IO type

### DIFF
--- a/src/clib/pio_msg.c
+++ b/src/clib/pio_msg.c
@@ -86,8 +86,8 @@ int init_async_msgs_sign(void )
      * B => byte array, needs to be prefixed by L/M
      */
     strncpy(pio_async_msg_sign[PIO_MSG_INVALID], "", PIO_MAX_ASYNC_MSG_ARGS);
-    /* PIO_MSG_OPEN_FILE message sends 1 int/len + 1 string + 1 int + 1 int */
-    strncpy(pio_async_msg_sign[PIO_MSG_OPEN_FILE], "scii", PIO_MAX_ASYNC_MSG_ARGS);
+    /* PIO_MSG_OPEN_FILE message sends 1 int/len + 1 string + 1 int + 1 int + 1 int */
+    strncpy(pio_async_msg_sign[PIO_MSG_OPEN_FILE], "sciii", PIO_MAX_ASYNC_MSG_ARGS);
     /* PIO_MSG_CREATE_FILE message sends 1 int/len + 1 string + 1 int + 1 int */
     strncpy(pio_async_msg_sign[PIO_MSG_CREATE_FILE], "scii", PIO_MAX_ASYNC_MSG_ARGS);
     /* PIO_MSG_INQ_ATT message sends 
@@ -3036,6 +3036,7 @@ int open_file_handler(iosystem_desc_t *ios)
     int len;
     int iotype;
     int mode;
+    int retry;
     int ret = PIO_NOERR;
 
     LOG((1, "open_file_handler comproot = %d", ios->comproot));
@@ -3044,7 +3045,7 @@ int open_file_handler(iosystem_desc_t *ios)
     /* Get the parameters for this function that the he comp master
      * task is broadcasting. */
     char filename[PIO_MAX_NAME+1];
-    PIO_RECV_ASYNC_MSG(ios, PIO_MSG_OPEN_FILE, &ret, &len, filename, &iotype, &mode);
+    PIO_RECV_ASYNC_MSG(ios, PIO_MSG_OPEN_FILE, &ret, &len, filename, &iotype, &mode, &retry);
     if(ret != PIO_NOERR)
     {
         return pio_err(ios, NULL, ret, __FILE__, __LINE__,
@@ -3055,7 +3056,7 @@ int open_file_handler(iosystem_desc_t *ios)
          len, filename, iotype, mode));
 
     /* Call the open file function */
-    ret = PIOc_openfile_retry(ios->iosysid, &ncid, &iotype, filename, mode, 0);
+    ret = PIOc_openfile_retry(ios->iosysid, &ncid, &iotype, filename, mode, retry);
     if (ret != PIO_NOERR)
     {
         return pio_err(ios, NULL, ret, __FILE__, __LINE__,

--- a/src/clib/pioc_support.c
+++ b/src/clib/pioc_support.c
@@ -3821,9 +3821,11 @@ int PIOc_openfile_retry(int iosysid, int *ncidp, int *iotype, const char *filena
             }
             if ((ierr != NC_NOERR) && (file->iotype != PIO_IOTYPE_NETCDF))
             {
-                /* reset file markers for NETCDF on all tasks */
+                /* reset file markers for NETCDF on all IO tasks */
                 file->iotype = PIO_IOTYPE_NETCDF;
 
+                /* FIXME: The changes below to modify the user-specified
+                 * iotype needs to be propogated to all tasks. */
                 /* modify the user-specified iotype on all tasks */
                 /* Modifying the user-specified iotype unfortunately
                  * causes some E3SM model components to reset the iotype
@@ -3873,6 +3875,21 @@ int PIOc_openfile_retry(int iosysid, int *ncidp, int *iotype, const char *filena
         free(file->io_fstats);
         free(file);
         return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
+    }
+
+    if (retry)
+    {
+        /* Broadcast IO type (might be switched on IO tasks) to all tasks. */
+        if ((mpierr = MPI_Bcast(&file->iotype, 1, MPI_INT, ios->ioroot, ios->my_comm)))
+        {
+            spio_ltimer_stop(ios->io_fstats->rd_timer_name);
+            spio_ltimer_stop(ios->io_fstats->tot_timer_name);
+            spio_ltimer_stop(file->io_fstats->rd_timer_name);
+            spio_ltimer_stop(file->io_fstats->tot_timer_name);
+            free(file->io_fstats);
+            free(file);
+            return check_mpi(NULL, file, mpierr, __FILE__, __LINE__);
+        }
     }
 
     ierr = check_netcdf(ios, file, ierr, __FILE__, __LINE__);

--- a/src/clib/pioc_support.c
+++ b/src/clib/pioc_support.c
@@ -3713,7 +3713,7 @@ int PIOc_openfile_retry(int iosysid, int *ncidp, int *iotype, const char *filena
     if(ios->async)
     {
         int len = strlen(filename) + 1;
-        PIO_SEND_ASYNC_MSG(ios, PIO_MSG_OPEN_FILE, &ierr, len, filename, file->iotype, file->mode);
+        PIO_SEND_ASYNC_MSG(ios, PIO_MSG_OPEN_FILE, &ierr, len, filename, file->iotype, file->mode, retry);
         if(ierr != PIO_NOERR)
         {
             spio_ltimer_stop(ios->io_fstats->rd_timer_name);


### PR DESCRIPTION
To inquire the type size with PnetCDF IO type, we do not need any
communication across processes. All tasks can directly call the
internal helper function pioc_pnetcdf_inq_type to get the results.

This PR simplifies PIOc_inq_type for PnetCDF IO type, reducing the
number of collective MPI_Bcast calls in SCORPIO.

It also fixes two potential issues:
* The retry flag passed to PIOc_openfile_retry might be inconsistent
  across all tasks when async is in use. 
* IO type internally modified by PIOc_openfile_retry on IO tasks is
  not known to non-IO tasks.