### PR TITLE
Fix cray+rocm build issues

### DIFF
--- a/src/clib/CMakeLists.txt
+++ b/src/clib/CMakeLists.txt
@@ -269,7 +269,7 @@ endif ()
 # The MPI library detection was done in the top level
 if (MPISERIAL_C_FOUND)
   target_compile_definitions (pioc
-    PRIVATE MPI_SERIAL)
+    PUBLIC MPI_SERIAL)
   target_include_directories (pioc
     PUBLIC ${MPISERIAL_C_INCLUDE_DIRS})
   target_link_libraries (pioc

--- a/src/clib/bget.h
+++ b/src/clib/bget.h
@@ -12,6 +12,11 @@
 //#endif
 
 typedef long bufsize;
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
 void    bpool(void *buffer, bufsize len);
 void   *bget(bufsize size);
 void   *bgetz(bufsize size);
@@ -28,5 +33,9 @@ void    bufdump(void *buf);
 void    bpoold(void *pool, int dumpalloc, int dumpfree);
 int     bpoolv(void *pool);
 void bfreespace(bufsize *maxfree, bufsize *totfree);
+
+#if defined(__cplusplus)
+}
+#endif
 
 #endif

--- a/src/clib/pio.h
+++ b/src/clib/pio.h
@@ -61,8 +61,6 @@
 #define BLOCK_COUNT_THRESHOLD ((unsigned long)(1024 * 1024 * 1024 * 1.9))
 #define BLOCK_METADATA_SIZE 70 /* Size of adios block metadata */
 
-adios2_adios *get_adios2_adios();
-unsigned long get_adios2_io_cnt();
 #endif
 #ifdef _HDF5
 #include <hdf5.h>
@@ -1608,9 +1606,11 @@ extern "C" {
                            const PIO_Offset *stride, const PIO_Offset *imap, long *buf);
 
 #ifdef _ADIOS2
+    /* FIXME: Shouldn't these ADIOS functions be moved to pio_internal.h ? */
     adios2_type PIOc_get_adios_type(nc_type xtype);
     int get_adios2_type_size(adios2_type type, const void *var);
     const char *convert_adios2_error_to_string(adios2_error error);
+    adios2_adios *get_adios2_adios();
     unsigned long get_adios2_io_cnt();
     int begin_adios2_step(file_desc_t *file, iosystem_desc_t *ios);
     int end_adios2_step(file_desc_t *file, iosystem_desc_t *ios);
@@ -1619,6 +1619,7 @@ extern "C" {
 #endif
 #endif
 
+    /* FIXME: Shouldn't these HDF5 functions be moved to pio_internal.h ? */
 #ifdef _HDF5
     hid_t nc_type_to_hdf5_type(nc_type xtype);
     PIO_Offset hdf5_get_nc_type_size(nc_type xtype);

--- a/src/clib/pio.h
+++ b/src/clib/pio.h
@@ -13,7 +13,20 @@
 #include <stdlib.h>
 #include <stdbool.h>
 #include <string.h> /* memcpy */
+
+#ifdef MPI_SERIAL
+#if defined(__cplusplus)
+extern "C" {
+#endif
+#endif
+
 #include <mpi.h>
+
+#ifdef MPI_SERIAL
+#if defined(__cplusplus)
+}
+#endif
+#endif
 
 #include "pio_config.h"
 #if PIO_USE_PNETCDF

--- a/src/clib/pio_internal.h
+++ b/src/clib/pio_internal.h
@@ -32,34 +32,34 @@
 #include <assert.h>
 #include "spio_ltimer.h"
 
-#if PIO_ENABLE_LOGGING
-void pio_log(int severity, const char *fmt, ...);
-#define LOG(e) pio_log e
-#else
-#define LOG(e)
-#endif /* PIO_ENABLE_LOGGING */
-
-#define max(a,b)                                \
-    ({ __typeof__ (a) _a = (a);                 \
-        __typeof__ (b) _b = (b);                \
-        _a > _b ? _a : _b; })
-
-#define min(a,b)                                \
-    ({ __typeof__ (a) _a = (a);                 \
-        __typeof__ (b) _b = (b);                \
-        _a < _b ? _a : _b; })
-
-#define MAX_GATHER_BLOCK_SIZE 0
-#define PIO_REQUEST_ALLOC_CHUNK 16
-
-/** This is needed to handle _long() functions. It may not be used as
- * a data type when creating attributes or varaibles, it is only used
- * internally. */
-#define PIO_LONG_INTERNAL 13
-
 #if defined(__cplusplus)
 extern "C" {
 #endif
+
+#if PIO_ENABLE_LOGGING
+    void pio_log(int severity, const char *fmt, ...);
+    #define LOG(e) pio_log e
+#else
+    #define LOG(e)
+#endif /* PIO_ENABLE_LOGGING */
+
+    #define max(a,b)                                \
+        ({ __typeof__ (a) _a = (a);                 \
+            __typeof__ (b) _b = (b);                \
+            _a > _b ? _a : _b; })
+
+    #define min(a,b)                                \
+        ({ __typeof__ (a) _a = (a);                 \
+            __typeof__ (b) _b = (b);                \
+            _a < _b ? _a : _b; })
+
+    #define MAX_GATHER_BLOCK_SIZE 0
+    #define PIO_REQUEST_ALLOC_CHUNK 16
+
+    /** This is needed to handle _long() functions. It may not be used as
+     * a data type when creating attributes or varaibles, it is only used
+     * internally. */
+    #define PIO_LONG_INTERNAL 13
 
     extern PIO_Offset pio_buffer_size_limit;
 
@@ -397,10 +397,6 @@ extern "C" {
           int **preq_block_ranges,
           int *nreq_blocks);
 
-#if defined(__cplusplus)
-}
-#endif
-
 /* Asynchronous I/O services start with the following seq num */
 static const int PIO_MSG_START_SEQ_NUM = 1024;
 /** These are the messages that can be sent over the intercomm when
@@ -674,5 +670,10 @@ const char *pio_get_vnames_from_file_id(int pio_file_id,
               int *varids, int varids_sz, char *buf, size_t buf_sz);
 const char *pio_async_msg_to_string(int msg);
 #define PIO_IS_NULL(p) ((p) ? "not NULL" : "NULL")
+
+#if defined(__cplusplus)
+}
+#endif
+
 
 #endif /* __PIO_INTERNAL__ */

--- a/src/clib/pio_mpi_timer.c
+++ b/src/clib/pio_mpi_timer.c
@@ -1,5 +1,4 @@
 #include "pio_config.h"
-#include "mpi.h"
 #include "pio_timer.h"
 #include "pio_internal.h"
 

--- a/src/clib/pio_sdecomps_regex.cpp
+++ b/src/clib/pio_sdecomps_regex.cpp
@@ -8,12 +8,10 @@
 #include <algorithm>
 #include <stack>
 
-extern "C"{
 #include "pio_config.h"
 #include "pio.h"
 #include "pio_internal.h"
 #include "pio_sdecomps_regex.h"
-}
 #include "pio_sdecomps_regex.hpp"
 
 namespace PIO_Util{

--- a/src/clib/pio_sdecomps_regex.h
+++ b/src/clib/pio_sdecomps_regex.h
@@ -1,6 +1,10 @@
 #ifndef __PIO_SDECOMPS_REGEX_H___
 #define __PIO_SDECOMPS_REGEX_H___
 
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
 /* The C API that matches user specified regular expression to save
  * I/O decomposition with the ioid, file and variables names provided
  * @param ioid : The I/O decomposition ID to match
@@ -10,5 +14,9 @@
  * previously specified regular expression, false otherwise
  */
 bool pio_save_decomps_regex_match(int ioid, const char *fname, const char *vname);
+
+#if defined(__cplusplus)
+}
+#endif
 
 #endif /* __PIO_SDECOMPS_REGEX_H__ */

--- a/src/clib/pio_sdecomps_regex.hpp
+++ b/src/clib/pio_sdecomps_regex.hpp
@@ -10,12 +10,10 @@
 #include <cctype>
 #include <algorithm>
 #include <stack>
-extern "C"{
 #include "pio_config.h"
 #include "pio.h"
 #include "pio_internal.h"
 #include "pio_sdecomps_regex.h"
-}
 
 namespace PIO_Util{
   /* Internal util classes and functions used for parsing and evaluating

--- a/src/clib/pio_timer.h
+++ b/src/clib/pio_timer.h
@@ -47,6 +47,10 @@ typedef enum mtimer_type {
     PIO_MICRO_NUM_TIMERS
 } mtimer_type_t;
 
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
 /* FIXME: Do we need to return error codes here - or just have asserts */
 /* Init timer framework - needs to be called once before using timers */
 int mtimer_init(mtimer_type_t type);
@@ -76,4 +80,9 @@ int mtimer_async_event_in_progress(mtimer_t mt, bool is_async_event_in_progress)
  * returns false otherwise
  */
 bool mtimer_has_async_event_in_progress(mtimer_t mt);
+
+#if defined(__cplusplus)
+}
+#endif
+
 #endif

--- a/src/clib/pio_timer.h
+++ b/src/clib/pio_timer.h
@@ -3,7 +3,21 @@
 
 #include "pio_config.h"
 #include <stdbool.h>
+
+#ifdef MPI_SERIAL
+#if defined(__cplusplus)
+extern "C" {
+#endif
+#endif
+
 #include "mpi.h"
+
+#ifdef MPI_SERIAL
+#if defined(__cplusplus)
+}
+#endif
+#endif
+
 #include "pio_internal.h"
 
 /* Timer states */

--- a/src/clib/spio_file_mvcache.cpp
+++ b/src/clib/spio_file_mvcache.cpp
@@ -3,12 +3,10 @@
 #include <stdexcept>
 #include <cassert>
 
-extern "C"{
 #include "pio_config.h"
 #include "pio.h"
 #include "pio_internal.h"
 #include "spio_file_mvcache.h"
-}
 
 #include "spio_file_mvcache.hpp"
 

--- a/src/clib/spio_file_mvcache.h
+++ b/src/clib/spio_file_mvcache.h
@@ -5,6 +5,10 @@
 #include "pio.h"
 #include "pio_internal.h"
 
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
 /* C interface for accessing the Multi-Variable Cache */
 
 /* Initialize the MVCache. The MVCache needs to init before using it */
@@ -21,4 +25,9 @@ void spio_file_mvcache_free(file_desc_t *file, int ioid);
 void spio_file_mvcache_clear(file_desc_t *file);
 /* Finalize the MVCache */
 void spio_file_mvcache_finalize(file_desc_t *file);
+
+#if defined(__cplusplus)
+}
+#endif
+
 #endif // __SPIO_FILE_MVCACHE_H__

--- a/src/clib/spio_file_mvcache.hpp
+++ b/src/clib/spio_file_mvcache.hpp
@@ -3,12 +3,10 @@
 
 #include <map>
 
-extern "C"{
 #include "pio_config.h"
 #include "pio.h"
 #include "pio_internal.h"
 #include "spio_file_mvcache.h"
-}
 
 namespace SPIO_Util{
   namespace File_Util{

--- a/src/clib/spio_io_summary.cpp
+++ b/src/clib/spio_io_summary.cpp
@@ -10,12 +10,10 @@
 #include <cstdlib>
 #include <unistd.h>
 
-extern "C"{
 #include "pio_config.h"
 #include "pio.h"
 #include "pio_internal.h"
 #include "spio_io_summary.h"
-}
 
 #include "spio_io_summary.hpp"
 #include "spio_serializer.hpp"

--- a/src/clib/spio_io_summary.h
+++ b/src/clib/spio_io_summary.h
@@ -22,6 +22,10 @@ typedef struct spio_io_fstats_summary{
   PIO_Offset wb;
 } spio_io_fstats_summary_t;
 
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
 /* Write the I/O performance summary. The function is
  * called when an I/O system is finalized
  */
@@ -30,4 +34,9 @@ int spio_write_io_summary(iosystem_desc_t *ios);
  * The function is called when a file is closed
  */
 int spio_write_file_io_summary(file_desc_t *file);
+
+#if defined(__cplusplus)
+}
+#endif
+
 #endif /* __SPIO_IO_SUMMARY_H__ */

--- a/src/clib/spio_ltimer.cpp
+++ b/src/clib/spio_ltimer.cpp
@@ -3,12 +3,10 @@
 #include <map>
 #include <cassert>
 
-extern "C"{
 #include "pio_config.h"
 #include "pio.h"
 #include "pio_internal.h"
 #include "spio_ltimer.h"
-}
 #include "spio_ltimer.hpp"
 
 /* Global timer cache */

--- a/src/clib/spio_ltimer.h
+++ b/src/clib/spio_ltimer.h
@@ -1,6 +1,10 @@
 #ifndef __SPIO_LTIMER_H__
 #define __SPIO_LTIMER_H__
 
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
 /* Start a timer */
 void spio_ltimer_start(const char *timer_name);
 /* Stop a timer */
@@ -10,6 +14,10 @@ void spio_ltimer_stop(const char *timer_name);
  * - A started timer needs to be stopped before querying the wallclock time
  */
 double spio_ltimer_get_wtime(const char *timer_name);
+
+#if defined(__cplusplus)
+}
+#endif
 
 #endif /* __SPIO_LTIMER_H__ */
 

--- a/src/gptl/CMakeLists.txt
+++ b/src/gptl/CMakeLists.txt
@@ -52,6 +52,18 @@ endif ()
 target_compile_definitions (gptl
   PUBLIC ${CMAKE_Fortran_COMPILER_DIRECTIVE})
 
+# Compiler-specific compiler options
+string (TOUPPER "${CMAKE_C_COMPILER_ID}" CMAKE_C_COMPILER_NAME)
+if (CMAKE_C_COMPILER_NAME STREQUAL "CRAY")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -h std=c99")
+elseif (CMAKE_C_COMPILER_NAME STREQUAL "PGI")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -c99")
+elseif (CMAKE_C_COMPILER_NAME STREQUAL "NVHPC")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -c99")
+else ()
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c99")
+endif ()
+
 if (CMAKE_Fortran_COMPILER_ID STREQUAL "NAG")
   set ( CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -mismatch_all" )
   #    target_compile_options (gptl

--- a/src/gptl/private.h
+++ b/src/gptl/private.h
@@ -8,6 +8,7 @@
 
 #include <stdio.h>
 #include <sys/time.h>
+#include <stdbool.h>
 
 #ifndef NO_COMM_F2C
 #ifndef HAVE_COMM_F2C
@@ -42,10 +43,6 @@
 ** all available options.
 */
 #define MAX_AUX 9
-
-#ifndef __cplusplus
-typedef enum {false = 0, true = 1} bool;  /* mimic C++ */
-#endif
 
 typedef struct {
   long last_utime;          /* saved usr time from "start" */

--- a/tests/cunit/pio_tests.h
+++ b/tests/cunit/pio_tests.h
@@ -66,6 +66,10 @@
         return e;                                                       \
     } while (0)
 
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
 /* Function prototypes. */
 int pio_test_init(int argc, char **argv, int *my_rank, int *ntasks, int target_ntasks, MPI_Comm *test_comm);
 int pio_test_init2(int argc, char **argv, int *my_rank, int *ntasks, int min_ntasks,
@@ -94,4 +98,9 @@ int run_test_main(int argc, char **argv, int min_ntasks, int max_ntasks,
 /* Create a 2D decomposition used in some tests. */
 int create_decomposition_2d(int ntasks, int my_rank, int iosysid, int *dim_len_2d, int *ioid,
                             int pio_type);
+
+#if defined(__cplusplus)
+}
+#endif
+
 #endif /* _PIO_TESTS_H */

--- a/tests/cunit/test_sdecomp_regex.cpp
+++ b/tests/cunit/test_sdecomp_regex.cpp
@@ -5,9 +5,7 @@
 #include <cassert>
 
 #include "pio_sdecomps_regex.hpp"
-extern "C"{
-#include <pio_tests.h>
-}
+#include "pio_tests.h"
 
 #define LOG_RANK0(rank, ...)                     \
             do{                                   \

--- a/tests/cunit/test_spio_file_mvcache.cpp
+++ b/tests/cunit/test_spio_file_mvcache.cpp
@@ -4,12 +4,10 @@
 #include <cassert>
 #include <cstring>
 
-extern "C"{
 #include "pio_config.h"
 #include "pio.h"
 #include "pio_tests.h"
 #include "spio_file_mvcache.h"
-}
 #include "spio_file_mvcache.hpp"
 
 #define LOG_RANK0(rank, ...)                     \

--- a/tests/cunit/test_spio_ltimer.cpp
+++ b/tests/cunit/test_spio_ltimer.cpp
@@ -5,12 +5,10 @@
 #include <algorithm>
 #include <cassert>
 
-extern "C"{
 #include "pio_config.h"
 #include "pio.h"
 #include "pio_tests.h"
 #include "spio_ltimer.h"
-}
 #include "spio_ltimer.hpp"
 
 #define LOG_RANK0(rank, ...)                     \

--- a/tests/cunit/test_spio_serializer.cpp
+++ b/tests/cunit/test_spio_serializer.cpp
@@ -6,11 +6,9 @@
 #include <cassert>
 #include <cctype>
 
-extern "C"{
 #include "pio_config.h"
 #include "pio.h"
 #include "pio_tests.h"
-}
 #include "spio_serializer.hpp"
 
 #define LOG_RANK0(rank, ...)                     \

--- a/tests/cunit/test_spio_tree.cpp
+++ b/tests/cunit/test_spio_tree.cpp
@@ -5,11 +5,9 @@
 #include <algorithm>
 #include <cassert>
 
-extern "C"{
 #include "pio_config.h"
 #include "pio.h"
 #include "pio_tests.h"
-}
 #include "spio_tree.hpp"
 
 #define LOG_RANK0(rank, ...)                     \

--- a/tools/adios2pio-nm/adios2pio-nm-lib-c.h
+++ b/tools/adios2pio-nm/adios2pio-nm-lib-c.h
@@ -1,7 +1,19 @@
 #ifndef _ADIOS2PIO_NM_LIB_C_H_
 #define _ADIOS2PIO_NM_LIB_C_H_
 
+#ifdef MPI_SERIAL
+#if defined(__cplusplus)
+extern "C" {
+#endif
+#endif
+
 #include <mpi.h>
+
+#ifdef MPI_SERIAL
+#if defined(__cplusplus)
+}
+#endif
+#endif
 
 #ifdef __cplusplus
 extern "C" {

--- a/tools/adios2pio-nm/adios2pio-nm-lib.cxx
+++ b/tools/adios2pio-nm/adios2pio-nm-lib.cxx
@@ -14,10 +14,8 @@
 
 #include <adios2.h>
 
-extern "C" {
 #include "pio.h"
 #include "pio_internal.h"
-}
 
 #include "adios2pio-nm-lib.h"
 #include "adios2pio-nm-lib-c.h"

--- a/tools/adios2pio-nm/adios2pio-nm-lib.h
+++ b/tools/adios2pio-nm/adios2pio-nm-lib.h
@@ -2,7 +2,16 @@
 #define _ADIOS2PIO_NM_LIB_H_ 
 
 #include <string>
+
+#ifdef MPI_SERIAL
+extern "C" {
+#endif
+
 #include <mpi.h>
+
+#ifdef MPI_SERIAL
+}
+#endif
 
 using namespace std;
 

--- a/tools/spio_finfo/spio_file_test_utils.h
+++ b/tools/spio_finfo/spio_file_test_utils.h
@@ -4,10 +4,8 @@
 #include <string>
 #include <vector>
 
-extern "C"{
 #include "pio_config.h"
 #include "pio.h"
-} // extern "C"
 
 #include "spio_finfo.h"
 

--- a/tools/spio_finfo/spio_finfo.h
+++ b/tools/spio_finfo/spio_finfo.h
@@ -4,10 +4,8 @@
 #include <string>
 #include <vector>
 
-extern "C"{
 #include "pio_config.h"
 #include "pio.h"
-} // extern "C"
 
 #include "mpi.h"
 

--- a/tools/spio_finfo/spio_finfo.h
+++ b/tools/spio_finfo/spio_finfo.h
@@ -7,8 +7,6 @@
 #include "pio_config.h"
 #include "pio.h"
 
-#include "mpi.h"
-
 /* Fwd decl reqd for create_spio_finfo() */
 class spio_finfo;
 

--- a/tools/util/argparser.h
+++ b/tools/util/argparser.h
@@ -1,4 +1,14 @@
+
+#ifdef MPI_SERIAL
+extern "C" {
+#endif
+
 #include "mpi.h"
+
+#ifdef MPI_SERIAL
+}
+#endif
+
 #include <iostream>
 #include <string>
 #include <vector>

--- a/tools/util/spio_lib_info.h
+++ b/tools/util/spio_lib_info.h
@@ -4,10 +4,8 @@
 #include <string>
 #include <vector>
 
-extern "C"{
 #include "pio_config.h"
 #include "pio.h"
-} // extern "C"
 
 namespace spio_tool_utils{
   namespace spio_lib_info{

--- a/tools/util/spio_misc_tool_utils.h
+++ b/tools/util/spio_misc_tool_utils.h
@@ -3,10 +3,8 @@
 
 #include <string>
 
-extern "C"{
 #include "pio_config.h"
 #include "pio.h"
-} // extern "C"
 #include "mpi.h"
 
 namespace spio_tool_utils{

--- a/tools/util/spio_misc_tool_utils.h
+++ b/tools/util/spio_misc_tool_utils.h
@@ -5,7 +5,6 @@
 
 #include "pio_config.h"
 #include "pio.h"
-#include "mpi.h"
 
 namespace spio_tool_utils{
   


### PR DESCRIPTION
Fixing build issues with the Cray compiler on Crusher
(with craype-accel-amd-gfx90a, rocm/5.1.0 modules)

* Fixing issues with the cray compiler implicitly loading stdbool.h
  for OpenMP builds (with craype-accel-amd-gfx90a, rocm/5.1.0) by
  explicitly including it (this is a different approach from what
  was used to fix the issue in GPTL distributed with E3SM/CIME)
* Fixing C/C++ linkage issues for OpenMP builds with the cray
  compiler (with craype-accel-amd-gfx90a, rocm/5.1.0) by moving
  extern "C" blocks from source files to header files (and not
  including system header files in an extern "C" block)

Fixes #496