### PR TITLE
Use function version of flush for XL

### DIFF
--- a/src/gptl/perf_utils.F90
+++ b/src/gptl/perf_utils.F90
@@ -158,7 +158,7 @@ SUBROUTINE shr_sys_flush(unit)
 !-------------------------------------------------------------------------------
 
 #if (defined IRIX64 || defined CRAY || defined OSF1 || defined SUNOS || defined LINUX || defined NEC_SX || defined UNICOSMP)
-#ifdef CPRNAG
+#if (defined CPRNAG || defined CPRIBM)
    flush(unit)
 #else
    call flush(unit)


### PR DESCRIPTION
The subroutine for flushing stdout, flush, is not available in newer
versions (at least 16.1.1-10 on Summit) of the XL compiler.

So for XL we now use the function version of flush

Fixes #497 