### PR TITLE
Fix missing flush function with XL

### DIFF
--- a/src/gptl/CMakeLists.txt
+++ b/src/gptl/CMakeLists.txt
@@ -61,6 +61,9 @@ elseif (CMAKE_Fortran_COMPILER_ID STREQUAL "GNU")
     set ( CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fallow-argument-mismatch" )
   endif ()
 endif ()
+if (CMAKE_Fortran_COMPILER_ID STREQUAL "XL")
+  set ( CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -qextname=flush" )
+endif ()
 
 #==============================================================================
 #  DEFINE THE INSTALL


### PR DESCRIPTION
Fix SCORPIO standalone build issues with the XL compiler
on Summit.

Declare flush as an external/global entity for the XL compiler.
This allows us to use flush (instead of flush_) in the code.

Fixes #497 