### PR TITLE
Skip MPI C++ bindings for SGI MPT

### DIFF
--- a/src/clib/CMakeLists.txt
+++ b/src/clib/CMakeLists.txt
@@ -215,10 +215,15 @@ target_compile_definitions (pioc
   PRIVATE ${CMAKE_SYSTEM_DIRECTIVE})
 target_compile_definitions (pioc
   PUBLIC ${CMAKE_C_COMPILER_DIRECTIVE})
+# Skip MPI C++ headers/bindings for MPICH lib
 target_compile_definitions (pioc
   PUBLIC MPICH_SKIP_MPICXX)
+# Skip MPI C++ headers/bindings for OpenMPI lib
 target_compile_definitions (pioc
   PUBLIC OMPI_SKIP_MPICXX)
+# Skip MPI C++ headers/bindings for SGI MPT lib
+target_compile_definitions (pioc
+  PUBLIC MPI_NO_CPPBIND)
 
 # Add user-specified include/libs/compiler/link options
 target_include_directories (pioc

--- a/tools/adios2pio-nm/CMakeLists.txt
+++ b/tools/adios2pio-nm/CMakeLists.txt
@@ -103,10 +103,15 @@ target_compile_definitions (adios2pio-nm-lib
   PRIVATE ${CMAKE_SYSTEM_DIRECTIVE})
 target_compile_definitions (adios2pio-nm-lib
   PUBLIC ${CMAKE_C_COMPILER_DIRECTIVE})
+# Skip MPI C++ headers/bindings for MPICH lib
 target_compile_definitions (adios2pio-nm-lib
   PUBLIC MPICH_SKIP_MPICXX)
+# Skip MPI C++ headers/bindings for OpenMPI lib
 target_compile_definitions (adios2pio-nm-lib
   PUBLIC OMPI_SKIP_MPICXX)
+# Skip MPI C++ headers/bindings for SGI MPT lib
+target_compile_definitions (adios2pio-nm-lib
+  PUBLIC MPI_NO_CPPBIND)
 
 # Set external lib compiler/link flags
 if (PnetCDF_C_FOUND)

--- a/tools/spio_finfo/CMakeLists.txt
+++ b/tools/spio_finfo/CMakeLists.txt
@@ -92,10 +92,15 @@ target_include_directories(spio_finfo.exe PRIVATE
   ${PnetCDF_C_INCLUDE_DIRS} 
   ${PIO_C_EXTRA_INCLUDE_DIRS})
 
+# Skip MPI C++ headers/bindings for MPICH lib
 target_compile_definitions (spio_finfo.exe
   PUBLIC MPICH_SKIP_MPICXX)
+# Skip MPI C++ headers/bindings for OpenMPI lib
 target_compile_definitions (spio_finfo.exe
   PUBLIC OMPI_SKIP_MPICXX)
+# Skip MPI C++ headers/bindings for SGI MPT lib
+target_compile_definitions (spio_finfo.exe
+  PUBLIC MPI_NO_CPPBIND)
 
 # Add external lib compile/link flags
 if (NetCDF_C_FOUND)


### PR DESCRIPTION
Skipping MPI C++ headers/bindigs for the SGI MPT library.
We already skip the MPI C++ headers/bindngs for MPICH
and OpenMPI libraries.