### PR TITLE
Define PIO_64BIT_DATA with NC_64BIT_DATA from NetCDF/PnetCDF

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -295,8 +295,8 @@ endif()
 
 # Min versions of libraries required
 set (MPE_MIN_VER_REQD "2.4.8")
-set (NETCDF_C_MIN_VER_REQD "4.3.3")
-set (NETCDF_FORTRAN_MIN_VER_REQD "4.3.3")
+set (NETCDF_C_MIN_VER_REQD "4.4.0")
+set (NETCDF_FORTRAN_MIN_VER_REQD "4.4.0")
 set (PNETCDF_MIN_VER_REQD "1.8.1")
 set (ADIOS_MIN_VER_REQD "2.7.0")
 

--- a/src/clib/pio.h
+++ b/src/clib/pio.h
@@ -210,10 +210,7 @@ typedef PIO_OFFSET_C_TYPENAME PIO_Offset;
 #define PIO_MAX_VAR_DIMS NC_MAX_VAR_DIMS
 #endif
 #define PIO_64BIT_OFFSET NC_64BIT_OFFSET
-
-/** NC_64BIT_DATA This is a problem - need to define directly instead
- * of using include file. */
-#define PIO_64BIT_DATA 0x0010
+#define PIO_64BIT_DATA NC_64BIT_DATA
 
 /** Define the netCDF-based error codes. */
 #define PIO_NOERR  NC_NOERR

--- a/tests/cunit/pio_tests.h
+++ b/tests/cunit/pio_tests.h
@@ -33,7 +33,7 @@
 #define NUM_REARRANGERS 2
 
 /* Number of sample files constructed for these tests. */
-#define NUM_SAMPLES 3
+#define NUM_SAMPLES 5
 
 /** Error code for when things go wrong. */
 #define ERR_CHECK 1109
@@ -82,6 +82,10 @@ int create_nc_sample_1(int iosysid, int format, char *filename, int my_rank, int
 int check_nc_sample_1(int iosysid, int format, char *filename, int my_rank, int *ncid);
 int create_nc_sample_2(int iosysid, int format, char *filename, int my_rank, int *ncid);
 int check_nc_sample_2(int iosysid, int format, char *filename, int my_rank, int *ncid);
+int create_nc_sample_64bit_offset(int iosysid, int format, char *filename, int my_rank, int *ncid);
+int check_nc_sample_64bit_offset(int iosysid, int format, char *filename, int my_rank, int *ncid);
+int create_nc_sample_64bit_data(int iosysid, int format, char *filename, int my_rank, int *ncid);
+int check_nc_sample_64bit_data(int iosysid, int format, char *filename, int my_rank, int *ncid);
 int get_iotypes(int *num_flavors, int *flavors);
 int get_iotype_name(int iotype, char *name);
 int pio_test_finalize(MPI_Comm *test_comm);


### PR DESCRIPTION
Due to historical reasons related to older versions of NetCDF and
PnetCDF, PIO_64BIT_DATA in SCORPIO was hard-coded to a specific
value. However, this causes a problem as it is different from the
NC_64BIT_DATA definition in newer versions of NetCDF (4.4.0 or
higher) and PnetCDF (1.6.0 or higher). This issue is demonstrated
through new C unit tests included in this PR.

To address this issue, the minimum required version of NetCDF is
being bumped from 4.3.3 to 4.4.0, which will allow us to safely
define PIO_64BIT_DATA as NC_64BIT_DATA.