### PR TITLE
Fix build errors with ADIOS2 2.9.0 by removing deprecated debug mode flag

### DIFF
--- a/src/clib/pioc.c
+++ b/src/clib/pioc.c
@@ -1305,7 +1305,7 @@ int PIOc_Init_Intracomm(MPI_Comm comp_comm, int num_iotasks, int stride, int bas
 
     if (ios->adios_io_process == 1)
     {
-        ios->adiosH = adios2_init(ios->adios_comm, adios2_debug_mode_on);
+        ios->adiosH = adios2_init_mpi(ios->adios_comm);
         if (ios->adiosH == NULL)
         {
             GPTLstop("PIO:PIOc_Init_Intracomm");

--- a/tools/adios2pio-nm/adios2pio-nm-lib.cxx
+++ b/tools/adios2pio-nm/adios2pio-nm-lib.cxx
@@ -2144,7 +2144,7 @@ int ConvertBPFile(const string &infilepath, const string &outfilename,
     nproc   = w_nproc;
 
     // Initialization of the class factory
-    adios2::ADIOS adios(w_comm, adios2::DebugON);
+    adios2::ADIOS adios(w_comm);
 
     double time_init = 0;
     double time_init_max = -1;
@@ -2230,7 +2230,7 @@ int ConvertBPFile(const string &infilepath, const string &outfilename,
         adios.RemoveIO(bpIO[0].Name());
         bpReader[1].Close();
         adios.RemoveIO(bpIO[1].Name());
-        adios2::ADIOS adios_new(comm, adios2::DebugON);
+        adios2::ADIOS adios_new(comm);
         ierr = OpenAdiosFile(adios_new, bpIO, bpReader, file0, err_msg);
 
         if (io_proc == 0)


### PR DESCRIPTION
This PR addresses build errors that occur when using ADIOS2 2.9.0
with SCORPIO. Specifically, the deprecated debug mode flag has
been removed to enable successful builds with the latest version
of ADIOS2. This PR ensures that SCORPIO can still be built with
ADIOS2 2.8 as well.