### PR TITLE
WIP: Export scorpio targets as a cmake package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -381,3 +381,31 @@ if (PIO_ENABLE_DOC)
 else ()
   message(STATUS "Disabling SCORPIO Documentation... (default, use -DPIO_ENABLE_DOC:BOOL=ON to enable documentation)")
 endif ()
+
+##############################################
+###   Package scorpio as a CMake package   ###
+##############################################
+
+include(GNUInstallDirs)
+include(CMakePackageConfigHelpers)
+
+configure_package_config_file(
+  cmake/ScorpioConfig.cmake.in
+  "${CLDERA_BINARY_DIR}/ScorpioConfig.cmake"
+  INSTALL_DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR}/cmake)
+
+write_basic_package_version_file(
+  "${CLDERA_BINARY_DIR}/ScorpioConfigVersion.cmake"
+  VERSION ${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}.
+  COMPATIBILITY SameMajorVersion)
+
+
+# Install the ScorpioConfig*.cmake files
+install(FILES
+  "${CLDERA_BINARY_DIR}/ScorpioConfig.cmake"
+  "${CLDERA_BINARY_DIR}/ScorpioConfigVersion.cmake"
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/scorpio)
+
+# Install cmake targets
+install(EXPORT ScorpioTargets
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/scorpio)

--- a/cmake/ScorpioConfig.cmake.in
+++ b/cmake/ScorpioConfig.cmake.in
@@ -1,0 +1,37 @@
+@PACKAGE_INIT@
+
+include(CMakeFindDependencyMacro)
+
+if (@PIO_ENABLE_TIMING@)
+  find_dependency(gptl)
+endif()
+
+if (@PIO_USE_MPISERIAL@)
+  find_package (MPISERIAL COMPONENTS C REQUIRED)
+else ()
+  find_dependency (MPI REQUIRED COMPONENTS C)
+endif()
+
+if (@WITH_NETCDF@)
+  find_dependency (NetCDF @NETCDF_C_MIN_VER_REQD@ COMPONENTS C)
+endif()
+if (@WITH_PNETCDF@)
+  find_dependency (PnetCDF @PNETCDF_MIN_VER_REQD@ COMPONENTS C)
+endif()
+if (@WITH_ADIOS2@)
+  find_dependency (ADIOS2 @ADIOS_MIN_VER_REQD@)
+endif()
+if (@WITH_HDF5@)
+  find_dependency (HDF5 COMPONENTS HL C)
+endif()
+
+if (@PIO_ENABLE_FORTRAN@)
+  if (@WITH_NETCDF@)
+    find_dependency (NetCDF @NETCDF_FORTRAN_MIN_VER_REQD@ COMPONENTS Fortran)
+  endif()
+  if (@WITH_PNETCDF@)
+    find_dependency (PnetCDF @PNETCDF_MIN_VER_REQD@ COMPONENTS Fortran)
+  endif()
+endif()
+
+include (${CMAKE_CURRENT_LIST_DIR}/ScorpioTargets.cmake)

--- a/src/clib/CMakeLists.txt
+++ b/src/clib/CMakeLists.txt
@@ -199,16 +199,17 @@ SET(CMAKE_EXTRA_INCLUDE_FILES)
 #==============================================================================
 #  SET THE COMPILER OPTIONS
 #==============================================================================
-# set up include-directories
-include_directories(
-  "${PROJECT_SOURCE_DIR}"   # to find foo/foo.h
-  "${PROJECT_BINARY_DIR}")  # to find foo/config.h
+# # set up include-directories
+# include_directories(
+#   "${PROJECT_SOURCE_DIR}"   # to find foo/foo.h
+#   "${PROJECT_BINARY_DIR}")  # to find foo/config.h
 
 # Include the clib source and binary directory
 target_include_directories (pioc
-  PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
-target_include_directories (pioc
-  PUBLIC ${CMAKE_CURRENT_BINARY_DIR})
+  PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+  PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
+  PUBLIC $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/pioc>
+)
 
 # System and compiler CPP directives
 target_compile_definitions (pioc
@@ -245,6 +246,12 @@ endif ()
 # MPI_Irsends
 target_compile_definitions (pioc
   PRIVATE USE_MPI_ISEND_FOR_FC)
+
+# Set public header property, so install can install headers
+set_target_properties (pioc PROPERTIES
+  PUBLIC_HEADER
+  "${CMAKE_CURRENT_SOURCE_DIR}/pio.h;${PROJECT_BINARY_DIR}/pio_config.h"
+)
 
 # Compiler-specific compiler options
 string (TOUPPER "${CMAKE_C_COMPILER_ID}" CMAKE_C_COMPILER_NAME)
@@ -302,22 +309,19 @@ else ()
   set(USE_MICRO_TIMING 0)
 endif ()
 
+# Generate pio_config.h
+configure_file (
+  "${PROJECT_SOURCE_DIR}/pio_config.h.in"
+  "${PROJECT_BINARY_DIR}/pio_config.h"
+)
+
 #==============================================================================
 #  INSTALL
 #==============================================================================
 
-# Install libpioc.a
-install (TARGETS pioc DESTINATION lib)
-
-# Install the header file
-install (FILES ${CMAKE_CURRENT_SOURCE_DIR}/pio.h DESTINATION include)
-
-# Generate and install pio_config.h
-configure_file (
-  "${PROJECT_SOURCE_DIR}/pio_config.h.in"
-  "${PROJECT_BINARY_DIR}/pio_config.h"
-  )
-
-# Install PIO config Include/Header File
-install (FILES ${PROJECT_BINARY_DIR}/pio_config.h DESTINATION include)
-
+# Install pioc target as part of ScorpioTargets
+install (TARGETS pioc
+  EXPORT ScorpioTargets
+  LIBRARY       DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  ARCHIVE       DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/pioc)

--- a/src/flib/CMakeLists.txt
+++ b/src/flib/CMakeLists.txt
@@ -65,10 +65,19 @@ add_dependencies (piof genf90)
 #==============================================================================
 #  SET THE COMPILER OPTIONS
 #==============================================================================
-# Include flib source and binary directories (for Fortran modules)
+
+# Beside source dir, include bin dir (for modules generated with genf90),
+# as well as the fortran module directory. If INSTALL_INTERFACE, simply include
+# the include dir
+
+set_target_properties (piof PROPERTIES
+  Fortran_MODULE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/modules)
 target_include_directories (piof
-  PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}
-  PUBLIC ${CMAKE_CURRENT_BINARY_DIR})
+  PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+  PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
+  PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/modules>
+  PUBLIC $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/piof>
+)
 
 # System and compiler CPP directives
 target_compile_definitions (piof
@@ -241,20 +250,15 @@ endif ()
 #==============================================================================
 #  INSTALL
 #==============================================================================
-set (PIO_Fortran_MODS ${CMAKE_CURRENT_BINARY_DIR}/pio.mod
-  ${CMAKE_CURRENT_BINARY_DIR}/pio_nf.mod
-  ${CMAKE_CURRENT_BINARY_DIR}/pio_types.mod
-  ${CMAKE_CURRENT_BINARY_DIR}/piolib_mod.mod
-  ${CMAKE_CURRENT_BINARY_DIR}/pionfget_mod.mod
-  ${CMAKE_CURRENT_BINARY_DIR}/pio_kinds.mod
-  ${CMAKE_CURRENT_BINARY_DIR}/pio_support.mod
-  ${CMAKE_CURRENT_BINARY_DIR}/piodarray.mod
-  ${CMAKE_CURRENT_BINARY_DIR}/pionfatt_mod.mod
-  ${CMAKE_CURRENT_BINARY_DIR}/pionfput_mod.mod)
 
-# Install libpiof.a
-install (TARGETS piof DESTINATION lib)
+# Install piof target as part of ScorpioTargets
+install (TARGETS piof
+  EXPORT ScorpioTargets
+  LIBRARY       DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  ARCHIVE       DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/piof)
 
-# Install the Fortran modules
-install (FILES ${PIO_Fortran_MODS} DESTINATION include)
-
+# Until CMake comes up with a better way to handle compiled Fortran modules,
+# we're stuck with installing modules by hand
+install (DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/modules/
+         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/piof)

--- a/src/gptl/CMakeLists.txt
+++ b/src/gptl/CMakeLists.txt
@@ -27,9 +27,19 @@ set (GPTL_Fortran_MODS ${CMAKE_CURRENT_BINARY_DIR}/perf_mod.mod
 
 add_library (gptl ${GPTL_Fortran_SRCS} ${GPTL_C_SRCS})
 
+set_target_properties (gptl PROPERTIES
+  Fortran_MODULE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/modules)
+set_target_properties (gptl PROPERTIES
+  PUBLIC_HEADER
+    ${CMAKE_CURRENT_SOURCE_DIR}/gptl.h
+)
+
 target_include_directories (gptl
-  PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}
-  PUBLIC ${CMAKE_CURRENT_BINARY_DIR})
+  PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+  PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
+  PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/modules>
+  PUBLIC $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/gptl>
+)
 
 target_compile_definitions (gptl
   PUBLIC INCLUDE_CMAKE_FCI)
@@ -76,19 +86,6 @@ endif ()
 if (CMAKE_Fortran_COMPILER_ID STREQUAL "XL")
   set ( CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -qextname=flush" )
 endif ()
-
-#==============================================================================
-#  DEFINE THE INSTALL
-#==============================================================================
-
-# Library
-install (TARGETS gptl DESTINATION lib)
-
-# Header/Include File
-install (FILES ${CMAKE_CURRENT_SOURCE_DIR}/gptl.h DESTINATION include)
-
-# Fortran Modules
-install (FILES ${GPTL_Fortran_MODS} DESTINATION include)
 
 #==============================================================================
 #  DEFINE THE DEPENDENCIES
@@ -192,3 +189,19 @@ if (NOT DEFINED SYSTEM_HAS_GETTIMEOFDAY)
   set (SYSTEM_HAS_GETTIMEOFDAY ${GETTIMEOFDAY}
     CACHE INTERNAL "Whether the gettimeofday function could be found")
 endif ()
+
+#==============================================================================
+#  DEFINE THE INSTALL
+#==============================================================================
+
+# Install gptl target as part of ScorpioTargets
+install (TARGETS gptl
+  EXPORT ScorpioTargets
+  LIBRARY       DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  ARCHIVE       DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/gptl)
+
+# Until CMake comes up with a better way to handle compiled Fortran modules,
+# we're stuck with installing modules by hand
+install (DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/modules/
+         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/gptl)


### PR DESCRIPTION
I have 1.5 projects that would benefit from being able to use scorpio, but the price to pay is that we need to install the project exporting the targets (in a modern CMake way). This requires scorpio to install its targets, as well as handle include directories in a careful way (depending on whether this is a BUILD_INTERFACE or INSTALL_INTERFACE).

This PR aims at getting there. It's not yet completed. So far I only verified that it builds and installs correctly, but I still need to a) stress test w.r.t configurations, and b) verify that a downstream find_package can find scorpio correctly.