### PR TITLE
No need to define and write attributes on all ranks for ADIOS IO type

### DIFF
--- a/src/clib/pio_file.c
+++ b/src/clib/pio_file.c
@@ -598,41 +598,44 @@ int PIOc_closefile(int ncid)
                                "adios2_begin_step failed for file (%s)", pio_get_fname_from_file(file));
             }
 
-            adios2_attribute *attributeH = adios2_inquire_attribute(file->ioH, "/__pio__/fillmode");
-            if (attributeH == NULL)
+            if (file->adios_rank == 0)
             {
-                attributeH = adios2_define_attribute(file->ioH, "/__pio__/fillmode", adios2_type_int32_t, &file->fillmode);
+                adios2_attribute *attributeH = adios2_inquire_attribute(file->ioH, "/__pio__/fillmode");
                 if (attributeH == NULL)
                 {
-                    if (file->iotype == PIO_IOTYPE_ADIOS)
+                    attributeH = adios2_define_attribute(file->ioH, "/__pio__/fillmode", adios2_type_int32_t, &file->fillmode);
+                    if (attributeH == NULL)
                     {
-                        GPTLstop("PIO:PIOc_closefile_adios");
-                        GPTLstop("PIO:write_total_adios");
-#ifndef _ADIOS_BP2NC_TEST
-                        GPTLstop("PIO:write_total");
-                        spio_ltimer_stop(ios->io_fstats->wr_timer_name);
-                        spio_ltimer_stop(ios->io_fstats->tot_timer_name);
-                        spio_ltimer_stop(file->io_fstats->wr_timer_name);
-                        spio_ltimer_stop(file->io_fstats->tot_timer_name);
-#endif
-                    }
-                    else
-                    {
-                        GPTLstop("PIO:PIOc_closefile");
-
-                        if (file->mode & PIO_WRITE)
+                        if (file->iotype == PIO_IOTYPE_ADIOS)
                         {
-                            GPTLstop("PIO:PIOc_closefile_write_mode");
+                            GPTLstop("PIO:PIOc_closefile_adios");
+                            GPTLstop("PIO:write_total_adios");
+#ifndef _ADIOS_BP2NC_TEST
                             GPTLstop("PIO:write_total");
                             spio_ltimer_stop(ios->io_fstats->wr_timer_name);
+                            spio_ltimer_stop(ios->io_fstats->tot_timer_name);
                             spio_ltimer_stop(file->io_fstats->wr_timer_name);
+                            spio_ltimer_stop(file->io_fstats->tot_timer_name);
+#endif
                         }
-                        spio_ltimer_stop(ios->io_fstats->tot_timer_name);
-                        spio_ltimer_stop(file->io_fstats->tot_timer_name);
+                        else
+                        {
+                            GPTLstop("PIO:PIOc_closefile");
+
+                            if (file->mode & PIO_WRITE)
+                            {
+                                GPTLstop("PIO:PIOc_closefile_write_mode");
+                                GPTLstop("PIO:write_total");
+                                spio_ltimer_stop(ios->io_fstats->wr_timer_name);
+                                spio_ltimer_stop(file->io_fstats->wr_timer_name);
+                            }
+                            spio_ltimer_stop(ios->io_fstats->tot_timer_name);
+                            spio_ltimer_stop(file->io_fstats->tot_timer_name);
+                        }
+                        return pio_err(ios, file, PIO_EADIOS2ERR, __FILE__, __LINE__,
+                                       "Defining (ADIOS) attribute (name=/__pio__/fillmode) failed for file (%s, ncid=%d)",
+                                       pio_get_fname_from_file(file), file->pio_ncid);
                     }
-                    return pio_err(ios, file, PIO_EADIOS2ERR, __FILE__, __LINE__,
-                                   "Defining (ADIOS) attribute (name=/__pio__/fillmode) failed for file (%s, ncid=%d)",
-                                   pio_get_fname_from_file(file), file->pio_ncid);
                 }
             }
 

--- a/src/clib/pio_getput_int.c
+++ b/src/clib/pio_getput_int.c
@@ -279,7 +279,7 @@ int PIOc_put_att_tc(int ncid, int varid, const char *name, nc_type atttype,
         }
 
         char att_name[PIO_MAX_NAME];
-        if (file->adios_io_process == 1)
+        if (file->adios_io_process == 1 && file->adios_rank == 0)
         {
             snprintf(att_name, PIO_MAX_NAME, "%s/%s", path, name);
             adios2_attribute *attributeH = adios2_inquire_attribute(file->ioH, att_name);


### PR DESCRIPTION
This patch is provided by @tkurc (Tahsin Kurc), which is required
for an ultra-high resolution scream IO benchmark test run with 8K
nodes on Frontier using ADIOS IO type to pass.

For ADIOS IO type, there is no need to define the same attributes
on all ranks, which might greatly increase the attribute metadata
size and cause ADIOS lib to throw an exception when trying to
gathering more than 2^31 elements.