### PR TITLE
Configure check for NC4 chunking consts

### DIFF
--- a/cmake/CheckNC4ChunkConsts.f90
+++ b/cmake/CheckNC4ChunkConsts.f90
@@ -1,0 +1,7 @@
+      PROGRAM check_nc4_chunk_consts
+        IMPLICIT NONE
+        include 'netcdf.inc'
+        INTEGER, PARAMETER :: PIO_CONTIGUOUS = NF_CONTIGUOUS
+        INTEGER, PARAMETER :: PIO_CHUNKED = NF_CHUNKED
+        INTEGER, PARAMETER :: PIO_COMPACT = NF_COMPACT
+      END PROGRAM check_nc4_chunk_consts

--- a/src/flib/CMakeLists.txt
+++ b/src/flib/CMakeLists.txt
@@ -233,6 +233,19 @@ if (WITH_NETCDF)
     if (EXISTS ${NetCDF_Fortran_INCLUDE_DIR}/netcdf_par.h)
       target_compile_definitions (piof
         PUBLIC _NETCDF4)
+      # Check if NETCDF4 chunk setting constants are available
+      # Note: Not all versions of NetCDF with NetCDF4 support have
+      # these chunking constants
+      check_macro (HAVE_NC4_CHUNK_CONSTS
+        NAME CheckNC4ChunkConsts.f90
+        HINTS ${CMAKE_MODULE_PATH}
+        DEFINITIONS -I${NetCDF_Fortran_INCLUDE_DIRS}
+        COMMENT "Whether the NetCDF4 chunking constants are available")
+      if(HAVE_NC4_CHUNK_CONSTS)
+        target_compile_definitions (piof PUBLIC HAVE_NC4_CHUNK_CONSTS)
+      else ()
+        message(WARNING "NetCDF4 is available but NetCDF4 chunking constants are not defined (limits chunking support)")
+      endif ()
     endif ()
   else ()
     message(STATUS "NetCDF Fortran library not found. Disabling support for NetCDF")

--- a/src/flib/spio_def_var.F90
+++ b/src/flib/spio_def_var.F90
@@ -569,6 +569,7 @@ CONTAINS
     INTEGER, INTENT(IN) :: storage
     INTEGER, DIMENSION(:), INTENT(IN) :: chunksizes
 
+    CHARACTER(LEN=PIO_MAX_NAME) :: log_msg
     INTEGER :: i, ndims
     INTEGER(C_INT), DIMENSION(:), ALLOCATABLE :: cchunksizes
 
@@ -582,6 +583,16 @@ CONTAINS
     DO i=1,ndims
       cchunksizes(i) = INT(chunksizes(ndims - i + 1), C_INT)
     END DO
+
+#ifndef HAVE_NC4_CHUNK_CONSTS
+    ! NetCDF4 support is available but the chunking constants (for storage option) is not
+    ! defined
+    WRITE(log_msg, *) "NetCDF4 support is available but the NetCDF4 chunking constants",&
+                      " were not defined. The chunking storage options specified by the",&
+                      " user might be ignored (pio_def_var_chunking_file_vdesc()).",&
+                      " fh = ", file%fh, ", varid = ", vdesc%varid
+    CALL pio_warn(file%iosystem, __PIO_FILE__, __LINE__, TRIM(log_msg))
+#endif
 
     ierr = PIOc_def_var_chunking(file%fh, INT(vdesc%varid, C_INT) - 1,&
                                   INT(storage, C_INT), cchunksizes)

--- a/src/flib/spio_netcdf_types.F90
+++ b/src/flib/spio_netcdf_types.F90
@@ -20,7 +20,7 @@ MODULE spio_netcdf_types
 !!  - PIO_COMPACT : Store data in the file header for compactness (variables < 64MB)
 !<
 
-#ifdef _NETCDF4
+#ifdef HAVE_NC4_CHUNK_CONSTS
 #include <netcdf.inc>
   integer, public, parameter :: PIO_CONTIGUOUS = NF_CONTIGUOUS
   integer, public, parameter :: PIO_CHUNKED = NF_CHUNKED


### PR DESCRIPTION
Adding a configure check (and appropriate warning messages) for NetCDF4
chunking constants.

Fixes #523 