### PR TITLE
Adding config check for is_contiguous

### DIFF
--- a/cmake/CheckIsContiguous.f90
+++ b/cmake/CheckIsContiguous.f90
@@ -1,0 +1,7 @@
+      PROGRAM check_is_contiguous
+        IMPLICIT NONE
+        INTEGER :: a(10)
+        LOGICAL :: res
+        
+        res = IS_CONTIGUOUS(a)
+      END PROGRAM check_is_contiguous

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -28,6 +28,20 @@ add_subdirectory (clib)
 # Add the Fortran library
 if (PIO_ENABLE_FORTRAN)
   message(STATUS "Enabling the Fortran interface...")
+
+  # Check if prereqs for new Fortran interface is available
+  check_macro (HAVE_IS_CONTIGUOUS
+    NAME CheckIsContiguous.f90
+    HINTS ${CMAKE_MODULE_PATH}
+    COMMENT "Checking whether IS_CONTIGUOUS (F2008) is available")
+
+  if (NOT PIO_USE_FORTRAN_LEGACY_LIB)
+    if (NOT HAVE_IS_CONTIGUOUS)
+      message(WARNING "Some F2008 features required for new Fortran interface is missing. Forcing use of the legacy Fortran interface")
+      set (PIO_USE_FORTRAN_LEGACY_LIB ON)
+    endif ()
+  endif ()
+
   if (PIO_USE_FORTRAN_LEGACY_LIB)
     message(STATUS "Using the Fortran legacy interface library...")
     add_subdirectory (flib_legacy)


### PR DESCRIPTION
Adding config checks for F2008 features required for the
new Fortran interface (IS_CONTIGUOUS).

Fixes #529 