### PR TITLE
Resolve I/O Performance summary issue for ADIOS type

### DIFF
--- a/src/clib/pio_getput_int.c
+++ b/src/clib/pio_getput_int.c
@@ -272,7 +272,7 @@ int PIOc_put_att_tc(int ncid, int varid, const char *name, nc_type atttype,
         file->adios_attrs[num_attrs].adios_type = adios_type;
         file->num_attrs++;
 
-        if (file->all_rank == MPI_ROOT)
+        if (ios->iomaster == MPI_ROOT)
         {
             ios->io_fstats->wb += len * atttype_len;
             file->io_fstats->wb += len * atttype_len;


### PR DESCRIPTION
Comparing file->all_rank with MPI_ROOT to calculate bytes written
in PIOc_put_att_tc() using ADIOS type is incorrect.

Opt for ios->iomaster for the comparison instead.

This fix is crucial to ensure that the I/O performance summary
accurately reflects the bytes written in PIOc_put_att_tc() for
ADIOS type.