### PR TITLE
Adding support for pio_set_fill

### DIFF
--- a/src/flib/pio.F90
+++ b/src/flib/pio.F90
@@ -18,7 +18,7 @@ module pio
                         pio_set_hint, pio_set_rearr_opts, pio_set_blocksize
   use spio_file, only : pio_openfile, pio_createfile, pio_closefile,&
                         pio_deletefile, pio_setframe, pio_advanceframe,&
-                        pio_syncfile, pio_file_is_open
+                        pio_syncfile, pio_file_is_open, pio_set_fill
   use spio_misc_api, only : pio_set_buffer_size_limit, pio_iotype_available
   use spio_err, only : pio_setdebuglevel, pio_seterrorhandling, pio_strerror, pio_set_log_level
 
@@ -33,7 +33,7 @@ module pio
        pio_global, pio_char, pio_write, pio_nowrite, pio_clobber, pio_noclobber, &
        pio_max_name, pio_max_var_dims, pio_rearr_subset, pio_rearr_box, &
 #if defined(_NETCDF) || defined(_PNETCDF)
-       pio_nofill, pio_unlimited, pio_fill_char, pio_fill_int, pio_fill_double, pio_fill_float, &
+       pio_fill, pio_nofill, pio_unlimited, pio_fill_char, pio_fill_int, pio_fill_double, pio_fill_float, &
 #endif
        pio_64bit_offset, pio_64bit_data, &
        pio_internal_error, pio_bcast_error, pio_reduce_error,&

--- a/src/flib/pio_types.F90
+++ b/src/flib/pio_types.F90
@@ -240,6 +240,7 @@ module pio_types
    integer, public, parameter :: PIO_nowrite  = nf_nowrite
    integer, public, parameter :: PIO_CLOBBER = nf_clobber
    integer, public, parameter :: PIO_NOCLOBBER = nf_NOclobber
+   integer, public, parameter :: PIO_FILL = nf_fill
    integer, public, parameter :: PIO_NOFILL = nf_nofill
    integer, public, parameter :: PIO_MAX_DIMS = min(nf_max_dims, PIO_MAX_DIMS_UB)
    integer, public, parameter :: PIO_MAX_ATTRS = min(nf_max_attrs, PIO_MAX_ATTRS_UB)
@@ -267,6 +268,7 @@ module pio_types
    integer, public, parameter :: PIO_nowrite = nf_nowrite
    integer, public, parameter :: PIO_CLOBBER = nf_clobber
    integer, public, parameter :: PIO_NOCLOBBER = nf_NOclobber
+   integer, public, parameter :: PIO_FILL = nf_fill
    integer, public, parameter :: PIO_NOFILL = nf_nofill
    integer, public, parameter :: PIO_MAX_DIMS = min(nf_max_dims, PIO_MAX_DIMS_UB)
    integer, public, parameter :: PIO_MAX_ATTRS = min(nf_max_attrs, PIO_MAX_ATTRS_UB)
@@ -291,6 +293,8 @@ module pio_types
    integer, public, parameter :: PIO_MAX_VARS = PIO_MAX_VARS_UB
    integer, public, parameter :: PIO_MAX_NAME = PIO_MAX_NAME_UB
    integer, public, parameter :: PIO_MAX_VAR_DIMS = 6
+   integer, public, parameter :: PIO_FILL = 0
+   integer, public, parameter :: PIO_NOFILL = 1
    integer, public, parameter :: PIO_CLOBBER = 10
    integer, public, parameter :: PIO_NOCLOBBER = 11
    integer, public, parameter :: PIO_WRITE = 20

--- a/src/flib/spio_file_cint.F90
+++ b/src/flib/spio_file_cint.F90
@@ -154,4 +154,23 @@ INTERFACE
   END FUNCTION PIOc_File_is_Open
 END INTERFACE
 
+INTERFACE
+!> @private
+!! @brief Set the default fillmode to use for variables in a file
+!!
+!! @details
+!! @param[in] fh The handle/id to the file with the variable
+!! @param[in] fillmode The fillmode to use for variables in the file
+!! @param[out]  prev_fillmode The previous fillmode set for this file
+!! @return PIO_NOERR on success, an error code otherwise
+!!
+  INTEGER(C_INT) FUNCTION PIOc_set_fill(fh, fillmode, prev_fillmode)&
+                          bind(C,name="PIOc_set_fill")
+    USE iso_c_binding
+    INTEGER(C_INT), VALUE :: fh
+    INTEGER(C_INT), VALUE :: fillmode
+    INTEGER(C_INT)        :: prev_fillmode
+  END FUNCTION PIOc_set_fill
+END INTERFACE
+
 END MODULE spio_file_cint

--- a/src/flib_legacy/pio.F90
+++ b/src/flib_legacy/pio.F90
@@ -17,7 +17,7 @@ module pio
        pio_freedecomp, pio_syncfile, &
        pio_finalize, pio_set_hint, pio_getnumiotasks, pio_file_is_open, &
        PIO_deletefile, PIO_get_numiotasks, PIO_iotype_available, &
-       pio_set_rearr_opts
+       pio_set_rearr_opts, pio_set_fill
 
   use pio_types, only : io_desc_t, file_desc_t, var_desc_t, iosystem_desc_t, &
        pio_rearr_opt_t, pio_rearr_comm_fc_opt_t, pio_rearr_comm_fc_2d_enable,&
@@ -30,7 +30,7 @@ module pio
        pio_global, pio_char, pio_write, pio_nowrite, pio_clobber, pio_noclobber, &
        pio_max_name, pio_max_var_dims, pio_rearr_subset, pio_rearr_box, &
 #if defined(_NETCDF) || defined(_PNETCDF)
-       pio_nofill, pio_unlimited, pio_fill_char, pio_fill_int, pio_fill_double, pio_fill_float, &
+       pio_fill, pio_nofill, pio_unlimited, pio_fill_char, pio_fill_int, pio_fill_double, pio_fill_float, &
 #endif
        pio_64bit_offset, pio_64bit_data, &
        pio_internal_error, pio_bcast_error, pio_reduce_error,&

--- a/src/flib_legacy/pio_types.F90
+++ b/src/flib_legacy/pio_types.F90
@@ -195,6 +195,7 @@ module pio_types
    integer, public, parameter :: PIO_nowrite  = nf_nowrite
    integer, public, parameter :: PIO_CLOBBER = nf_clobber
    integer, public, parameter :: PIO_NOCLOBBER = nf_NOclobber
+   integer, public, parameter :: PIO_FILL = nf_fill
    integer, public, parameter :: PIO_NOFILL = nf_nofill
    integer, public, parameter :: PIO_MAX_DIMS = min(nf_max_dims, PIO_MAX_DIMS_UB)
    integer, public, parameter :: PIO_MAX_ATTRS = min(nf_max_attrs, PIO_MAX_ATTRS_UB)
@@ -222,6 +223,7 @@ module pio_types
    integer, public, parameter :: PIO_nowrite = nf_nowrite
    integer, public, parameter :: PIO_CLOBBER = nf_clobber
    integer, public, parameter :: PIO_NOCLOBBER = nf_NOclobber
+   integer, public, parameter :: PIO_FILL = nf_fill
    integer, public, parameter :: PIO_NOFILL = nf_nofill
    integer, public, parameter :: PIO_MAX_DIMS = min(nf_max_dims, PIO_MAX_DIMS_UB)
    integer, public, parameter :: PIO_MAX_ATTRS = min(nf_max_attrs, PIO_MAX_ATTRS_UB)
@@ -246,6 +248,8 @@ module pio_types
    integer, public, parameter :: PIO_MAX_VARS = PIO_MAX_VARS_UB
    integer, public, parameter :: PIO_MAX_NAME = 25
    integer, public, parameter :: PIO_MAX_VAR_DIMS = 6
+   integer, public, parameter :: PIO_FILL = 0
+   integer, public, parameter :: PIO_NOFILL = 1
    integer, public, parameter :: PIO_CLOBBER = 10
    integer, public, parameter :: PIO_NOCLOBBER = 11
    integer, public, parameter :: PIO_WRITE = 20

--- a/src/flib_legacy/piolib_mod.F90
+++ b/src/flib_legacy/piolib_mod.F90
@@ -53,7 +53,8 @@ module piolib_mod
        PIO_deletefile, &
        PIO_get_numiotasks, &
        PIO_iotype_available, &
-       PIO_set_rearr_opts
+       PIO_set_rearr_opts, &
+       PIO_set_fill
 
 #ifdef MEMCHK
 !> this is an internal variable for memory leak debugging
@@ -1201,6 +1202,45 @@ contains
                                 max_pend_req_i2c)
 
   end function pio_set_rearr_opts
+
+!>
+!! @public
+!! @ingroup PIO_set_fill
+!! @brief Set the fillmode for a file
+!! @details
+!! @param file : The file handle
+!! @param fillmode : The new fillmode for the file
+!! @param prev_fillmode : (Optional) The previous/old fillmode for the file
+!<
+  integer function pio_set_fill(file, fillmode, prev_fillmode) result(ierr)
+    type(file_desc_t), intent(in) :: file
+    integer, intent(in) :: fillmode
+    integer, intent(out), optional :: prev_fillmode
+
+    integer(c_int) :: cprev_fillmode
+    interface
+       integer(c_int) function PIOc_set_fill(fh, fmode, prev_fmode) &
+            bind(C,name="PIOc_set_fill")
+         use iso_c_binding
+         integer(C_INT), value :: fh
+         integer(C_INT), value :: fmode
+         integer(C_INT) :: prev_fmode
+       end function PIOc_set_fill
+    end interface
+
+#ifdef TIMING
+    ! This call is not very costly, we can ignore it
+    !call t_startf("PIO:set_fill")
+#endif
+    ierr = PIOc_set_fill(file%fh, int(fillmode, C_INT), cprev_fillmode)
+    if(present(prev_fillmode)) then
+      prev_fillmode = int(cprev_fillmode)
+    end if
+#ifdef TIMING
+    !call t_stopf("PIO:set_fill")
+#endif
+
+  end function pio_set_fill
 
 
 end module piolib_mod

--- a/tests/general/pio_decomp_fillval.F90.in
+++ b/tests/general/pio_decomp_fillval.F90.in
@@ -405,3 +405,132 @@ PIO_TF_AUTO_TEST_SUB_BEGIN nc_read_1d_implicit_fval
   deallocate(rbuf)
   deallocate(rcompdof)
 PIO_TF_AUTO_TEST_SUB_END nc_read_1d_implicit_fval
+
+! FIXME: Add tests for >1D vars, partially written out vars and distributed arrays
+
+PIO_TF_TEMPLATE<PIO_TF_PREDEF_TYPENAME PIO_TF_DATA_TYPE, PIO_TF_PREDEF_TYPENAME PIO_TF_FC_DATA_TYPE>
+PIO_TF_AUTO_TEST_SUB_BEGIN test_set_fill
+  Implicit none
+  type(file_desc_t) :: pio_file
+  character(len=PIO_TF_MAX_STR_LEN) :: filename
+  type(var_desc_t)  :: pio_var_nofill, pio_var_fill, pio_cvar_nofill, pio_cvar_fill
+  integer :: pio_dim
+  integer, parameter :: DIM_LEN = 100
+  PIO_TF_FC_DATA_TYPE, dimension(DIM_LEN) :: pval, gval
+  CHARACTER(len=DIM_LEN) :: pcval, gcval
+  integer, dimension(:), allocatable :: iotypes
+  character(len=PIO_TF_MAX_STR_LEN), dimension(:), allocatable :: iotype_descs
+  character(len=*), parameter :: PIO_VAR_NOFILL_NAME = 'dummy_nofill_var_put_val'
+  character(len=*), parameter :: PIO_VAR_FILL_NAME = 'dummy_fill_var_put_val'
+  character(len=*), parameter :: PIO_CVAR_NOFILL_NAME = 'dummy_nofill_var_put_cval'
+  character(len=*), parameter :: PIO_CVAR_FILL_NAME = 'dummy_fill_var_put_cval'
+  integer :: num_iotypes
+  integer :: i, ret, prev_fillmode
+
+  pval = pio_tf_world_sz_
+  pcval = "DUMMY_STRING"
+  num_iotypes = 0
+  call PIO_TF_Get_nc_iotypes(iotypes, iotype_descs, num_iotypes)
+  filename = "test_pio_ncdf_get_put.testfile"
+  do i=1,num_iotypes
+    PIO_TF_LOG(0,*) "Testing type :", iotype_descs(i)
+    ret = PIO_createfile(pio_tf_iosystem_, pio_file, iotypes(i), filename, PIO_CLOBBER)
+    PIO_TF_CHECK_ERR(ret, "Failed to open:" // trim(filename))
+
+    ! Since file is just created no need to enter redef
+    ret = PIO_def_dim(pio_file, 'dummy_dim_put_val', DIM_LEN, pio_dim)
+    PIO_TF_CHECK_ERR(ret, "Failed to define dim:" // trim(filename))
+
+    ret = PIO_def_var(pio_file, PIO_VAR_NOFILL_NAME, PIO_TF_DATA_TYPE, (/pio_dim/), pio_var_nofill)
+    PIO_TF_CHECK_ERR(ret, "Failed to define var:" // trim(filename))
+
+    ret = PIO_def_var(pio_file, PIO_VAR_FILL_NAME, PIO_TF_DATA_TYPE, (/pio_dim/), pio_var_fill)
+    PIO_TF_CHECK_ERR(ret, "Failed to define var:" // trim(filename))
+
+    ret = PIO_def_var(pio_file, PIO_CVAR_NOFILL_NAME, PIO_char, (/pio_dim/), pio_cvar_nofill)
+    PIO_TF_CHECK_ERR(ret, "Failed to define char var:" // trim(filename))
+
+    ret = PIO_def_var(pio_file, PIO_CVAR_FILL_NAME, PIO_char, (/pio_dim/), pio_cvar_fill)
+    PIO_TF_CHECK_ERR(ret, "Failed to define char var:" // trim(filename))
+
+    ret = PIO_set_fill(pio_file, PIO_NOFILL, prev_fillmode)
+    PIO_TF_CHECK_ERR(ret, "Failed to set fillmode to NOFILL:" // trim(filename))
+
+    ret = PIO_enddef(pio_file)
+    PIO_TF_CHECK_ERR(ret, "Failed to enddef:" // trim(filename))
+
+    ret = PIO_put_var(pio_file, pio_var_nofill, pval);
+    PIO_TF_CHECK_ERR(ret, "Failed to put var:" // trim(filename))
+
+    ret = PIO_put_var(pio_file, pio_cvar_nofill, pcval);
+    PIO_TF_CHECK_ERR(ret, "Failed to put char var:" // trim(filename))
+
+    ret = PIO_redef(pio_file)
+    PIO_TF_CHECK_ERR(ret, "Failed to redef:" // trim(filename))
+
+    ret = PIO_set_fill(pio_file, PIO_FILL, prev_fillmode)
+    PIO_TF_CHECK_ERR(ret, "Failed to set fillmode to NOFILL:" // trim(filename))
+
+    ret = PIO_enddef(pio_file)
+    PIO_TF_CHECK_ERR(ret, "Failed to enddef:" // trim(filename))
+
+    ret = PIO_put_var(pio_file, pio_var_fill, pval);
+    PIO_TF_CHECK_ERR(ret, "Failed to put var:" // trim(filename))
+
+    ret = PIO_put_var(pio_file, pio_cvar_fill, pcval);
+    PIO_TF_CHECK_ERR(ret, "Failed to put char var:" // trim(filename))
+
+#ifdef PIO_TEST_CLOSE_OPEN_FOR_SYNC
+    call PIO_closefile(pio_file)
+
+    ret = PIO_openfile(pio_tf_iosystem_, pio_file, iotypes(i), filename, PIO_nowrite)
+    PIO_TF_CHECK_ERR(ret, "Failed to reopen:" // trim(filename))
+
+    ret = PIO_inq_varid(pio_file, PIO_VAR_NOFILL_NAME, pio_var_nofill)
+    PIO_TF_CHECK_ERR(ret, "Failed to get scalar var:" // trim(filename))
+
+    ret = PIO_inq_varid(pio_file, PIO_VAR_FILL_NAME, pio_var_fill)
+    PIO_TF_CHECK_ERR(ret, "Failed to get scalar var:" // trim(filename))
+
+    ret = PIO_inq_varid(pio_file, PIO_CVAR_NOFILL_NAME, pio_cvar_nofill)
+    PIO_TF_CHECK_ERR(ret, "Failed to get scalar char var:" // trim(filename))
+
+    ret = PIO_inq_varid(pio_file, PIO_CVAR_FILL_NAME, pio_cvar_fill)
+    PIO_TF_CHECK_ERR(ret, "Failed to get scalar char var:" // trim(filename))
+#else
+    call PIO_syncfile(pio_file)
+#endif
+
+    gval = 0
+    ret = PIO_get_var(pio_file, pio_var_nofill, gval);
+    PIO_TF_CHECK_ERR(ret, "Failed to get var (fillmode = NOFILL):" // trim(filename))
+
+    PIO_TF_CHECK_VAL((gval, pval), "Got wrong value (fillmode = NOFILL)")
+
+    gval = 0
+    ret = PIO_get_var(pio_file, pio_var_fill, gval);
+    PIO_TF_CHECK_ERR(ret, "Failed to get var (fillmode = FILL):" // trim(filename))
+
+    PIO_TF_CHECK_VAL((gval, pval), "Got wrong value (fillmode = FILL)")
+
+    gcval = ''
+    ret = PIO_get_var(pio_file, pio_cvar_nofill, gcval);
+    PIO_TF_CHECK_ERR(ret, "Failed to get char var (fillmode = NOFILL):" // trim(filename))
+
+    PIO_TF_CHECK_VAL((gcval, pcval), "Got wrong value (fillmode = NOFILL)")
+
+    gcval = ''
+    ret = PIO_get_var(pio_file, pio_cvar_fill, gcval);
+    PIO_TF_CHECK_ERR(ret, "Failed to get char var (fillmode = FILL):" // trim(filename))
+
+    PIO_TF_CHECK_VAL((gcval, pcval), "Got wrong value (fillmode = FILL)")
+
+    call PIO_closefile(pio_file)
+    call PIO_deletefile(pio_tf_iosystem_, filename);
+  end do
+  if(allocated(iotypes)) then
+    deallocate(iotypes)
+    deallocate(iotype_descs)
+  end if
+
+PIO_TF_AUTO_TEST_SUB_END test_set_fill


### PR DESCRIPTION
Adding support for pio_set_fill(), a function that can be used
to set the default fill mode for variables in a file

Fixes E3SM-Project/E3SM#6070