### PR TITLE
Allow ADIOS IO type to write an array of attribute values

### DIFF
--- a/src/clib/pio_getput_int.c
+++ b/src/clib/pio_getput_int.c
@@ -288,7 +288,13 @@ int PIOc_put_att_tc(int ncid, int varid, const char *name, nc_type atttype,
                 if (NC_CHAR == atttype || adios2_type_string == adios_type)
                     attributeH = adios2_define_attribute(file->ioH, att_name, adios2_type_string, op);
                 else
-                    attributeH = adios2_define_attribute(file->ioH, att_name, adios_type, op);
+                {
+                    /* If len > 1, it is an attribute array. Use ADIOS attribute array function. */
+                    if (len > 1)
+                        attributeH = adios2_define_attribute_array(file->ioH, att_name, adios_type, op, (size_t)len);
+                    else
+                        attributeH = adios2_define_attribute(file->ioH, att_name, adios_type, op);
+                }
 
                 if (attributeH == NULL)
                 {

--- a/tools/adios2pio-nm/adios2pio-nm-lib.cxx
+++ b/tools/adios2pio-nm/adios2pio-nm-lib.cxx
@@ -403,7 +403,11 @@ int ProcessVariableAndAttributeDefinitions(adios2::IO &bpIO, adios2::Engine &bpR
                 }
                 else
                 {
-                    ret = PIOc_put_att(ncid, vars_map[varname].nc_varid, attname, piotype, 1, adata[0].data());
+                    /* adata[0].data() may point to an attribute array. Compute the number of array elements. */
+                    int type_size = adios2_type_size_a2(atype);
+                    assert(type_size > 0);
+                    PIO_Offset data_len = (PIO_Offset) (adata[0].size() / type_size);
+                    ret = PIOc_put_att(ncid, vars_map[varname].nc_varid, attname, piotype, data_len, adata[0].data());
                 }
 
                 if (ret != PIO_NOERR)
@@ -441,7 +445,11 @@ int ProcessVariableAndAttributeDefinitions(adios2::IO &bpIO, adios2::Engine &bpR
             }
             else
             {
-                ret = PIOc_put_att(ncid, PIO_GLOBAL, attname, piotype, 1, adata[0].data());
+                /* adata[0].data() may point to an attribute array. Compute the number of array elements. */
+                int type_size = adios2_type_size_a2(atype);
+                assert(type_size > 0);
+                PIO_Offset data_len = (PIO_Offset) (adata[0].size() / type_size);
+                ret = PIOc_put_att(ncid, PIO_GLOBAL, attname, piotype, data_len, adata[0].data());
             }
 
             if (ret != PIO_NOERR)


### PR DESCRIPTION
This patch is provided by @tkurc (Tahsin Kurc), which is required
for the ADIOS I/O type to write an array of attribute values.

Fixes #546