### PR TITLE
Enhance nightly unit tests for ADIOS read support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -305,7 +305,7 @@ set (MPE_MIN_VER_REQD "2.4.8")
 set (NETCDF_C_MIN_VER_REQD "4.4.0")
 set (NETCDF_FORTRAN_MIN_VER_REQD "4.4.0")
 set (PNETCDF_MIN_VER_REQD "1.8.1")
-set (ADIOS_MIN_VER_REQD "2.7.0")
+set (ADIOS_MIN_VER_REQD "2.9.0")
 
 # Setting code coverage compiler flags (only GNU is supported for now)
 if (PIO_ENABLE_COVERAGE)

--- a/ctest/CTestScript-Test.cmake
+++ b/ctest/CTestScript-Test.cmake
@@ -30,7 +30,10 @@ ctest_test(INCLUDE "pio_unit_test|^init|pio_file\
 |pio_decomp|pio_sync_tests|pio_buf_lim_tests|pio_iodesc_tests\
 |pio_iosystem_tests|examplePio|example1|darray_no_async|test_adios")
 elseif (DEFINED ENV{ADIOS_READ_CTEST})
-ctest_test(INCLUDE "test_adios")
+ctest_test(INCLUDE "pio_unit_test|^init|pio_file\
+|ncdf_simple_tests\
+|pio_decomp_tests_|pio_decomp_frame_tests_|pio_decomp_extra_dims_\
+|pio_iosystem_tests|examplePio|example1|darray_no_async|test_adios")
 elseif (DEFINED ENV{HDF5_CTEST})
 ctest_test(INCLUDE "test_hdf5")
 else ()


### PR DESCRIPTION
Introduce preliminary Fortran unit tests to validate ADIOS read
support, with intentions to incorporate additional tests later
as we resolve identified issues.

Additionally, update the minimal required ADIOS version to 2.9.0,
as it is necessary for ADIOS read support.