### PR TITLE
Fix usage of find_package_handle_standard_args

### DIFF
--- a/cmake/FindGPTL.cmake
+++ b/cmake/FindGPTL.cmake
@@ -70,3 +70,6 @@ foreach (GPTL_comp IN LISTS GPTL_FIND_VALID_COMPONENTS)
     endif ()
     
 endforeach ()
+
+# Handle QUIET/REQUIRED, and set <PKG>_FOUND if all required components were found
+find_package_handle_standard_args (GPTL HANDLE_COMPONENTS)

--- a/cmake/FindHDF5.cmake
+++ b/cmake/FindHDF5.cmake
@@ -123,3 +123,6 @@ foreach (HDF5_comp IN LISTS HDF5_FIND_VALID_COMPONENTS)
     endif ()
     
 endforeach ()
+
+# Handle QUIET/REQUIRED, and set <PKG>_FOUND if all required components were found
+find_package_handle_standard_args (HDF5 HANDLE_COMPONENTS)

--- a/cmake/FindMPE.cmake
+++ b/cmake/FindMPE.cmake
@@ -48,3 +48,6 @@ foreach (NCDFcomp IN LISTS MPE_FIND_VALID_COMPONENTS)
   endif ()
   
 endforeach ()
+
+# Handle QUIET/REQUIRED, and set <PKG>_FOUND if all required components were found
+find_package_handle_standard_args (MPE HANDLE_COMPONENTS)

--- a/cmake/FindMPISERIAL.cmake
+++ b/cmake/FindMPISERIAL.cmake
@@ -42,3 +42,6 @@ foreach (MPISERIAL_comp IN LISTS MPISERIAL_FIND_VALID_COMPONENTS)
     endif ()
 
 endforeach ()
+
+# Handle QUIET/REQUIRED, and set <PKG>_FOUND if all required components were found
+find_package_handle_standard_args (MPISERIAL HANDLE_COMPONENTS)

--- a/cmake/FindNetCDF.cmake
+++ b/cmake/FindNetCDF.cmake
@@ -152,3 +152,6 @@ foreach (NCDFcomp IN LISTS NetCDF_FIND_VALID_COMPONENTS)
     endif ()
 
 endforeach ()
+
+# Handle QUIET/REQUIRED, and set <PKG>_FOUND if all required components were found
+find_package_handle_standard_args (NetCDF HANDLE_COMPONENTS)

--- a/cmake/FindPnetCDF.cmake
+++ b/cmake/FindPnetCDF.cmake
@@ -69,3 +69,6 @@ foreach (PNCDFcomp IN LISTS PnetCDF_FIND_VALID_COMPONENTS)
     endif ()
     
 endforeach ()
+
+# Handle QUIET/REQUIRED, and set <PKG>_FOUND if all required components were found
+find_package_handle_standard_args (PnetCDF HANDLE_COMPONENTS)

--- a/cmake/LibFind.cmake
+++ b/cmake/LibFind.cmake
@@ -297,15 +297,18 @@ function (find_package_component PKG)
             
         endforeach ()
         
-        # handle the QUIETLY and REQUIRED arguments and 
-        # set NetCDF_C_FOUND to TRUE if all listed variables are TRUE
-        find_package_handle_standard_args (${PKGCOMP} DEFAULT_MSG
-                                           ${PKGCOMP}_LIBRARY 
-                                           ${PKGCOMP}_INCLUDE_DIR)
+        # Use find_package_handle_standard_args only if this is not a component-specific
+        # call, to avoid cmake errors. If this is a component specific call, the upstream
+        # Find<PKG>.cmake module will take care of calling the macro, using HANDLE_COMPONENTS
+        if (NOT COMP) 
+          find_package_handle_standard_args (${PKGCOMP} DEFAULT_MSG
+                                             ${PKGCOMP}_LIBRARY 
+                                             ${PKGCOMP}_INCLUDE_DIR)
+        elseif (${PKGCOMP}_LIBRARY AND ${PKGCOMP}_INCLUDE_DIR)
+          set (${PKGCOMP}_FOUND TRUE)
+        endif()
+
         mark_as_advanced (${PKGCOMP}_INCLUDE_DIR ${PKGCOMP}_LIBRARY)
-        
-        # HACK For bug in CMake v3.0:
-        set (${PKGCOMP}_FOUND ${${PKGCOMPUP}_FOUND})
     
         # Set return variables
         if (${PKGCOMP}_FOUND)
@@ -320,7 +323,6 @@ function (find_package_component PKG)
         set (${PKGCOMP}_LIBRARY      ${${PKGCOMP}_LIBRARY}       PARENT_SCOPE)
         set (${PKGCOMP}_LIBRARIES    ${${PKGCOMP}_LIBRARIES}     PARENT_SCOPE)
         set (${PKGCOMP}_IS_SHARED    ${${PKGCOMP}_IS_SHARED}     PARENT_SCOPE)
-        
     endif ()
 
 endfunction ()

--- a/cmake/LibFind.cmake
+++ b/cmake/LibFind.cmake
@@ -203,12 +203,14 @@ function (find_package_component PKG)
              $ENV{${PKGUP}}
              ${CMAKE_SYSTEM_PREFIX_PATH})
 
-           # Start the search for the include file(s) and library file(s)
+        # Start the search for the include file(s) and library file(s)
         find_path (${PKGCOMP}_INCLUDE_DIR
                    NAMES ${${PKGCOMP}_INCLUDE_NAMES}
-                   PATHS ${SEARCH_DIRS})
+                   HINTS ${SEARCH_DIRS}
+                   PATH_SUFFIXES include)
 
-        # Only search for libs "near" the include dir
+        # From now on, use NO_DEFAULT_PATH, since we want to ONLY search
+        # the directories "near" the include dir, which we provide via HINTS
         find_library (${PKGCOMP}_LIBRARY
                       NAMES ${${PKGCOMP}_LIBRARY_NAMES}
                       HINTS ${${PKGCOMP}_INCLUDE_DIR} ${${PKGCOMP}_INCLUDE_DIR}/../


### PR DESCRIPTION
I'm resurrecting this branch, rebased on current master, in case there's a renewed interest. This PR removes CMake warnings like the following, which are polluting the output quite a bit.

```
CMake Warning (dev) at /home/lbertag/workdir/utils/cmake/cmake-install/share/cmake-3.27/Modules/FindPackageHandleStandardArgs.cmake:438 (message):
  The package name passed to `find_package_handle_standard_args` (PnetCDF_C)
  does not match the name of the calling package (PnetCDF).  This can lead to
  problems in calling code that expects `find_package` result variables
  (e.g., `_FOUND`) to follow a certain pattern.
Call Stack (most recent call first):
  /home/lbertag/workdir/scream/scream-src/master/externals/scorpio/cmake/LibFind.cmake:302 (find_package_handle_standard_args)
  /home/lbertag/workdir/scream/scream-src/master/externals/scorpio/cmake/FindPnetCDF.cmake:51 (find_package_component)
  /home/lbertag/workdir/scream/scream-src/master/externals/scorpio/src/clib/CMakeLists.txt:96 (find_package)
This warning is for project developers.  Use -Wno-dev to suppress it.
```