### PR TITLE
Add symlinks for ADIOS BP output files

### DIFF
--- a/src/clib/pio_internal.h
+++ b/src/clib/pio_internal.h
@@ -365,6 +365,11 @@ extern "C" {
     /* Handle end and re-defs. */
     int pioc_change_def(int ncid, int is_enddef);
 
+#ifdef _ADIOS2
+    /* Remove a directory in the filesystem */
+    int spio_remove_directory(const char *path);
+#endif
+
     /* Initialize and finalize logging. */
     void pio_init_logging(void);
     void pio_finalize_logging(void );

--- a/src/clib/pioc_support.c
+++ b/src/clib/pioc_support.c
@@ -53,7 +53,7 @@ extern bool fortran_order;
 /**
  * Utility function to remove a directory and all its contents.
  */
-static int remove_directory(const char *path)
+int spio_remove_directory(const char *path)
 {
     DIR *d = opendir(path);
     size_t path_len = strlen(path);
@@ -87,7 +87,7 @@ static int remove_directory(const char *path)
                 if (!stat(buf, &statbuf))
                 {
                     if (S_ISDIR(statbuf.st_mode))
-                        r2 = remove_directory(buf);
+                        r2 = spio_remove_directory(buf);
                     else
                         r2 = unlink(buf);
                 }
@@ -2882,7 +2882,7 @@ int PIOc_createfile_int(int iosysid, int *ncidp, const int *iotype, const char *
                         unlink(filename);
 
                     /* Delete the BP file */
-                    remove_directory(adios_bp_filename);
+                    spio_remove_directory(adios_bp_filename);
                 }
             }
         }

--- a/src/clib/pioc_support.c
+++ b/src/clib/pioc_support.c
@@ -2890,6 +2890,9 @@ int PIOc_createfile_int(int iosysid, int *ncidp, const int *iotype, const char *
             if (ios->union_rank == 0)
             {
                 struct stat sd;
+                if (0 == stat(filename, &sd))
+                    unlink(filename);
+
                 if (0 == stat(file->filename, &sd))
                     remove_directory(file->filename);
             }
@@ -2979,6 +2982,15 @@ int PIOc_createfile_int(int iosysid, int *ncidp, const int *iotype, const char *
                                pio_get_fname_from_file(file));
             }
             GPTLstop("PIO:adios2_open_call");
+
+            if(file->adios_rank == 0)
+            {
+                ierr = symlink(file->filename, filename);
+                if(ierr != 0)
+                {
+                    LOG((1, "PIO: WARNING: Creating symlink for %s file failed, ierr = %d", file->filename, ierr));
+                }
+            }
 
             ierr = begin_adios2_step(file, ios);
             if (ierr != PIO_NOERR)

--- a/src/clib/pioc_support.c
+++ b/src/clib/pioc_support.c
@@ -2886,20 +2886,19 @@ int PIOc_createfile_int(int iosysid, int *ncidp, const int *iotype, const char *
                 }
             }
         }
-
-        /* FIXME: Frequently due to application error different MPI processes have different
-         * file mode flags, so although ideally we need this barrier inside if(!(file->mode & PIO_NOCLOBBER))
-         * block above adding it here to avoid a potential hang */
-        /* Make sure that no task is trying to operate on the ADIOS BP file
-         * while it is being deleted */
-        if ((mpierr = MPI_Barrier(ios->io_comm)))
-        {
-            free(adios_bp_filename);
-            spio_ltimer_stop(file->io_fstats->wr_timer_name);
-            spio_ltimer_stop(file->io_fstats->tot_timer_name);
-            return check_mpi(ios, file, mpierr, __FILE__, __LINE__);
-        }
         free(adios_bp_filename);
+    }
+
+    /* FIXME: Frequently due to application error different MPI processes have different
+     * file mode flags, so although ideally we need this barrier inside if(!(file->mode & PIO_NOCLOBBER))
+     * block above adding it here to avoid a potential hang */
+    /* Make sure that no task is trying to operate on the ADIOS BP file
+     * while it is being deleted */
+    if ((mpierr = MPI_Barrier(ios->union_comm)))
+    {
+        spio_ltimer_stop(file->io_fstats->wr_timer_name);
+        spio_ltimer_stop(file->io_fstats->tot_timer_name);
+        return check_mpi(ios, file, mpierr, __FILE__, __LINE__);
     }
 
     /* ADIOS: assume all procs are also IO tasks */

--- a/src/clib/pioc_support.c
+++ b/src/clib/pioc_support.c
@@ -2853,24 +2853,70 @@ int PIOc_createfile_int(int iosysid, int *ncidp, const int *iotype, const char *
         }
     }
 
-    /* ADIOS: assume all procs are also IO tasks */
 #ifdef _ADIOS2
+    /* Append ".bp" to output filename for the corresponding ADIOS BP filename */
+    static const char adios_bp_filename_extn[] = ".bp";
+    size_t adios_bp_filename_len = strlen(filename) + sizeof(adios_bp_filename_extn) + 1;
+    if (ios->ioproc)
+    {
+        char *adios_bp_filename = (char *) calloc(adios_bp_filename_len, sizeof(char));
+        if (adios_bp_filename == NULL)
+        {
+            spio_ltimer_stop(file->io_fstats->wr_timer_name);
+            spio_ltimer_stop(file->io_fstats->tot_timer_name);
+            return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__,
+                           "Allocating memory for adios filename (%s) failed. Out of memory allocating %lld bytes for the file name",
+                           adios_bp_filename, (unsigned long long) (adios_bp_filename_len));
+        }
+        snprintf(adios_bp_filename, adios_bp_filename_len, "%s%s", filename, adios_bp_filename_extn);
+        if (!(file->mode & PIO_NOCLOBBER))
+        {
+            /* If PIO_NOCLOBBER is not set, i.e., CLOBBER mode, delete any ADIOS BP files with the same name */
+            if (ios->io_rank == 0)
+            {
+                struct stat sd;
+                if (0 == stat(adios_bp_filename, &sd))
+                {
+                    /* Delete symbolic link to the BP file (foo.nc -> foo.nc.bp) */
+                    if (0 == stat(filename, &sd))
+                        unlink(filename);
+
+                    /* Delete the BP file */
+                    remove_directory(adios_bp_filename);
+                }
+            }
+        }
+
+        /* FIXME: Frequently due to application error different MPI processes have different
+         * file mode flags, so although ideally we need this barrier inside if(!(file->mode & PIO_NOCLOBBER))
+         * block above adding it here to avoid a potential hang */
+        /* Make sure that no task is trying to operate on the ADIOS BP file
+         * while it is being deleted */
+        if ((mpierr = MPI_Barrier(ios->io_comm)))
+        {
+            free(adios_bp_filename);
+            spio_ltimer_stop(file->io_fstats->wr_timer_name);
+            spio_ltimer_stop(file->io_fstats->tot_timer_name);
+            return check_mpi(ios, file, mpierr, __FILE__, __LINE__);
+        }
+        free(adios_bp_filename);
+    }
+
+    /* ADIOS: assume all procs are also IO tasks */
     if (file->iotype == PIO_IOTYPE_ADIOS)
     {
         LOG((2, "Calling adios_open mode = %d", file->mode));
 
-        /* Append .bp to output file for ADIOS output */
-        int len = strlen(filename);
-        file->filename = (char*)calloc(len + 4, sizeof(char));
+        file->filename = (char*)calloc(adios_bp_filename_len, sizeof(char));
         if (file->filename == NULL)
         {
             spio_ltimer_stop(file->io_fstats->wr_timer_name);
             spio_ltimer_stop(file->io_fstats->tot_timer_name);
             return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__,
                            "Creating file (%s) using ADIOS iotype failed. Out of memory allocating %lld bytes for the file name",
-                           filename, (unsigned long long) (len + 4));
+                           filename, (unsigned long long) (adios_bp_filename_len));
         }
-        snprintf(file->filename, len + 4, "%s.bp", filename);
+        snprintf(file->filename, adios_bp_filename_len, "%s%s", filename, adios_bp_filename_extn);
 
         if (file->mode & PIO_NOCLOBBER) /* Check whether BP directory filename.bp exists */
         {
@@ -2882,28 +2928,6 @@ int PIOc_createfile_int(int iosysid, int *ncidp, const int *iotype, const char *
                 return pio_err(ios, NULL, PIO_EEXIST, __FILE__, __LINE__,
                                "Creating file (%s) using ADIOS iotype and PIO_NOCLOBBER mode failed. BP directory (%s) already exists",
                                filename, file->filename);
-            }
-        }
-        else
-        {
-            /* Delete directory filename.bp if it exists */
-            if (ios->union_rank == 0)
-            {
-                struct stat sd;
-                if (0 == stat(filename, &sd))
-                    unlink(filename);
-
-                if (0 == stat(file->filename, &sd))
-                    remove_directory(file->filename);
-            }
-
-            /* Make sure that no task is trying to operate on the
-             * directory while it is being deleted */
-            if ((mpierr = MPI_Barrier(ios->union_comm)))
-            {
-                spio_ltimer_stop(file->io_fstats->wr_timer_name);
-                spio_ltimer_stop(file->io_fstats->tot_timer_name);
-                return check_mpi(ios, file, mpierr, __FILE__, __LINE__);
             }
         }
 

--- a/src/clib/pioc_support.c
+++ b/src/clib/pioc_support.c
@@ -3012,7 +3012,7 @@ int PIOc_createfile_int(int iosysid, int *ncidp, const int *iotype, const char *
                 ierr = symlink(file->filename, filename);
                 if(ierr != 0)
                 {
-                    LOG((1, "PIO: WARNING: Creating symlink for %s file failed, ierr = %d", file->filename, ierr));
+                    fprintf(stdout, "PIO: WARNING: Creating symlink for %s file failed, ierr = %d", file->filename, ierr);
                 }
             }
 

--- a/src/clib/pioc_support.c
+++ b/src/clib/pioc_support.c
@@ -2859,21 +2859,22 @@ int PIOc_createfile_int(int iosysid, int *ncidp, const int *iotype, const char *
     size_t adios_bp_filename_len = strlen(filename) + sizeof(adios_bp_filename_extn) + 1;
     if (ios->ioproc)
     {
-        char *adios_bp_filename = (char *) calloc(adios_bp_filename_len, sizeof(char));
-        if (adios_bp_filename == NULL)
-        {
-            spio_ltimer_stop(file->io_fstats->wr_timer_name);
-            spio_ltimer_stop(file->io_fstats->tot_timer_name);
-            return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__,
-                           "Allocating memory for adios filename (%s) failed. Out of memory allocating %lld bytes for the file name",
-                           adios_bp_filename, (unsigned long long) (adios_bp_filename_len));
-        }
-        snprintf(adios_bp_filename, adios_bp_filename_len, "%s%s", filename, adios_bp_filename_extn);
         if (!(file->mode & PIO_NOCLOBBER))
         {
             /* If PIO_NOCLOBBER is not set, i.e., CLOBBER mode, delete any ADIOS BP files with the same name */
             if (ios->io_rank == 0)
             {
+                char *adios_bp_filename = (char *) calloc(adios_bp_filename_len, sizeof(char));
+                if (adios_bp_filename == NULL)
+                {
+                    spio_ltimer_stop(file->io_fstats->wr_timer_name);
+                    spio_ltimer_stop(file->io_fstats->tot_timer_name);
+                    return pio_err(ios, NULL, PIO_ENOMEM, __FILE__, __LINE__,
+                                   "Allocating memory for adios filename (%s) failed. Out of memory allocating %lld bytes for the file name",
+                                   adios_bp_filename, (unsigned long long) (adios_bp_filename_len));
+                }
+                snprintf(adios_bp_filename, adios_bp_filename_len, "%s%s", filename, adios_bp_filename_extn);
+
                 struct stat sd;
                 if (0 == stat(adios_bp_filename, &sd))
                 {
@@ -2884,9 +2885,9 @@ int PIOc_createfile_int(int iosysid, int *ncidp, const int *iotype, const char *
                     /* Delete the BP file */
                     spio_remove_directory(adios_bp_filename);
                 }
+                free(adios_bp_filename);
             }
         }
-        free(adios_bp_filename);
     }
 
     /* FIXME: Frequently due to application error different MPI processes have different

--- a/tools/adios2pio-nm/adios2pio-nm-lib.cxx
+++ b/tools/adios2pio-nm/adios2pio-nm-lib.cxx
@@ -2259,6 +2259,13 @@ int ConvertBPFile(const string &infilepath, const string &outfilename,
             ierr = BP2PIO_ERROR;
         }
 
+        /* Delete symlink, foo.nc, that points to the ADIOS BP dir, foo.nc.bp */
+        struct stat sd;
+        if(stat(outfilename.c_str(), &sd) == 0)
+        {
+            unlink(outfilename.c_str());
+        }
+
         /* Create output file */
         /*
          *   Use NC_64BIT_DATA instead of PIO_64BIT_OFFSET. Some output files will have variables

--- a/tools/adios2pio-nm/adios2pio-nm-lib.cxx
+++ b/tools/adios2pio-nm/adios2pio-nm-lib.cxx
@@ -2307,7 +2307,7 @@ int ConvertBPFile(const string &infilepath, const string &outfilename,
          *   Use NC_64BIT_DATA instead of PIO_64BIT_OFFSET. Some output files will have variables
          *   that require more than 4GB storage.
          */
-        ret = PIOc_createfile(iosysid, &ncid, &pio_iotype, outfilename.c_str(), NC_64BIT_DATA);
+        ret = PIOc_createfile(iosysid, &ncid, &pio_iotype, outfilename.c_str(), PIO_64BIT_DATA | PIO_CLOBBER);
         if (ret != PIO_NOERR)
         {
             cerr << "rank " << mpirank << ":ERROR in PIOc_createfile(), code = " << ret


### PR DESCRIPTION
Adding symlink (that has the filename specified by the user) for
ADIOS BP output files.

Also cleaning up the conversion tool to avoid duplicate conversion
of ADIOS BP output files (when the tool is run in a directory with
BP files that have already been converted to NetCDF)