### PR TITLE
Remove openfile retry calls from examples

### DIFF
--- a/examples/c/darray_async.c
+++ b/examples/c/darray_async.c
@@ -122,7 +122,7 @@ int resultlen;
 /*     /\* int expected[DIM_LEN_X];        /\\* Data values we expect to find. *\\/ *\/ */
 
 /*     /\* Open the file. *\/ */
-/*     if ((ret = PIOc_openfile_retry(iosysid, &ncid, &iotype, filename, 0, 0))) */
+/*     if ((ret = PIOc_openfile_retry(iosysid, &ncid, &iotype, filename, 0))) */
 /*         return ret; */
 /*     printf("opened file %s ncid = %d\n", filename, ncid); */
 

--- a/examples/c/darray_no_async.c
+++ b/examples/c/darray_no_async.c
@@ -110,7 +110,7 @@ int check_file(int iosysid, int ntasks, char *filename, int iotype,
     /* int expected[DIM_LEN_X];        /\* Data values we expect to find. *\/ */
 
     /* Open the file. */
-    if ((ret = PIOc_openfile_retry(iosysid, &ncid, &iotype, filename, 0, 0)))
+    if ((ret = PIOc_openfile(iosysid, &ncid, &iotype, filename, 0)))
         return ret;
     printf("opened file %s ncid = %d\n", filename, ncid);
 


### PR DESCRIPTION
Replacing the PIOc_openfile_retry() calls in C examples 
with PIOc_openfile() call

Without this change compilers that do not allow implicit function
declarations fail (or warn) when building C examples.