### PR TITLE
Adding PIO_REARR_ANY rearranger

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -254,6 +254,20 @@ else()
   message (STATUS "Configurable parameters used by ADIOS type are not applicable (default)")
 endif()
 
+# Maximum length of the local decomposition map for BOX rearanger
+set(DEF_SPIO_MAX_MAP_LEN_BOX_REARR 524288)
+if(DEFINED PIO_MAX_MAP_LEN_BOX_REARR)
+  if(PIO_MAX_MAP_LEN_BOX_REARR GREATER 0)
+    message(STATUS "Setting the maximum length of the local decomposition map for BOX rearanger to PIO_MAX_MAP_LEN_BOX_REARR = " ${PIO_MAX_MAP_LEN_BOX_REARR})
+  else()
+    message(WARNING "User-defined PIO_MAX_MAP_LEN_BOX_REARR is invalid, setting it to " ${DEF_SPIO_MAX_MAP_LEN_BOX_REARR} " (default)")
+    set(PIO_MAX_MAP_LEN_BOX_REARR ${DEF_SPIO_MAX_MAP_LEN_BOX_REARR})
+  endif()
+else()
+  set(PIO_MAX_MAP_LEN_BOX_REARR ${DEF_SPIO_MAX_MAP_LEN_BOX_REARR})
+  message(STATUS "Setting the maximum length of the local decomposition map for BOX rearanger to PIO_MAX_MAP_LEN_BOX_REARR = " ${PIO_MAX_MAP_LEN_BOX_REARR} " (default)")
+endif()
+
 #==============================================================================
 #  DETECT SYSTEM/COMPILERS (and set compiler specific options)
 #==============================================================================

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -254,18 +254,14 @@ else()
   message (STATUS "Configurable parameters used by ADIOS type are not applicable (default)")
 endif()
 
-# Maximum length of the local decomposition map for BOX rearanger
-set(DEF_SPIO_MAX_MAP_LEN_BOX_REARR 524288)
-if(DEFINED PIO_MAX_MAP_LEN_BOX_REARR)
-  if(PIO_MAX_MAP_LEN_BOX_REARR GREATER 0)
-    message(STATUS "Setting the maximum length of the local decomposition map for BOX rearanger to PIO_MAX_MAP_LEN_BOX_REARR = " ${PIO_MAX_MAP_LEN_BOX_REARR})
-  else()
-    message(WARNING "User-defined PIO_MAX_MAP_LEN_BOX_REARR is invalid, setting it to " ${DEF_SPIO_MAX_MAP_LEN_BOX_REARR} " (default)")
-    set(PIO_MAX_MAP_LEN_BOX_REARR ${DEF_SPIO_MAX_MAP_LEN_BOX_REARR})
-  endif()
+# Range of the length (max across all procs) of the local decomposition map for
+# switching to SUBSET rearranger, [512K, inf)
+set(DEF_SPIO_REARR_ANY_SUBSET_RANGE "(524288, -1)")
+if(DEFINED PIO_REARR_ANY_SUBSET_RANGE)
+  message(STATUS "PIO_REARR_ANY rearranger : Setting the local decomposition map length range for SUBSET rearanger (PIO_REARR_ANY_SUBSET_RANGE) to " ${PIO_REARR_ANY_SUBSET_RANGE})
 else()
-  set(PIO_MAX_MAP_LEN_BOX_REARR ${DEF_SPIO_MAX_MAP_LEN_BOX_REARR})
-  message(STATUS "Setting the maximum length of the local decomposition map for BOX rearanger to PIO_MAX_MAP_LEN_BOX_REARR = " ${PIO_MAX_MAP_LEN_BOX_REARR} " (default)")
+  set(PIO_REARR_ANY_SUBSET_RANGE ${DEF_SPIO_REARR_ANY_SUBSET_RANGE})
+  message(STATUS "PIO_REARR_ANY rearranger : Setting the local decomposition map length range for SUBSET rearanger (PIO_REARR_ANY_SUBSET_RANGE) to " ${PIO_REARR_ANY_SUBSET_RANGE} " (default)")
 endif()
 
 #==============================================================================

--- a/src/clib/CMakeLists.txt
+++ b/src/clib/CMakeLists.txt
@@ -15,7 +15,7 @@ add_library (pioc topology.c pio_mpi_timer.c pio_timer.c pio_file.c
   pioc.c pioc_sc.c pio_spmd.c pio_rearrange.c pio_nc4.c bget.c
   pio_nc.c pio_put_nc.c pio_get_nc.c pio_getput_int.c pio_msg.c pio_varm.c
   pio_darray.c pio_darray_int.c spio_hash.cpp pio_sdecomps_regex.cpp spio_io_summary.cpp
-  spio_ltimer.cpp spio_serializer.cpp spio_file_mvcache.cpp)
+  spio_ltimer.cpp spio_serializer.cpp spio_file_mvcache.cpp spio_rearrange_any.cpp)
 
 #==============================================================================
 #  FIND EXTERNAL LIBRARIES/DEPENDENCIES

--- a/src/clib/pio.h
+++ b/src/clib/pio.h
@@ -1197,7 +1197,10 @@ enum PIO_REARRANGERS
     PIO_REARR_BOX = 1,
 
     /** Subset rearranger. */
-    PIO_REARR_SUBSET = 2
+    PIO_REARR_SUBSET = 2,
+
+    /** Let the library choose the rearranger. */
+    PIO_REARR_ANY = 3
 };
 
 /**

--- a/src/clib/pio_config.h.in
+++ b/src/clib/pio_config.h.in
@@ -61,8 +61,8 @@
 /** Maximum number of cached application steps for ADIOS type */
 #define PIO_MAX_CACHED_STEPS_FOR_ADIOS @PIO_MAX_CACHED_STEPS_FOR_ADIOS@
 
-/** Maximum length of the local decomposition map for BOX rearanger. */
-#define PIO_MAX_MAP_LEN_BOX_REARR @PIO_MAX_MAP_LEN_BOX_REARR@
+/** Range of length of the local decomposition map for SUBSET rearanger. */
+#define PIO_REARR_ANY_SUBSET_RANGE "@PIO_REARR_ANY_SUBSET_RANGE@"
 
 /** Set to 1 if the library is configured to use the PnetCDF library,
  *  0 otherwise */

--- a/src/clib/pio_config.h.in
+++ b/src/clib/pio_config.h.in
@@ -61,6 +61,9 @@
 /** Maximum number of cached application steps for ADIOS type */
 #define PIO_MAX_CACHED_STEPS_FOR_ADIOS @PIO_MAX_CACHED_STEPS_FOR_ADIOS@
 
+/** Maximum length of the local decomposition map for BOX rearanger. */
+#define PIO_MAX_MAP_LEN_BOX_REARR @PIO_MAX_MAP_LEN_BOX_REARR@
+
 /** Set to 1 if the library is configured to use the PnetCDF library,
  *  0 otherwise */
 #define PIO_USE_PNETCDF @PIO_USE_PNETCDF@

--- a/src/clib/spio_rearrange_any.cpp
+++ b/src/clib/spio_rearrange_any.cpp
@@ -1,0 +1,96 @@
+#include <iostream>
+#include <stdexcept>
+#include <cassert>
+#include <string>
+#include <vector>
+#include <utility>
+#include <limits>
+
+#include "pio_config.h"
+#include "pio.h"
+//#include "pio_internal.h"
+
+extern "C"{
+#include "spio_rearrange_any.h"
+}
+
+namespace SPIO_Util{
+
+  /* FIXME: Handle malformed string pairs */
+  /* Convert "(intx, inty)" to std::pair<int, int> */
+  std::pair<int, int> str2pair(const std::string &spair)
+  {
+    std::pair<int, int> res;
+    const char PAIR_BBEGIN = '(';
+    const char PAIR_BEND = ')';
+    const char PAIR_SEP = ',';
+
+    res.first = stoi(spair.substr(spair.find(PAIR_BBEGIN) + 1, spair.find(PAIR_SEP)));
+    res.second = stoi(spair.substr(spair.find(PAIR_SEP) + 1, spair.find(PAIR_BEND)));
+
+    return res;
+  }
+
+  namespace GVars{
+    /* Collection of I/O decomposition length (local) ranges for different rearrangers */
+    static std::vector<std::pair<std::pair<int, int>, int> > opt_pio_rearr_ranges;
+  } // namespace GVars
+
+} // namespace SPIO_Util
+
+void spio_init_pio_rearr_any(void )
+{
+  static bool initialized = false;
+  if(initialized){
+    return;
+  }
+
+  /* FIXME: Once we have more ranges here, we need to sort the coll */
+  /* Add the range for SUBSET rearranger - from configure */
+  std::pair<int, int> subset_range = SPIO_Util::str2pair(PIO_REARR_ANY_SUBSET_RANGE);
+  if(subset_range.first == -1){
+    subset_range.first = std::numeric_limits<int>::max();
+  }
+  if(subset_range.second == -1){
+    subset_range.second = std::numeric_limits<int>::max();
+  }
+  SPIO_Util::GVars::opt_pio_rearr_ranges.push_back(std::make_pair(subset_range, PIO_REARR_SUBSET));
+
+  initialized = true;
+}
+
+int spio_get_opt_pio_rearr(iosystem_desc_t *iosys, int local_decomp_maplen)
+{
+  int mpierr = MPI_SUCCESS;
+
+  int opt_rearr = PIO_REARR_BOX;
+  int max_maplen = 0;
+
+  assert(iosys);
+  
+  mpierr = MPI_Allreduce(&local_decomp_maplen, &max_maplen,
+                          1, MPI_INT, MPI_MAX, iosys->union_comm);
+  if(mpierr != MPI_SUCCESS){
+    if(iosys->union_rank == 0){
+      fprintf(stderr,
+        "Finding max I/O decomposition len to decide on rearranger failed (iosysid = %d). Defaulting to BOX rearranger",
+        iosys->iosysid);
+    }
+    return PIO_REARR_BOX;
+  }
+
+  /* FIXME: Do more sophisticated searches once we have multiple ranges here */
+  for(std::vector<std::pair<std::pair<int, int>, int> >::const_iterator
+        citer = SPIO_Util::GVars::opt_pio_rearr_ranges.cbegin();
+        citer != SPIO_Util::GVars::opt_pio_rearr_ranges.cend(); ++citer){
+    if(citer->first.first > max_maplen){
+      break;
+    }
+    if((max_maplen >= citer->first.first) && (max_maplen < citer->first.second)){
+      opt_rearr = citer->second;
+      break;
+    }
+  }
+
+  return opt_rearr;
+}

--- a/src/clib/spio_rearrange_any.h
+++ b/src/clib/spio_rearrange_any.h
@@ -1,0 +1,13 @@
+#ifndef __SPIO_REARRANGE_ANY_H__
+#define __SPIO_REARRANGE_ANY_H__
+
+#include "pio_config.h"
+#include "pio.h"
+//#include "pio_internal.h"
+
+/* Initialize the PIO_REARR_ANY rearranger global info */
+void spio_init_pio_rearr_any(void );
+/* Get the optimal PIO rearranger for an I/O decomposition */
+int spio_get_opt_pio_rearr(iosystem_desc_t *iosys, int local_decomp_map_len);
+
+#endif // __SPIO_REARRANGE_ANY_H__

--- a/src/flib/pio.F90
+++ b/src/flib/pio.F90
@@ -31,7 +31,7 @@ module pio
        iotype_pnetcdf,  pio_iotype_netcdf4p, pio_iotype_netcdf4c, &
        pio_iotype_pnetcdf,pio_iotype_netcdf, pio_iotype_adios, pio_iotype_hdf5, &
        pio_global, pio_char, pio_write, pio_nowrite, pio_clobber, pio_noclobber, &
-       pio_max_name, pio_max_var_dims, pio_rearr_subset, pio_rearr_box, &
+       pio_max_name, pio_max_var_dims, pio_rearr_subset, pio_rearr_box, pio_rearr_any,&
 #if defined(_NETCDF) || defined(_PNETCDF)
        pio_fill, pio_nofill, pio_unlimited, pio_fill_char, pio_fill_int, pio_fill_double, pio_fill_float, &
 #endif

--- a/src/flib/pio_types.F90
+++ b/src/flib/pio_types.F90
@@ -143,10 +143,12 @@ module pio_types
 !!  - PIO_rearr_none : Do not use any form of rearrangement
 !!  - PIO_rearr_box : Use a PIO internal box rearrangement
 !! -  PIO_rearr_subset : Use a PIO internal subsetting rearrangement
+!! -  PIO_rearr_any : Let the library choose the optimal rearranger
 !>
 
     integer(i4), public, parameter :: PIO_rearr_box =  1
     integer(i4), public, parameter :: PIO_rearr_subset =  2
+    integer(i4), public, parameter :: PIO_rearr_any =  3
 
 !>
 !! @public

--- a/tests/general/pio_rearr.F90.in
+++ b/tests/general/pio_rearr.F90.in
@@ -138,9 +138,9 @@ PIO_TF_AUTO_TEST_SUB_BEGIN test_rearrs_base
   character(len=PIO_TF_MAX_STR_LEN), target :: fname = "pio_test_rearrs_base.nc"
   character(len=PIO_TF_MAX_STR_LEN), parameter :: attname = "filename"
   character(len=PIO_TF_MAX_STR_LEN), parameter :: dimname = "filename_dim"
-  integer, parameter :: NUM_REARRANGERS = 2
-  integer :: rearrs(NUM_REARRANGERS) = (/pio_rearr_subset,pio_rearr_box/)
-  character(len=PIO_TF_MAX_STR_LEN) :: rearrs_info(NUM_REARRANGERS) = (/"PIO_REARR_SUBSET","PIO_REARR_BOX   "/)
+  integer, parameter :: NUM_REARRANGERS = 3
+  integer :: rearrs(NUM_REARRANGERS) = (/pio_rearr_subset,pio_rearr_box,pio_rearr_any/)
+  character(len=PIO_TF_MAX_STR_LEN) :: rearrs_info(NUM_REARRANGERS) = (/"PIO_REARR_SUBSET","PIO_REARR_BOX   ","PIO_REARR_ANY   "/)
   integer, dimension(:), allocatable :: iotypes
   character(len=PIO_TF_MAX_STR_LEN), dimension(:), allocatable :: iotype_descs
   integer :: i, j, k, num_iotypes = 0


### PR DESCRIPTION
Adding a new rearranger, PIO_REARR_ANY, that lets the
library choose the rearranger based on the I/O decomposition
characteristics.

This new rearranger is useful for achieving high I/O
throughput for ultra high resolution E3SM simulations using
the ADIOS iotype