### PR TITLE
Support for PIO_REARR_ANY in Fortran legacy interface

### DIFF
--- a/src/flib_legacy/pio.F90
+++ b/src/flib_legacy/pio.F90
@@ -28,7 +28,7 @@ module pio
        iotype_pnetcdf,  pio_iotype_netcdf4p, pio_iotype_netcdf4c, &
        pio_iotype_pnetcdf,pio_iotype_netcdf, pio_iotype_adios, pio_iotype_hdf5, &
        pio_global, pio_char, pio_write, pio_nowrite, pio_clobber, pio_noclobber, &
-       pio_max_name, pio_max_var_dims, pio_rearr_subset, pio_rearr_box, &
+       pio_max_name, pio_max_var_dims, pio_rearr_subset, pio_rearr_box, pio_rearr_any,&
 #if defined(_NETCDF) || defined(_PNETCDF)
        pio_fill, pio_nofill, pio_unlimited, pio_fill_char, pio_fill_int, pio_fill_double, pio_fill_float, &
 #endif

--- a/src/flib_legacy/pio_types.F90
+++ b/src/flib_legacy/pio_types.F90
@@ -126,10 +126,12 @@ module pio_types
 !!  - PIO_rearr_none : Do not use any form of rearrangement
 !!  - PIO_rearr_box : Use a PIO internal box rearrangement
 !! -  PIO_rearr_subset : Use a PIO internal subsetting rearrangement
+!! -  PIO_rearr_any : Let the library choose the rearranger
 !>
 
     integer(i4), public, parameter :: PIO_rearr_box =  1
     integer(i4), public, parameter :: PIO_rearr_subset =  2
+    integer(i4), public, parameter :: PIO_rearr_any = 3
 
 !>
 !! @public


### PR DESCRIPTION
Adding support for PIO_REARR_ANY in the Fortran legacy interface

Also see PR #577 