### PR TITLE
Specify the POSIX standard required for the C library

### DIFF
--- a/src/clib/CMakeLists.txt
+++ b/src/clib/CMakeLists.txt
@@ -136,6 +136,10 @@ if (WITH_ADIOS2)
     set(PIO_USE_ADIOS 1)
     target_compile_definitions (pioc
       PUBLIC _ADIOS2)
+    # 2001 edition of the POSIX standard (IEEE Standard 1003.1-2001)
+    # Required for symlink() support/decl in unistd.h
+    target_compile_definitions (pioc
+      PRIVATE _POSIX_C_SOURCE=200112L)
     target_link_libraries (pioc
       PUBLIC adios2::adios2 adios2pio-nm-lib)
   else ()


### PR DESCRIPTION
Some compilers (Intel icx on Perlmutter) require this for enabling
(declaring) support for symlink(), which is required for ADIOS support.

Without this fix SCORPIO builds with ADIOS support fails on
Perlmutter when using the Intel compiler.