### PR TITLE
Bug fixes and enhancements for ADIOS IO type to handle attributes

### DIFF
--- a/examples/c/test_adios.c
+++ b/examples/c/test_adios.c
@@ -1752,6 +1752,8 @@ int test_adios_read_case_3()
     int varid_dummy_scalar_var_int_write = -1;
     int varid_dummy_scalar_var_int_read = -1;
 
+    PIO_Offset att_len;
+
     int ret = PIO_NOERR;
 
     MPI_Comm_rank(MPI_COMM_WORLD, &my_rank);
@@ -1766,10 +1768,16 @@ int test_adios_read_case_3()
 
     ret = PIOc_createfile(iosysid, &ncid_write, &format, "test_adios_read_case_3.nc", PIO_CLOBBER); ERR
 
+    ret = PIOc_put_att_text(ncid_write, PIO_GLOBAL, "last_write", strlen("1994-10-04-00000"), "1994-10-04-00000"); ERR
+    ret = PIOc_put_att_text(ncid_write, PIO_GLOBAL, "empty_string", strlen(""), ""); ERR
+
     /* Define some variables for PIOc_write_darray. */
     ret = PIOc_def_var(ncid_write, "dummy_scalar_var_int", PIO_INT, 0, NULL, &varid_dummy_scalar_var_int_write); ERR
     if (my_rank == 0)
         printf("varid_dummy_scalar_var_int_write = %d\n", varid_dummy_scalar_var_int_write);
+
+    ret = PIOc_put_att_text(ncid_write, varid_dummy_scalar_var_int_write, "last_write", strlen("1994-10-04-00000"), "1994-10-04-00000"); ERR
+    ret = PIOc_put_att_text(ncid_write, varid_dummy_scalar_var_int_write, "empty_string", strlen(""), ""); ERR
 
     ret = PIOc_enddef(ncid_write); ERR
 
@@ -1777,9 +1785,25 @@ int test_adios_read_case_3()
 
     ret = PIOc_openfile(iosysid, &ncid_read, &format, "test_adios_read_case_3.nc", PIO_NOWRITE); ERR
 
+    att_len = -1;
+    ret = PIOc_inq_attlen(ncid_read, PIO_GLOBAL, "last_write", &att_len); ERR
+    assert(att_len == strlen("1994-10-04-00000"));
+
+    att_len = -1;
+    ret = PIOc_inq_attlen(ncid_read, PIO_GLOBAL, "empty_string", &att_len); ERR
+    assert(att_len == 0);
+
     ret = PIOc_inq_varid(ncid_read, "dummy_scalar_var_int", &varid_dummy_scalar_var_int_read); ERR
     if (my_rank == 0)
         printf("varid_dummy_scalar_var_int_read = %d\n", varid_dummy_scalar_var_int_read);
+
+    att_len = -1;
+    ret = PIOc_inq_attlen(ncid_read, varid_dummy_scalar_var_int_read, "last_write", &att_len); ERR
+    assert(att_len == strlen("1994-10-04-00000"));
+
+    att_len = -1;
+    ret = PIOc_inq_attlen(ncid_read, varid_dummy_scalar_var_int_read, "empty_string", &att_len); ERR
+    assert(att_len == 0);
 
     ret = PIOc_closefile(ncid_read); ERR
 

--- a/src/clib/pio_getput_int.c
+++ b/src/clib/pio_getput_int.c
@@ -313,6 +313,12 @@ int PIOc_put_att_tc(int ncid, int varid, const char *name, nc_type atttype,
                 }
                 file->num_written_blocks += 1;
             }
+            else
+            {
+                fprintf(stdout, "PIO: WARNING: Writing variable (%s, varid=%d) attribute (%s) to file (%s, ncid=%d) using ADIOS iotype is ignored. "
+                        "Overwriting an existing attribute is not supported yet\n",
+                        pio_get_vname_from_file(file, varid), varid, name, pio_get_fname_from_file(file), ncid);
+            }
         }
 
         GPTLstop("PIO:PIOc_put_att_tc");

--- a/src/clib/pioc_support.c
+++ b/src/clib/pioc_support.c
@@ -3745,7 +3745,7 @@ static int adios_get_attr(file_desc_t *file, int attr_id, char *const *attr_name
                                attr_id, file->adios_attrs[attr_id].att_name, pio_get_fname_from_file(file), file->pio_ncid, convert_adios2_error_to_string(adiosErr));
             }
 
-            file->adios_attrs[attr_id].att_len = (PIO_Offset)(strlen(attr_data) + 1);
+            file->adios_attrs[attr_id].att_len = (PIO_Offset)(strlen(attr_data));
         }
         else
         {


### PR DESCRIPTION
This PR includes several improvements for ADIOS IO type:
* New ADIOS read tests on retrieving the length of string attributes
* Sets expected length for string attributes during ADIOS read
* Adds a warning for overwriting existing attributes with ADIOS type