### PR TITLE
Fix usage of find_package_handle_standard_args

### DIFF
--- a/cmake/FindGPTL.cmake
+++ b/cmake/FindGPTL.cmake
@@ -70,3 +70,6 @@ foreach (GPTL_comp IN LISTS GPTL_FIND_VALID_COMPONENTS)
     endif ()
     
 endforeach ()
+
+# Handle QUIET/REQUIRED, and set <PKG>_FOUND if all required components were found
+find_package_handle_standard_args (GPTL HANDLE_COMPONENTS)

--- a/cmake/FindHDF5.cmake
+++ b/cmake/FindHDF5.cmake
@@ -123,3 +123,6 @@ foreach (HDF5_comp IN LISTS HDF5_FIND_VALID_COMPONENTS)
     endif ()
     
 endforeach ()
+
+# Handle QUIET/REQUIRED, and set <PKG>_FOUND if all required components were found
+find_package_handle_standard_args (HDF5 HANDLE_COMPONENTS)

--- a/cmake/FindMPE.cmake
+++ b/cmake/FindMPE.cmake
@@ -48,3 +48,6 @@ foreach (NCDFcomp IN LISTS MPE_FIND_VALID_COMPONENTS)
   endif ()
   
 endforeach ()
+
+# Handle QUIET/REQUIRED, and set <PKG>_FOUND if all required components were found
+find_package_handle_standard_args (MPE HANDLE_COMPONENTS)

--- a/cmake/FindMPISERIAL.cmake
+++ b/cmake/FindMPISERIAL.cmake
@@ -42,3 +42,6 @@ foreach (MPISERIAL_comp IN LISTS MPISERIAL_FIND_VALID_COMPONENTS)
     endif ()
 
 endforeach ()
+
+# Handle QUIET/REQUIRED, and set <PKG>_FOUND if all required components were found
+find_package_handle_standard_args (MPISERIAL HANDLE_COMPONENTS)

--- a/cmake/FindNetCDF.cmake
+++ b/cmake/FindNetCDF.cmake
@@ -152,3 +152,6 @@ foreach (NCDFcomp IN LISTS NetCDF_FIND_VALID_COMPONENTS)
     endif ()
 
 endforeach ()
+
+# Handle QUIET/REQUIRED, and set <PKG>_FOUND if all required components were found
+find_package_handle_standard_args (NetCDF HANDLE_COMPONENTS)

--- a/cmake/FindPnetCDF.cmake
+++ b/cmake/FindPnetCDF.cmake
@@ -69,3 +69,6 @@ foreach (PNCDFcomp IN LISTS PnetCDF_FIND_VALID_COMPONENTS)
     endif ()
     
 endforeach ()
+
+# Handle QUIET/REQUIRED, and set <PKG>_FOUND if all required components were found
+find_package_handle_standard_args (PnetCDF HANDLE_COMPONENTS)

--- a/cmake/LibFind.cmake
+++ b/cmake/LibFind.cmake
@@ -297,15 +297,18 @@ function (find_package_component PKG)
             
         endforeach ()
         
-        # handle the QUIETLY and REQUIRED arguments and 
-        # set NetCDF_C_FOUND to TRUE if all listed variables are TRUE
-        find_package_handle_standard_args (${PKGCOMP} DEFAULT_MSG
-                                           ${PKGCOMP}_LIBRARY 
-                                           ${PKGCOMP}_INCLUDE_DIR)
+        # Use find_package_handle_standard_args only if this is not a component-specific
+        # call, to avoid cmake errors. If this is a component specific call, the upstream
+        # Find<PKG>.cmake module will take care of calling the macro, using HANDLE_COMPONENTS
+        if (NOT COMP)
+          find_package_handle_standard_args (${PKGCOMP} DEFAULT_MSG
+                                             ${PKGCOMP}_LIBRARY
+                                             ${PKGCOMP}_INCLUDE_DIR)
+        elseif (${PKGCOMP}_LIBRARY AND ${PKGCOMP}_INCLUDE_DIR)
+          set (${PKGCOMP}_FOUND TRUE)
+        endif()
+
         mark_as_advanced (${PKGCOMP}_INCLUDE_DIR ${PKGCOMP}_LIBRARY)
-        
-        # HACK For bug in CMake v3.0:
-        set (${PKGCOMP}_FOUND ${${PKGCOMPUP}_FOUND})
     
         # Set return variables
         if (${PKGCOMP}_FOUND)
@@ -320,7 +323,6 @@ function (find_package_component PKG)
         set (${PKGCOMP}_LIBRARY      ${${PKGCOMP}_LIBRARY}       PARENT_SCOPE)
         set (${PKGCOMP}_LIBRARIES    ${${PKGCOMP}_LIBRARIES}     PARENT_SCOPE)
         set (${PKGCOMP}_IS_SHARED    ${${PKGCOMP}_IS_SHARED}     PARENT_SCOPE)
-        
     endif ()
 
 endfunction ()


### PR DESCRIPTION
This fix moves find_package_handle_standard_args() call from
find_package_component() to the appropriate `Find<Package>.cmake`
file and now passes the Package name instead of the Package
component name to it.

This change removes CMake warnings about mismatch between
package name passed to find_package_handle_standard_args() and
the calling package (PnetCDF_C vs PnetCDF)