### PR TITLE
Adding dummy support for pio_rearr_any in v1.4.*

### DIFF
--- a/src/clib/pio.h
+++ b/src/clib/pio.h
@@ -1145,7 +1145,10 @@ enum PIO_REARRANGERS
     PIO_REARR_BOX = 1,
 
     /** Subset rearranger. */
-    PIO_REARR_SUBSET = 2
+    PIO_REARR_SUBSET = 2,
+
+    /** Let the library choose the rearranger. Always set to box in 1.4.* */
+    PIO_REARR_ANY = PIO_REARR_BOX
 };
 
 /**

--- a/src/flib/pio.F90
+++ b/src/flib/pio.F90
@@ -28,7 +28,7 @@ module pio
        iotype_pnetcdf,  pio_iotype_netcdf4p, pio_iotype_netcdf4c, &
        pio_iotype_pnetcdf,pio_iotype_netcdf, pio_iotype_adios, pio_iotype_hdf5, &
        pio_global, pio_char, pio_write, pio_nowrite, pio_clobber, pio_noclobber, &
-       pio_max_name, pio_max_var_dims, pio_rearr_subset, pio_rearr_box, &
+       pio_max_name, pio_max_var_dims, pio_rearr_subset, pio_rearr_box, pio_rearr_any,&
 #if defined(_NETCDF) || defined(_PNETCDF)
        pio_nofill, pio_unlimited, pio_fill_char, pio_fill_int, pio_fill_double, pio_fill_float, &
 #endif

--- a/src/flib/pio_types.F90
+++ b/src/flib/pio_types.F90
@@ -126,10 +126,12 @@ module pio_types
 !!  - PIO_rearr_none : Do not use any form of rearrangement
 !!  - PIO_rearr_box : Use a PIO internal box rearrangement
 !! -  PIO_rearr_subset : Use a PIO internal subsetting rearrangement
+!! -  PIO_rearr_any : Let the library choose the rearranger (always chooses box in v1.4.*)
 !>
 
     integer(i4), public, parameter :: PIO_rearr_box =  1
     integer(i4), public, parameter :: PIO_rearr_subset =  2
+    integer(i4), public, parameter :: PIO_rearr_any = PIO_rearr_box
 
 !>
 !! @public


### PR DESCRIPTION
Adding basic/dummy support for PIO_REARR_ANY rearranger
by setting it to PIO_REARR_BOX