### PR TITLE
Enhancements to ADIOS conversion tool

### DIFF
--- a/src/clib/pio_internal.h
+++ b/src/clib/pio_internal.h
@@ -347,6 +347,7 @@ extern "C" {
     void pio_finalize_logging(void );
 
     /* Initialize and finalize GPTL timers. */
+    bool spio_gptl_was_init_in_lib(void );
     void pio_init_gptl(void);
     void pio_finalize_gptl(void );
 

--- a/src/clib/pioc.cpp
+++ b/src/clib/pioc.cpp
@@ -1776,17 +1776,19 @@ int PIOc_finalize_impl(int iosysid)
     GPTLstop("PIO:PIOc_finalize");
 #ifdef TIMING
 #ifdef TIMING_INTERNAL
-    if(ios->io_comm != MPI_COMM_NULL)
-    {
-        snprintf(gptl_iolog_fname, PIO_MAX_NAME, "piorwgptlioinfo%010dwrank.dat", ios->ioroot);
-        GPTLpr_summary_file(ios->io_comm, gptl_iolog_fname);
-        LOG((2, "Finished writing gptl io proc summary"));
-    }
-    snprintf(gptl_log_fname, PIO_MAX_NAME, "piorwgptlinfo%010dwrank.dat", ios->ioroot);
-    if(ios->io_rank == 0)
-    {
-        GPTLpr_file(gptl_log_fname);
-        LOG((2, "Finished writing gptl summary"));
+    if(spio_gptl_was_init_in_lib()){
+      if(ios->io_comm != MPI_COMM_NULL)
+      {
+          snprintf(gptl_iolog_fname, PIO_MAX_NAME, "piorwgptlioinfo%010dwrank.dat", ios->ioroot);
+          GPTLpr_summary_file(ios->io_comm, gptl_iolog_fname);
+          LOG((2, "Finished writing gptl io proc summary"));
+      }
+      snprintf(gptl_log_fname, PIO_MAX_NAME, "piorwgptlinfo%010dwrank.dat", ios->ioroot);
+      if(ios->io_rank == 0)
+      {
+          GPTLpr_file(gptl_log_fname);
+          LOG((2, "Finished writing gptl summary"));
+      }
     }
     pio_finalize_gptl();
 #endif

--- a/src/clib/pioc_support.cpp
+++ b/src/clib/pioc_support.cpp
@@ -707,6 +707,11 @@ void pio_finalize_logging(void)
  */
 /* Indicate if GPTL was initialized inside the library */
 static bool GPTL_was_init_in_lib = false;
+bool spio_gptl_was_init_in_lib(void )
+{
+  return GPTL_was_init_in_lib;
+}
+
 void pio_init_gptl(void )
 {
 #ifdef TIMING_INTERNAL
@@ -727,7 +732,7 @@ void pio_finalize_gptl(void)
 {
 #ifdef TIMING_INTERNAL
     pio_timer_ref_cnt -= 1;
-    if((pio_timer_ref_cnt == 0) && (GPTL_was_init_in_lib))
+    if((pio_timer_ref_cnt == 0) && (spio_gptl_was_init_in_lib()))
     {
         GPTLfinalize();
     }

--- a/tools/adios2pio-nm/adios2pio-nm-lib.cxx
+++ b/tools/adios2pio-nm/adios2pio-nm-lib.cxx
@@ -753,7 +753,9 @@ Decomposition adios2_ProcessOneDecomposition(adios2::Variable<T> &v_base,
         for (size_t i = 0; i < block_list.size(); i++)
         {
             blk_var.SetBlockSelection(i);
+            GPTLstart("adios2pio:adios2_ProcessOneDecomposition:blk_var_Get_Sync");
             bpReader.Get(blk_var, block_writer_cnt, adios2::Mode::Sync);
+            GPTLstop("adios2pio:adios2_ProcessOneDecomposition:blk_var_Get_Sync");
             for (int k = 0; k < block_writer_cnt[0]; k++) /* number of writers */
             {
                  int writer_id = block_list[i][k];
@@ -821,7 +823,9 @@ Decomposition adios2_ProcessOneDecomposition(adios2::Variable<T> &v_base,
                 if (bp_block_id >= 0)
                 {
                     v_base.SetBlockSelection(bp_block_id);
+                    GPTLstart("adios2pio:adios2_ProcessOneDecomposition:v_base_Get_Sync");
                     bpReader.Get(v_base, v_data, adios2::Mode::Sync);
+                    GPTLstop("adios2pio:adios2_ProcessOneDecomposition:v_base_Get_Sync");
                     d_out.insert(d_out.end(), v_data.begin(), v_data.end());
                 }
             }
@@ -1160,7 +1164,9 @@ void ProcessDimensions(adios2::IO &bpIO, adios2::Engine &bpReader, int ncid,
                     std::vector<T> dimval; \
                     try \
                     { \
+                        GPTLstart("adios2pio:ProcessDimensions:v_base_Get_Sync"); \
                         bpReader.Get(v_base, dimval, adios2::Mode::Sync); \
+                        GPTLstop("adios2pio:ProcessDimensions:v_base_Get_Sync"); \
                     } \
                     catch (const std::exception &e) \
                     { \
@@ -1395,7 +1401,9 @@ int adios2_ConvertVariablePutVar(adios2::Variable<T> &v_base,
         std::vector<T> v_value;
         try
         {
+            GPTLstart("adios2pio:adios2_ConvertVariablePutVar:v_base_Get_Sync");
             bpReader.Get(v_base, v_value, adios2::Mode::Sync);
+            GPTLstop("adios2pio:adios2_ConvertVariablePutVar:v_base_Get_Sync");
         }
         catch (const std::exception &e)
         {
@@ -1436,7 +1444,9 @@ int adios2_ConvertVariablePutVar(adios2::Variable<T> &v_base,
             {
                 std::vector<T> v_data;
                 v_base.SetBlockSelection(ii);
+                GPTLstart("adios2pio:adios2_ConvertVariablePutVar:v_base_Get_Sync");
                 bpReader.Get(v_base, v_data, adios2::Mode::Sync);
+                GPTLstop("adios2pio:adios2_ConvertVariablePutVar:v_base_Get_Sync");
 
                 int64_t *pio_var_startp, *pio_var_countp;
                 char *data_buf;
@@ -1595,7 +1605,9 @@ int adios2_ConvertVariableTimedPutVar(adios2::Variable<T> &v_base,
 
                 std::vector<T> v_data;
                 v_base.SetBlockSelection(ts);
+                GPTLstart("adios2pio:adios2_ConvertVariableTimedPutVar:v_base_Get_Sync");
                 bpReader.Get(v_base, v_data, adios2::Mode::Sync);
+                GPTLstop("adios2pio:adios2_ConvertVariableTimedPutVar:v_base_Get_Sync");
 
                 int64_t *pio_var_startp, *pio_var_countp;
                 char *data_buf;
@@ -1752,7 +1764,9 @@ int adios2_ConvertVariableDarray(adios2::Variable<T> &v_base,
         for (size_t i = 0; i < vb_blocks.size(); i++)
         {
             frameid_var.SetBlockSelection(i);
+            GPTLstart("adios2pio:adios2_ConvertVariableDarray:frameid_var_Get_Sync");
             bpReader[0].Get(frameid_var, frame_buffer+tmp_idx, adios2::Mode::Sync);
+            GPTLstop("adios2pio:adios2_ConvertVariableDarray:frameid_var_Get_Sync");
             tmp_idx += vb_blocks[i].Count[0];
         }
 
@@ -1770,7 +1784,9 @@ int adios2_ConvertVariableDarray(adios2::Variable<T> &v_base,
         for (size_t i = 0; i < db_blocks.size(); i++)
         {
             decompid_var.SetBlockSelection(i);
+            GPTLstart("adios2pio:adios2_ConvertVariableDarray:decompid_var_Get_Sync");
             bpReader[0].Get(decompid_var, decomp_buffer + tmp_idx, adios2::Mode::Sync);
+            GPTLstop("adios2pio:adios2_ConvertVariableDarray:decompid_var_Get_Sync");
             tmp_idx += db_blocks[i].Count[0];
         }
 
@@ -1788,7 +1804,9 @@ int adios2_ConvertVariableDarray(adios2::Variable<T> &v_base,
             for (size_t i = 0; i < fb_blocks.size(); i++)
             {
                 fillval_var.SetBlockSelection(i);
+                GPTLstart("adios2pio:adios2_ConvertVariableDarray:fillval_var_Get_Sync");
                 bpReader[0].Get(fillval_var, fb_tmp, adios2::Mode::Sync);
+                GPTLstop("adios2pio:adios2_ConvertVariableDarray:fillval_var_Get_Sync");
                 fb_tmp_size = fb_tmp.size() * sizeof(T);
                 memcpy(fillval_buffer + tmp_idx, fb_tmp.data(), fb_tmp_size);
                 tmp_idx += fb_tmp_size;
@@ -1846,7 +1864,9 @@ int adios2_ConvertVariableDarray(adios2::Variable<T> &v_base,
             for (int ii = 0; ii < num_bp_blocks_per_group; ii++)
             {
                 blk_var.SetBlockSelection(b_idx);
+                GPTLstart("adios2pio:adios2_ConvertVariableDarray:blk_var_Get_Sync");
                 bpReader[0].Get(blk_var, block_writer_cnt, adios2::Mode::Sync);
+                GPTLstop("adios2pio:adios2_ConvertVariableDarray:blk_var_Get_Sync");
                 for (size_t j = 0; j < block_writer_cnt.size(); j++)
                 {
                     for (int k = 0; k < block_writer_cnt[j]; k++)
@@ -1946,7 +1966,9 @@ int adios2_ConvertVariableDarray(adios2::Variable<T> &v_base,
                     if (bp_block_id >= 0)
                     {
                         v_base.SetBlockSelection(bp_block_id);
+                        GPTLstart("adios2pio:adios2_ConvertVariableDarray:v_base_Get_Sync");
                         bpReader[0].Get(v_base, t_data + offset, adios2::Mode::Sync);
+                        GPTLstop("adios2pio:adios2_ConvertVariableDarray:v_base_Get_Sync");
                         offset += (vb_blocks[bp_block_id].Count[0]);
                     }
                 }
@@ -2225,6 +2247,7 @@ int ConvertBPFile(const string &infilepath, const string &outfilename,
 
     try
     {
+        GPTLstart("adios2pio:ConvertBPFile");
         t1 = MPI_Wtime();
 
         /* Allocate IO and Engine and open BP4 file */
@@ -2245,7 +2268,9 @@ int ConvertBPFile(const string &infilepath, const string &outfilename,
         adios2::Variable<int> bpNProc = bpIO[0].InquireVariable<int>("/__pio__/info/nproc");
         if (bpNProc)
         {
+            GPTLstart("adios2pio:ConvertBPFile:bpNProc_Get_Sync");
             bpReader[0].Get(bpNProc, &n_bp_writers, adios2::Mode::Sync);
+            GPTLstop("adios2pio:ConvertBPFile:bpNProc_Get_Sync");
         }
         else
         {
@@ -2257,7 +2282,9 @@ int ConvertBPFile(const string &infilepath, const string &outfilename,
         adios2::Variable<int> bpDecompStored = bpIO[0].InquireVariable<int>("/__pio__/info/decomp_stored");
         if (bpDecompStored)
         {
+            GPTLstart("adios2pio:ConvertBPFile:bpDecompStored_Get_Sync");
             bpReader[0].Get(bpDecompStored, &decomp_stored_flag, adios2::Mode::Sync);
+            GPTLstop("adios2pio:ConvertBPFile:bpDecompStored_Get_Sync");
             assert(decomp_stored_flag == 0 || decomp_stored_flag == 1);
         }
         else
@@ -2283,7 +2310,9 @@ int ConvertBPFile(const string &infilepath, const string &outfilename,
             for (size_t i = 0; i < v_blocks.size(); i++)
             {
                 blockProcs.SetBlockSelection(i);
+                GPTLstart("adios2pio:ConvertBPFile:blockProcs_Get_Sync");
                 bpReader[0].Get(blockProcs, &block_procs[i], adios2::Mode::Sync);
+                GPTLstop("adios2pio:ConvertBPFile:blockProcs_Get_Sync");
             }
         }
         else
@@ -2301,7 +2330,9 @@ int ConvertBPFile(const string &infilepath, const string &outfilename,
             for (size_t i = 0; i < v_blocks.size(); i++)
             {
                 blockList.SetBlockSelection(i);
+                GPTLstart("adios2pio:ConvertBPFile:blockList_Get_Sync");
                 bpReader[0].Get(blockList, block_list[i], adios2::Mode::Sync);
+                GPTLstop("adios2pio:ConvertBPFile:blockList_Get_Sync");
             }
         }
         else
@@ -2313,7 +2344,9 @@ int ConvertBPFile(const string &infilepath, const string &outfilename,
         t_loop += (MPI_Wtime() - t1_loop);
 
         int io_proc;
+        GPTLstart("adios2pio:ConvertBPFile:CreateIOProcessGroup");
         ierr = CreateIOProcessGroup(w_comm, w_nproc, w_mpirank, block_procs, &comm, &mpirank, &nproc, &io_proc);
+        GPTLstop("adios2pio:ConvertBPFile:CreateIOProcessGroup");
         if (ierr != BP2PIO_NOERR)
             return ierr;
 
@@ -2497,6 +2530,7 @@ int ConvertBPFile(const string &infilepath, const string &outfilename,
                  << " at " << __func__ << ":" << __LINE__ << endl;
             ierr = BP2PIO_ERROR;
         }
+        GPTLstop("adios2pio:ConvertBPFile");
 
         ret = PIOc_finalize(iosysid);
         if (ret != PIO_NOERR)

--- a/tools/adios2pio-nm/adios2pio-nm-lib.cxx
+++ b/tools/adios2pio-nm/adios2pio-nm-lib.cxx
@@ -2282,6 +2282,8 @@ int ConvertBPFile(const string &infilepath, const string &outfilename,
     int w_mpirank, mpirank;
     int w_nproc, nproc;
 
+    GPTLstart("adios2pio:ConvertBPFile");
+
     w_comm = comm_in;
     MPI_Comm_set_errhandler(w_comm, MPI_ERRORS_RETURN);
     MPI_Comm_rank(w_comm, &w_mpirank);
@@ -2314,7 +2316,6 @@ int ConvertBPFile(const string &infilepath, const string &outfilename,
 
     try
     {
-        GPTLstart("adios2pio:ConvertBPFile");
         t1 = MPI_Wtime();
 
         /* Allocate IO and Engine and open BP4 file */
@@ -2649,7 +2650,6 @@ int ConvertBPFile(const string &infilepath, const string &outfilename,
                  << " at " << __func__ << ":" << __LINE__ << endl;
             ierr = BP2PIO_ERROR;
         }
-        GPTLstop("adios2pio:ConvertBPFile");
 
         ret = PIOc_finalize(iosysid);
         if (ret != PIO_NOERR)
@@ -2675,6 +2675,8 @@ int ConvertBPFile(const string &infilepath, const string &outfilename,
     MPI_Comm_free(&comm);
 
     MPI_Barrier(w_comm);
+
+    GPTLstop("adios2pio:ConvertBPFile");
 
     if (ierr != BP2PIO_NOERR)
         return ierr;

--- a/tools/adios2pio-nm/adios2pio-nm-lib.cxx
+++ b/tools/adios2pio-nm/adios2pio-nm-lib.cxx
@@ -34,7 +34,7 @@ static int debug_out = 0;
 #define BP2PIO_ERROR -600
 #define BP2PIO_ENOMEM -601
 
-#define DECOMP_CACHE_MAX_SIZE 5
+#define DECOMP_CACHE_MAX_SIZE 64
 
 #define ERROR_CHECK_RETURN(ierr, err_val, err_cnt, comm) \
     err_val = 0; \

--- a/tools/adios2pio-nm/adios2pio-nm-lib.cxx
+++ b/tools/adios2pio-nm/adios2pio-nm-lib.cxx
@@ -2369,7 +2369,11 @@ int ConvertBPFile(const string &infilepath, const string &outfilename,
         /* Assign blocks to reader processes */
         std::vector<int> local_proc_blocks = FindProcessBlockGroupAssignments(block_procs, mpirank, nproc, comm);
 
-        int rearr_type = (rearr == "box")? PIO_REARR_BOX : PIO_REARR_SUBSET;
+        int rearr_type = PIO_REARR_ANY;
+        if (rearr == "box")
+            rearr_type = PIO_REARR_BOX;
+        else if (rearr == "subset")
+            rearr_type = PIO_REARR_SUBSET;
         iosysid = InitPIO(comm, mpirank, nproc, rearr_type);
         if (iosysid == BP2PIO_ERROR)
         {

--- a/tools/adios2pio-nm/adios2pio-nm.cxx
+++ b/tools/adios2pio-nm/adios2pio-nm.cxx
@@ -13,7 +13,7 @@ static void init_user_options(spio_tool_utils::ArgParser &ap)
       .add_opt("idir", "Directory containing data output from PIO (in ADIOS format)")
       .add_opt("nc-file", "output file name after conversion")
       .add_opt("pio-format", "output PIO_IO_TYPE. Supported parameters: \"pnetcdf\",  \"netcdf\",  \"netcdf4c\",  \"netcdf4p\"")
-      .add_opt("rearr", "PIO rearranger. Supported parameters: \"subset\", \"box\". Default \"subset\".")
+      .add_opt("rearr", "PIO rearranger. Supported parameters: \"subset\", \"box\", \"any\". Default \"any\".")
       .add_opt("verbose", "Turn on verbose info messages");
 }
 
@@ -60,7 +60,7 @@ static int get_user_options(
               int &debug_lvl)
 {
     const std::string DEFAULT_PIO_FORMAT("pnetcdf");
-    const std::string DEFAULT_REARRANGER("subset");
+    const std::string DEFAULT_REARRANGER("any");
     debug_lvl = 0;
 
 #ifdef SPIO_NO_CXX_REGEX

--- a/tools/adios2pio-nm/adios2pio-nm.cxx
+++ b/tools/adios2pio-nm/adios2pio-nm.cxx
@@ -148,7 +148,7 @@ int main(int argc, char *argv[])
     }
 
 #ifdef SPIO_ENABLE_GPTL_TIMING
-#ifndef SPIO_ENABLE_GPTL_TIMING_INTERNAL
+#ifdef SPIO_ENABLE_GPTL_TIMING_INTERNAL
     /* Initialize the GPTL timing library. */
     if ((ret = GPTLinitialize()))
         return ret;
@@ -168,7 +168,7 @@ int main(int argc, char *argv[])
     MPI_Barrier(comm_in);
 
 #ifdef SPIO_ENABLE_GPTL_TIMING
-#ifndef SPIO_ENABLE_GPTL_TIMING_INTERNAL
+#ifdef SPIO_ENABLE_GPTL_TIMING_INTERNAL
     /* Finalize the GPTL timing library. */
     if ((ret = GPTLfinalize()))
         return ret;

--- a/tools/adios2pio-nm/adios2pio-nm.cxx
+++ b/tools/adios2pio-nm/adios2pio-nm.cxx
@@ -159,6 +159,8 @@ int main(int argc, char *argv[])
         return ret;
 #endif
 
+    GPTLstart("adios2pio:main");
+
     SetDebugOutput(debug_lvl);
     MPI_Barrier(comm_in);
     if (idir.size() == 0)
@@ -170,6 +172,8 @@ int main(int argc, char *argv[])
         ret = MConvertBPToNC(idir, piotype, rearr, comm_in);
     }
     MPI_Barrier(comm_in);
+
+    GPTLstop("adios2pio:main");
 
 #ifdef SPIO_ENABLE_GPTL_TIMING
     /* Write the GPTL summary/rank_0 output */


### PR DESCRIPTION
This PR implements some key optimizations for the ADIOS
conversion tool in SCORPIO:

[Performance measurement]
Added GPTL timers for performance tracking and hotspot
identification.

[Decomposition cache size increase]
Expanded DECOMP_CACHE_MAX_SIZE from 5 to 64 to reduce
overhead in cache management.

[Default rearranger]
Changed the default rearranger to REARR_ANY for better
adaptability in rearranger selection.

[Optimize hotspot Get() calls]
Switched some hotspot Get() calls to Deferred mode to
utilize optimized batch reads and used rank 0 for reads
to reduce contention.