### PR TITLE
Adding dummy type PIO_IOTYPE_ADIOSC

### DIFF
--- a/src/clib/pio.h
+++ b/src/clib/pio.h
@@ -1188,8 +1188,11 @@ enum PIO_IOTYPE
     /** ADIOS parallel */
     PIO_IOTYPE_ADIOS = 5,
 
+    /** ADIOS parallel - with data compression */
+    PIO_IOTYPE_ADIOSC = 6,
+
     /** HDF5 parallel */
-    PIO_IOTYPE_HDF5 = 6
+    PIO_IOTYPE_HDF5 = 7
 };
 
 /**

--- a/src/flib/pio.F90
+++ b/src/flib/pio.F90
@@ -29,7 +29,7 @@ module pio
        pio_rearr_comm_p2p, pio_rearr_comm_coll,&
        pio_int, pio_real, pio_double, pio_noerr, iotype_netcdf, &
        iotype_pnetcdf,  pio_iotype_netcdf4p, pio_iotype_netcdf4c, &
-       pio_iotype_pnetcdf,pio_iotype_netcdf, pio_iotype_adios, pio_iotype_hdf5, &
+       pio_iotype_pnetcdf,pio_iotype_netcdf, pio_iotype_adios, pio_iotype_adiosc, pio_iotype_hdf5, &
        pio_global, pio_char, pio_write, pio_nowrite, pio_clobber, pio_noclobber, &
        pio_max_name, pio_max_var_dims, pio_rearr_subset, pio_rearr_box, pio_rearr_any,&
 #if defined(_NETCDF) || defined(_PNETCDF)

--- a/src/flib/pio_types.F90
+++ b/src/flib/pio_types.F90
@@ -117,7 +117,8 @@ module pio_types
 !!   - PIO_iotype_netcdf : serial (only the root I/O process) read/write using the NetCDF library
 !!   - PIO_iotype_netcdf4c : parallel read/serial write of NetCDF4 (HDF5) files with data compression
 !!   - PIO_iotype_netcdf4p : parallel read/write of NETCDF4 (HDF5) files
-!!   - PIO_iotype_adios : parallel write of ADIOS files with subset rearrangement only
+!!   - PIO_iotype_adios : parallel read/write of ADIOS files
+!!   - PIO_iotype_adiosc : parallel read/write of ADIOS files with data compression
 !!   - PIO_iotype_hdf5 : parallel write of HDF5 files
 !>
     integer(i4), public, parameter ::  &
@@ -125,8 +126,9 @@ module pio_types
         PIO_iotype_netcdf  = 2, &   ! serial read/write of NetCDF file using 'base_node'
         PIO_iotype_netcdf4c = 3, &  ! netcdf4 (hdf5 format) file opened for compression (serial write access only)
         PIO_iotype_netcdf4p = 4, &  ! netcdf4 (hdf5 format) file opened in parallel (all netcdf4 files for read will be opened this way)
-        PIO_iotype_adios = 5, &     ! parallel write of ADIOS files (Write only, rearr subset only)
-        PIO_iotype_hdf5 = 6         ! parallel write of HDF5 files
+        PIO_iotype_adios = 5, &     ! parallel read/write of ADIOS files
+        PIO_iotype_adiosc = 6, &    ! parallel read/write of ADIOS files with data compression
+        PIO_iotype_hdf5 = 7         ! parallel write of HDF5 files
 
 
 ! These are for backward compatability and should not be used or expanded upon


### PR DESCRIPTION
Adding a dummy I/O type PIO_IOTYPE_ADIOSC to support
building code that uses this type.