### PR TITLE
Adding PIO_IOTYPE_ADIOSC iotype

### DIFF
--- a/src/clib/pio.h
+++ b/src/clib/pio.h
@@ -1195,8 +1195,11 @@ enum PIO_IOTYPE
     /** ADIOS parallel */
     PIO_IOTYPE_ADIOS = 5,
 
+    /** ADIOS parallel with compression */
+    PIO_IOTYPE_ADIOSC = 6,
+
     /** HDF5 parallel */
-    PIO_IOTYPE_HDF5 = 6
+    PIO_IOTYPE_HDF5 = 7
 };
 
 /**

--- a/src/clib/pio_darray.cpp
+++ b/src/clib/pio_darray.cpp
@@ -2022,7 +2022,7 @@ int PIOc_write_darray_impl(int ncid, int varid, int ioid, PIO_Offset arraylen, c
     spio_ltimer_start(ios->io_fstats->wr_timer_name);
     spio_ltimer_start(ios->io_fstats->tot_timer_name);
 
-    if (file->iotype == PIO_IOTYPE_ADIOS)
+    if ((file->iotype == PIO_IOTYPE_ADIOS) || (file->iotype == PIO_IOTYPE_ADIOSC))
     {
         GPTLstart("PIO:PIOc_write_darray_adios");
         GPTLstart("PIO:write_total_adios");
@@ -2043,7 +2043,7 @@ int PIOc_write_darray_impl(int ncid, int varid, int ioid, PIO_Offset arraylen, c
         spio_ltimer_stop(ios->io_fstats->tot_timer_name);
         spio_ltimer_stop(file->io_fstats->wr_timer_name);
         spio_ltimer_stop(file->io_fstats->tot_timer_name);
-        if (file->iotype == PIO_IOTYPE_ADIOS)
+        if ((file->iotype == PIO_IOTYPE_ADIOS) || (file->iotype == PIO_IOTYPE_ADIOSC))
         {
             GPTLstop("PIO:PIOc_write_darray_adios");
             GPTLstop("PIO:write_total_adios");
@@ -2061,7 +2061,7 @@ int PIOc_write_darray_impl(int ncid, int varid, int ioid, PIO_Offset arraylen, c
         spio_ltimer_stop(ios->io_fstats->tot_timer_name);
         spio_ltimer_stop(file->io_fstats->wr_timer_name);
         spio_ltimer_stop(file->io_fstats->tot_timer_name);
-        if (file->iotype == PIO_IOTYPE_ADIOS)
+        if ((file->iotype == PIO_IOTYPE_ADIOS) || (file->iotype == PIO_IOTYPE_ADIOSC))
         {
             GPTLstop("PIO:PIOc_write_darray_adios");
             GPTLstop("PIO:write_total_adios");
@@ -2082,7 +2082,7 @@ int PIOc_write_darray_impl(int ncid, int varid, int ioid, PIO_Offset arraylen, c
         spio_ltimer_stop(ios->io_fstats->tot_timer_name);
         spio_ltimer_stop(file->io_fstats->wr_timer_name);
         spio_ltimer_stop(file->io_fstats->tot_timer_name);
-        if (file->iotype == PIO_IOTYPE_ADIOS)
+        if ((file->iotype == PIO_IOTYPE_ADIOS) || (file->iotype == PIO_IOTYPE_ADIOSC))
         {
             GPTLstop("PIO:PIOc_write_darray_adios");
             GPTLstop("PIO:write_total_adios");
@@ -2114,7 +2114,7 @@ int PIOc_write_darray_impl(int ncid, int varid, int ioid, PIO_Offset arraylen, c
             spio_ltimer_stop(ios->io_fstats->tot_timer_name);
             spio_ltimer_stop(file->io_fstats->wr_timer_name);
             spio_ltimer_stop(file->io_fstats->tot_timer_name);
-            if (file->iotype == PIO_IOTYPE_ADIOS)
+            if ((file->iotype == PIO_IOTYPE_ADIOS) || (file->iotype == PIO_IOTYPE_ADIOSC))
             {
                 GPTLstop("PIO:PIOc_write_darray_adios");
                 GPTLstop("PIO:write_total_adios");
@@ -2191,7 +2191,7 @@ if (file->iotype != PIO_IOTYPE_HDF5)
         {
             GPTLstop("PIO:PIOc_write_darray");
             GPTLstop("PIO:write_total");
-            if (file->iotype == PIO_IOTYPE_ADIOS)
+            if ((file->iotype == PIO_IOTYPE_ADIOS) || (file->iotype == PIO_IOTYPE_ADIOSC))
             {
                 GPTLstop("PIO:PIOc_write_darray_adios");
                 GPTLstop("PIO:write_total_adios");
@@ -2219,7 +2219,7 @@ if (file->iotype != PIO_IOTYPE_HDF5)
     LOG((3, "wmb->ioid = %d wmb->recordvar = %d", wmb->ioid, wmb->recordvar));
 
 #ifdef _ADIOS2
-    if (file->iotype == PIO_IOTYPE_ADIOS)
+    if ((file->iotype == PIO_IOTYPE_ADIOS) || (file->iotype == PIO_IOTYPE_ADIOSC))
     {
         ierr = PIO_NOERR;
         ierr = PIOc_write_darray_adios(file, varid, ioid, iodesc, arraylen, array, fillvalue);
@@ -3578,7 +3578,7 @@ int PIOc_read_darray_impl(int ncid, int varid, int ioid, PIO_Offset arraylen,
               "unknown rearranger", __FILE__, __LINE__);
 
     /* Get var description. */
-    if (file->iotype == PIO_IOTYPE_ADIOS)
+    if ((file->iotype == PIO_IOTYPE_ADIOS) || (file->iotype == PIO_IOTYPE_ADIOSC))
     {
 #ifdef _ADIOS2
         vdesc_adios2 = &(file->adios_vars[varid]);
@@ -3597,7 +3597,7 @@ int PIOc_read_darray_impl(int ncid, int varid, int ioid, PIO_Offset arraylen,
         spio_ltimer_stop(file->io_fstats->tot_timer_name);
 
         /* Find out PIO data type of var. */
-        if (file->iotype == PIO_IOTYPE_ADIOS)
+        if ((file->iotype == PIO_IOTYPE_ADIOS) || (file->iotype == PIO_IOTYPE_ADIOSC))
         {
 #ifdef _ADIOS2
             assert(vdesc_adios2->nc_type != PIO_NAT);
@@ -3620,7 +3620,7 @@ int PIOc_read_darray_impl(int ncid, int varid, int ioid, PIO_Offset arraylen,
         }
 
         /* Find out length of type. */
-        if (file->iotype == PIO_IOTYPE_ADIOS)
+        if ((file->iotype == PIO_IOTYPE_ADIOS) || (file->iotype == PIO_IOTYPE_ADIOSC))
         {
 #ifdef _ADIOS2
             if (vdesc_adios2->adios_type_size == 0)
@@ -3649,7 +3649,7 @@ int PIOc_read_darray_impl(int ncid, int varid, int ioid, PIO_Offset arraylen,
         spio_ltimer_start(file->io_fstats->tot_timer_name);
     }
 
-    if (file->iotype == PIO_IOTYPE_ADIOS)
+    if ((file->iotype == PIO_IOTYPE_ADIOS) || (file->iotype == PIO_IOTYPE_ADIOSC))
     {
 #ifdef _ADIOS2
         ios->io_fstats->rb += vdesc_adios2->adios_type_size * iodesc->llen;
@@ -3698,7 +3698,7 @@ int PIOc_read_darray_impl(int ncid, int varid, int ioid, PIO_Offset arraylen,
    else
        rlen = iodesc->llen;
 
-   if (file->iotype == PIO_IOTYPE_ADIOS)
+   if ((file->iotype == PIO_IOTYPE_ADIOS) || (file->iotype == PIO_IOTYPE_ADIOSC))
        rlen = 0;
 
     if(!ios->async || !ios->ioproc)
@@ -3822,6 +3822,7 @@ int PIOc_read_darray_impl(int ncid, int varid, int ioid, PIO_Offset arraylen,
             break;
 #ifdef _ADIOS2
         case PIO_IOTYPE_ADIOS:
+        case PIO_IOTYPE_ADIOSC:
             GPTLstart("PIO:PIOc_read_darray_adios");
             if ((ierr = PIOc_read_darray_adios(file, fndims, iodesc, varid, array)))
             {

--- a/src/clib/pio_file.cpp
+++ b/src/clib/pio_file.cpp
@@ -135,7 +135,7 @@ int PIOc_createfile_impl(int iosysid, int *ncidp, const int *iotype, const char 
 
     GPTLstart("PIO:PIOc_createfile");
     GPTLstart("PIO:write_total");
-    if (*iotype == PIO_IOTYPE_ADIOS)
+    if ((*iotype == PIO_IOTYPE_ADIOS) || (*iotype == PIO_IOTYPE_ADIOSC))
     {
         GPTLstart("PIO:PIOc_createfile_adios");
         GPTLstart("PIO:write_total_adios");
@@ -146,7 +146,7 @@ int PIOc_createfile_impl(int iosysid, int *ncidp, const int *iotype, const char 
     {
         GPTLstop("PIO:PIOc_createfile");
         GPTLstop("PIO:write_total");
-        if (*iotype == PIO_IOTYPE_ADIOS)
+        if ((*iotype == PIO_IOTYPE_ADIOS) || (*iotype == PIO_IOTYPE_ADIOSC))
         {
             GPTLstop("PIO:PIOc_createfile_adios");
             GPTLstop("PIO:write_total_adios");
@@ -165,7 +165,7 @@ int PIOc_createfile_impl(int iosysid, int *ncidp, const int *iotype, const char 
         GPTLstop("PIO:write_total");
         spio_ltimer_stop(ios->io_fstats->wr_timer_name);
         spio_ltimer_stop(ios->io_fstats->tot_timer_name);
-        if (*iotype == PIO_IOTYPE_ADIOS)
+        if ((*iotype == PIO_IOTYPE_ADIOS) || (*iotype == PIO_IOTYPE_ADIOSC))
         {
             GPTLstop("PIO:PIOc_createfile_adios");
             GPTLstop("PIO:write_total_adios");
@@ -188,7 +188,7 @@ int PIOc_createfile_impl(int iosysid, int *ncidp, const int *iotype, const char 
         {
             GPTLstop("PIO:PIOc_createfile");
             GPTLstop("PIO:write_total");
-            if (*iotype == PIO_IOTYPE_ADIOS)
+            if ((*iotype == PIO_IOTYPE_ADIOS) || (*iotype == PIO_IOTYPE_ADIOSC))
             {
                 GPTLstop("PIO:PIOc_createfile_adios");
                 GPTLstop("PIO:write_total_adios");
@@ -204,7 +204,7 @@ int PIOc_createfile_impl(int iosysid, int *ncidp, const int *iotype, const char 
     GPTLstop("PIO:write_total");
     spio_ltimer_stop(ios->io_fstats->wr_timer_name);
     spio_ltimer_stop(ios->io_fstats->tot_timer_name);
-    if (*iotype == PIO_IOTYPE_ADIOS)
+    if ((*iotype == PIO_IOTYPE_ADIOS) || (*iotype == PIO_IOTYPE_ADIOSC))
     {
         GPTLstop("PIO:PIOc_createfile_adios");
         GPTLstop("PIO:write_total_adios");
@@ -290,7 +290,7 @@ static int sync_file(int ncid)
     spio_ltimer_start(file->io_fstats->tot_timer_name);
 
 #ifdef _ADIOS2
-    if (file->iotype == PIO_IOTYPE_ADIOS)
+    if ((file->iotype == PIO_IOTYPE_ADIOS) || (file->iotype == PIO_IOTYPE_ADIOSC))
     {
         if (file->mode & PIO_WRITE)
         {
@@ -468,7 +468,7 @@ int PIOc_closefile_impl(int ncid)
     ios = file->iosystem;
     assert(ios);
 
-    if (file->iotype == PIO_IOTYPE_ADIOS)
+    if ((file->iotype == PIO_IOTYPE_ADIOS) || (file->iotype == PIO_IOTYPE_ADIOSC))
     {
         GPTLstart("PIO:PIOc_closefile_adios");
 
@@ -499,7 +499,7 @@ int PIOc_closefile_impl(int ncid)
             sync_file(ncid);
         }
 
-    if (file->iotype == PIO_IOTYPE_ADIOS)
+    if ((file->iotype == PIO_IOTYPE_ADIOS) || (file->iotype == PIO_IOTYPE_ADIOSC))
     {
 #ifndef _ADIOS_BP2NC_TEST
         if (file->mode & PIO_WRITE)
@@ -533,7 +533,7 @@ int PIOc_closefile_impl(int ncid)
         PIO_SEND_ASYNC_MSG(ios, msg, &ierr, ncid);
         if(ierr != PIO_NOERR)
         {
-            if (file->iotype == PIO_IOTYPE_ADIOS)
+            if ((file->iotype == PIO_IOTYPE_ADIOS) || (file->iotype == PIO_IOTYPE_ADIOSC))
             {
                 GPTLstop("PIO:PIOc_closefile_adios");
 
@@ -572,7 +572,7 @@ int PIOc_closefile_impl(int ncid)
 
     /* ADIOS: assume all procs are also IO tasks */
 #ifdef _ADIOS2
-    if (file->iotype == PIO_IOTYPE_ADIOS)
+    if ((file->iotype == PIO_IOTYPE_ADIOS) || (file->iotype == PIO_IOTYPE_ADIOSC))
     {
         adios2_error adiosErr = adios2_error_none;
 
@@ -585,7 +585,7 @@ int PIOc_closefile_impl(int ncid)
                 ierr = begin_adios2_step(file, NULL);
                 if (ierr != PIO_NOERR)
                 {
-                    if (file->iotype == PIO_IOTYPE_ADIOS)
+                    if ((file->iotype == PIO_IOTYPE_ADIOS) || (file->iotype == PIO_IOTYPE_ADIOSC))
                     {
                         GPTLstop("PIO:PIOc_closefile_adios");
                         GPTLstop("PIO:write_total_adios");
@@ -619,7 +619,7 @@ int PIOc_closefile_impl(int ncid)
                         attributeH = adios2_define_attribute(file->ioH, "/__pio__/fillmode", adios2_type_int32_t, &file->fillmode);
                         if (attributeH == NULL)
                         {
-                            if (file->iotype == PIO_IOTYPE_ADIOS)
+                            if ((file->iotype == PIO_IOTYPE_ADIOS) || (file->iotype == PIO_IOTYPE_ADIOSC))
                             {
                                 GPTLstop("PIO:PIOc_closefile_adios");
                                 GPTLstop("PIO:write_total_adios");
@@ -680,7 +680,7 @@ int PIOc_closefile_impl(int ncid)
                 GPTLstop("end_adios2_step_PIOc_closefile");
                 if (ierr != PIO_NOERR)
                 {
-                    if (file->iotype == PIO_IOTYPE_ADIOS)
+                    if ((file->iotype == PIO_IOTYPE_ADIOS) || (file->iotype == PIO_IOTYPE_ADIOSC))
                     {
                         GPTLstop("PIO:PIOc_closefile_adios");
                         GPTLstop("PIO:write_total_adios");
@@ -709,7 +709,7 @@ int PIOc_closefile_impl(int ncid)
                 adiosErr = adios2_close(file->engineH);
                 if (adiosErr != adios2_error_none)
                 {
-                    if (file->iotype == PIO_IOTYPE_ADIOS)
+                    if ((file->iotype == PIO_IOTYPE_ADIOS) || (file->iotype == PIO_IOTYPE_ADIOSC))
                     {
                         GPTLstop("PIO:PIOc_closefile_adios");
                         GPTLstop("PIO:write_total_adios");
@@ -911,7 +911,7 @@ int PIOc_closefile_impl(int ncid)
             LOG((1, "DONE CONVERTING: %s", file->filename));
             if (ierr != PIO_NOERR)
             {
-                if (file->iotype == PIO_IOTYPE_ADIOS)
+                if ((file->iotype == PIO_IOTYPE_ADIOS) || (file->iotype == PIO_IOTYPE_ADIOSC))
                 {
                     GPTLstop("PIO:PIOc_closefile_adios");
                     GPTLstop("PIO:write_total_adios");
@@ -941,7 +941,7 @@ int PIOc_closefile_impl(int ncid)
             file->filename = NULL;
         }
 
-        if (file->iotype == PIO_IOTYPE_ADIOS)
+        if ((file->iotype == PIO_IOTYPE_ADIOS) || (file->iotype == PIO_IOTYPE_ADIOSC))
         {
             GPTLstop("PIO:PIOc_closefile_adios");
 
@@ -983,7 +983,7 @@ int PIOc_closefile_impl(int ncid)
     }
 #endif
 
-    assert(file->iotype != PIO_IOTYPE_ADIOS);
+    assert((file->iotype != PIO_IOTYPE_ADIOS) && (file->iotype != PIO_IOTYPE_ADIOSC));
 
     /* If this is an IO task, then call the netCDF function. */
     if (ios->ioproc)
@@ -1239,7 +1239,7 @@ int PIOc_sync_impl(int ncid)
     if (file->mode & PIO_WRITE)
     {
         GPTLstart("PIO:write_total");
-        if (file->iotype == PIO_IOTYPE_ADIOS)
+        if ((file->iotype == PIO_IOTYPE_ADIOS) || (file->iotype == PIO_IOTYPE_ADIOSC))
             GPTLstart("PIO:write_total_adios");
     }
 
@@ -1248,7 +1248,7 @@ int PIOc_sync_impl(int ncid)
     if (file->mode & PIO_WRITE)
     {
         GPTLstop("PIO:write_total");
-        if (file->iotype == PIO_IOTYPE_ADIOS)
+        if ((file->iotype == PIO_IOTYPE_ADIOS) || (file->iotype == PIO_IOTYPE_ADIOSC))
             GPTLstop("PIO:write_total_adios");
     }
 

--- a/src/clib/pio_getput_int.cpp
+++ b/src/clib/pio_getput_int.cpp
@@ -60,7 +60,7 @@ int spio_put_att_tc(int ncid, int varid, const char *name, nc_type atttype,
     spio_ltimer_start(ios->io_fstats->wr_timer_name);
     spio_ltimer_start(ios->io_fstats->tot_timer_name);
 
-    if (file->iotype == PIO_IOTYPE_ADIOS)
+    if ((file->iotype == PIO_IOTYPE_ADIOS) || (file->iotype == PIO_IOTYPE_ADIOSC))
     {
         GPTLstart("PIO:spio_put_att_tc_adios");
         GPTLstart("PIO:write_total_adios");
@@ -75,7 +75,7 @@ int spio_put_att_tc(int ncid, int varid, const char *name, nc_type atttype,
         spio_ltimer_stop(ios->io_fstats->tot_timer_name);
         spio_ltimer_stop(file->io_fstats->wr_timer_name);
         spio_ltimer_stop(file->io_fstats->tot_timer_name);
-        if (file->iotype == PIO_IOTYPE_ADIOS)
+        if ((file->iotype == PIO_IOTYPE_ADIOS) || (file->iotype == PIO_IOTYPE_ADIOSC))
         {
             GPTLstop("PIO:spio_put_att_tc_adios");
             GPTLstop("PIO:write_total_adios");
@@ -101,7 +101,7 @@ int spio_put_att_tc(int ncid, int varid, const char *name, nc_type atttype,
             LOG((1, "PIOc_inq_type failed, ierr = %d", ierr));
             GPTLstop("PIO:spio_put_att_tc");
             GPTLstop("PIO:write_total");
-            if (file->iotype == PIO_IOTYPE_ADIOS)
+            if ((file->iotype == PIO_IOTYPE_ADIOS) || (file->iotype == PIO_IOTYPE_ADIOSC))
             {
                 GPTLstop("PIO:spio_put_att_tc_adios");
                 GPTLstop("PIO:write_total_adios");
@@ -118,7 +118,7 @@ int spio_put_att_tc(int ncid, int varid, const char *name, nc_type atttype,
             if(ierr != PIO_NOERR){
                 GPTLstop("PIO:spio_put_att_tc");
                 GPTLstop("PIO:write_total");
-                if (file->iotype == PIO_IOTYPE_ADIOS)
+                if ((file->iotype == PIO_IOTYPE_ADIOS) || (file->iotype == PIO_IOTYPE_ADIOSC))
                 {
                     GPTLstop("PIO:spio_put_att_tc_adios");
                     GPTLstop("PIO:write_total_adios");
@@ -151,7 +151,7 @@ int spio_put_att_tc(int ncid, int varid, const char *name, nc_type atttype,
             spio_ltimer_stop(ios->io_fstats->tot_timer_name);
             spio_ltimer_stop(file->io_fstats->wr_timer_name);
             spio_ltimer_stop(file->io_fstats->tot_timer_name);
-            if (file->iotype == PIO_IOTYPE_ADIOS)
+            if ((file->iotype == PIO_IOTYPE_ADIOS) || (file->iotype == PIO_IOTYPE_ADIOSC))
             {
                 GPTLstop("PIO:spio_put_att_tc_adios");
                 GPTLstop("PIO:write_total_adios");
@@ -169,7 +169,7 @@ int spio_put_att_tc(int ncid, int varid, const char *name, nc_type atttype,
             spio_ltimer_stop(ios->io_fstats->tot_timer_name);
             spio_ltimer_stop(file->io_fstats->wr_timer_name);
             spio_ltimer_stop(file->io_fstats->tot_timer_name);
-            if (file->iotype == PIO_IOTYPE_ADIOS)
+            if ((file->iotype == PIO_IOTYPE_ADIOS) || (file->iotype == PIO_IOTYPE_ADIOSC))
             {
                 GPTLstop("PIO:spio_put_att_tc_adios");
                 GPTLstop("PIO:write_total_adios");
@@ -184,7 +184,7 @@ int spio_put_att_tc(int ncid, int varid, const char *name, nc_type atttype,
             spio_ltimer_stop(ios->io_fstats->tot_timer_name);
             spio_ltimer_stop(file->io_fstats->wr_timer_name);
             spio_ltimer_stop(file->io_fstats->tot_timer_name);
-            if (file->iotype == PIO_IOTYPE_ADIOS)
+            if ((file->iotype == PIO_IOTYPE_ADIOS) || (file->iotype == PIO_IOTYPE_ADIOSC))
             {
                 GPTLstop("PIO:spio_put_att_tc_adios");
                 GPTLstop("PIO:write_total_adios");
@@ -197,7 +197,7 @@ int spio_put_att_tc(int ncid, int varid, const char *name, nc_type atttype,
 
     /* ADIOS: assume all procs are also IO tasks */
 #ifdef _ADIOS2
-    if (file->iotype == PIO_IOTYPE_ADIOS)
+    if ((file->iotype == PIO_IOTYPE_ADIOS) || (file->iotype == PIO_IOTYPE_ADIOSC))
     {
         LOG((2, "ADIOS define attribute %s, varid %d, type %d", name, varid, atttype));
 
@@ -453,7 +453,7 @@ int spio_put_att_tc(int ncid, int varid, const char *name, nc_type atttype,
     }
 #endif /* _HDF5 */
 
-        if (file->iotype != PIO_IOTYPE_PNETCDF && file->iotype != PIO_IOTYPE_ADIOS && file->iotype != PIO_IOTYPE_HDF5 && file->do_io)
+        if (file->iotype != PIO_IOTYPE_PNETCDF && file->iotype != PIO_IOTYPE_ADIOS && file->iotype != PIO_IOTYPE_ADIOSC && file->iotype != PIO_IOTYPE_HDF5 && file->do_io)
         {
             if (ios->iomaster == MPI_ROOT)
             {
@@ -703,7 +703,7 @@ int spio_get_att_tc(int ncid, int varid, const char *name, nc_type memtype, void
     file->io_fstats->rb += attlen * atttype_len;
 
 #ifdef _ADIOS2
-    if (file->iotype == PIO_IOTYPE_ADIOS)
+    if ((file->iotype == PIO_IOTYPE_ADIOS) || (file->iotype == PIO_IOTYPE_ADIOSC))
     {
         char *full_name = NULL;
         int full_name_len = 0;
@@ -874,7 +874,7 @@ int spio_get_att_tc(int ncid, int varid, const char *name, nc_type memtype, void
         }
 #endif /* _PNETCDF */
 
-        if (file->iotype != PIO_IOTYPE_PNETCDF && file->iotype != PIO_IOTYPE_ADIOS && file->do_io)
+        if (file->iotype != PIO_IOTYPE_PNETCDF && file->iotype != PIO_IOTYPE_ADIOS && file->iotype != PIO_IOTYPE_ADIOSC && file->do_io)
         {
             switch(memtype)
             {
@@ -1366,7 +1366,7 @@ int spio_get_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
         }
 #endif /* _PNETCDF */
 
-        if (file->iotype != PIO_IOTYPE_PNETCDF && file->iotype != PIO_IOTYPE_ADIOS && file->do_io)
+        if (file->iotype != PIO_IOTYPE_PNETCDF && file->iotype != PIO_IOTYPE_ADIOS && file->iotype != PIO_IOTYPE_ADIOSC && file->do_io)
             switch(xtype)
             {
 #ifdef _NETCDF
@@ -1436,7 +1436,7 @@ int spio_get_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
     }
 
 #ifdef _ADIOS2
-    if (file->iotype == PIO_IOTYPE_ADIOS)
+    if ((file->iotype == PIO_IOTYPE_ADIOS) || (file->iotype == PIO_IOTYPE_ADIOSC))
     {
         if (varid < 0 || varid >= file->num_vars)
         {
@@ -2463,7 +2463,7 @@ int spio_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
     spio_ltimer_start(ios->io_fstats->wr_timer_name);
     spio_ltimer_start(ios->io_fstats->tot_timer_name);
 
-    if (file->iotype == PIO_IOTYPE_ADIOS)
+    if ((file->iotype == PIO_IOTYPE_ADIOS) || (file->iotype == PIO_IOTYPE_ADIOSC))
     {
         GPTLstart("PIO:spio_put_vars_tc_adios");
         GPTLstart("PIO:write_total_adios");
@@ -2478,7 +2478,7 @@ int spio_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
         spio_ltimer_stop(ios->io_fstats->tot_timer_name);
         spio_ltimer_stop(file->io_fstats->wr_timer_name);
         spio_ltimer_stop(file->io_fstats->tot_timer_name);
-        if (file->iotype == PIO_IOTYPE_ADIOS)
+        if ((file->iotype == PIO_IOTYPE_ADIOS) || (file->iotype == PIO_IOTYPE_ADIOSC))
         {
             GPTLstop("PIO:spio_put_vars_tc_adios");
             GPTLstop("PIO:write_total_adios");
@@ -2500,7 +2500,7 @@ int spio_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
         if(ierr != PIO_NOERR){
             GPTLstop("PIO:spio_put_vars_tc");
             GPTLstop("PIO:write_total");
-            if (file->iotype == PIO_IOTYPE_ADIOS)
+            if ((file->iotype == PIO_IOTYPE_ADIOS) || (file->iotype == PIO_IOTYPE_ADIOSC))
             {
                 GPTLstop("PIO:spio_put_vars_tc_adios");
                 GPTLstop("PIO:write_total_adios");
@@ -2518,7 +2518,7 @@ int spio_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
         if(ierr != PIO_NOERR){
             GPTLstop("PIO:spio_put_vars_tc");
             GPTLstop("PIO:write_total");
-            if (file->iotype == PIO_IOTYPE_ADIOS)
+            if ((file->iotype == PIO_IOTYPE_ADIOS) || (file->iotype == PIO_IOTYPE_ADIOSC))
             {
                 GPTLstop("PIO:spio_put_vars_tc_adios");
                 GPTLstop("PIO:write_total_adios");
@@ -2536,7 +2536,7 @@ int spio_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
             if(ierr != PIO_NOERR){
                 GPTLstop("PIO:spio_put_vars_tc");
                 GPTLstop("PIO:write_total");
-                if (file->iotype == PIO_IOTYPE_ADIOS)
+                if ((file->iotype == PIO_IOTYPE_ADIOS) || (file->iotype == PIO_IOTYPE_ADIOSC))
                 {
                     GPTLstop("PIO:spio_put_vars_tc_adios");
                     GPTLstop("PIO:write_total_adios");
@@ -2598,7 +2598,7 @@ int spio_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
             spio_ltimer_stop(ios->io_fstats->tot_timer_name);
             spio_ltimer_stop(file->io_fstats->wr_timer_name);
             spio_ltimer_stop(file->io_fstats->tot_timer_name);
-            if (file->iotype == PIO_IOTYPE_ADIOS)
+            if ((file->iotype == PIO_IOTYPE_ADIOS) || (file->iotype == PIO_IOTYPE_ADIOSC))
             {
                 GPTLstop("PIO:spio_put_vars_tc_adios");
                 GPTLstop("PIO:write_total_adios");
@@ -2630,7 +2630,7 @@ int spio_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
             spio_ltimer_stop(ios->io_fstats->tot_timer_name);
             spio_ltimer_stop(file->io_fstats->wr_timer_name);
             spio_ltimer_stop(file->io_fstats->tot_timer_name);
-            if (file->iotype == PIO_IOTYPE_ADIOS)
+            if ((file->iotype == PIO_IOTYPE_ADIOS) || (file->iotype == PIO_IOTYPE_ADIOSC))
             {
                 GPTLstop("PIO:spio_put_vars_tc_adios");
                 GPTLstop("PIO:write_total_adios");
@@ -2645,7 +2645,7 @@ int spio_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
             spio_ltimer_stop(ios->io_fstats->tot_timer_name);
             spio_ltimer_stop(file->io_fstats->wr_timer_name);
             spio_ltimer_stop(file->io_fstats->tot_timer_name);
-            if (file->iotype == PIO_IOTYPE_ADIOS)
+            if ((file->iotype == PIO_IOTYPE_ADIOS) || (file->iotype == PIO_IOTYPE_ADIOSC))
             {
                 GPTLstop("PIO:spio_put_vars_tc_adios");
                 GPTLstop("PIO:write_total_adios");
@@ -2657,7 +2657,7 @@ int spio_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
 
     /* ADIOS: assume all procs are also IO tasks */
 #ifdef _ADIOS2
-    if (file->iotype == PIO_IOTYPE_ADIOS)
+    if ((file->iotype == PIO_IOTYPE_ADIOS) || (file->iotype == PIO_IOTYPE_ADIOSC))
     {
         if (varid < 0 || varid >= file->num_vars)
         {
@@ -3346,7 +3346,7 @@ int spio_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
     }
 #endif /* _HDF5 */
 
-        if (file->iotype != PIO_IOTYPE_PNETCDF && file->iotype != PIO_IOTYPE_ADIOS && file->iotype != PIO_IOTYPE_HDF5 && file->do_io)
+        if (file->iotype != PIO_IOTYPE_PNETCDF && file->iotype != PIO_IOTYPE_ADIOS && file->iotype != PIO_IOTYPE_ADIOSC && file->iotype != PIO_IOTYPE_HDF5 && file->do_io)
         {
             LOG((2, "spio_put_vars_tc calling netcdf function file->iotype = %d",
                  file->iotype));

--- a/src/clib/pio_nc.cpp
+++ b/src/clib/pio_nc.cpp
@@ -127,7 +127,7 @@ int PIOc_inq_impl(int ncid, int *ndimsp, int *nvarsp, int *ngattsp, int *unlimdi
 
     /* ADIOS: assume all procs are also IO tasks */
 #ifdef _ADIOS2
-    if (file->iotype == PIO_IOTYPE_ADIOS)
+    if ((file->iotype == PIO_IOTYPE_ADIOS) || (file->iotype == PIO_IOTYPE_ADIOSC))
     {
         if (ndimsp)
             *ndimsp = file->num_dim_vars;
@@ -223,7 +223,7 @@ int PIOc_inq_impl(int ncid, int *ndimsp, int *nvarsp, int *ngattsp, int *unlimdi
                 LOG((2, "classic unlimdimid = %d", *unlimdimidp));
         }
 #ifdef _NETCDF4
-        else if (file->iotype != PIO_IOTYPE_PNETCDF && file->iotype != PIO_IOTYPE_ADIOS && file->do_io)
+        else if (file->iotype != PIO_IOTYPE_PNETCDF && file->iotype != PIO_IOTYPE_ADIOS && file->iotype != PIO_IOTYPE_ADIOSC && file->do_io)
         {
             LOG((2, "PIOc_inq calling netcdf-4 nc_inq"));
             ierr = nc_inq(file->fh, ndimsp, nvarsp, ngattsp, unlimdimidp);
@@ -461,7 +461,7 @@ int PIOc_inq_unlimdims_impl(int ncid, int *nunlimdimsp, int *unlimdimidsp)
 
     /* ADIOS: assume all procs are also IO tasks */
 #ifdef _ADIOS2
-    if (file->iotype == PIO_IOTYPE_ADIOS)
+    if ((file->iotype == PIO_IOTYPE_ADIOS) || (file->iotype == PIO_IOTYPE_ADIOSC))
     {
         LOG((2, "ADIOS missing %s:%s", __FILE__, __func__));
         ierr = PIO_NOERR;
@@ -587,7 +587,7 @@ int PIOc_inq_type_impl(int ncid, nc_type xtype, char *name, PIO_Offset *sizep)
 
     /* ADIOS: assume all procs are also IO tasks */
 #ifdef _ADIOS2
-    if (file->iotype == PIO_IOTYPE_ADIOS)
+    if ((file->iotype == PIO_IOTYPE_ADIOS) || (file->iotype == PIO_IOTYPE_ADIOSC))
     {
         if (sizep)
         {
@@ -623,7 +623,7 @@ int PIOc_inq_type_impl(int ncid, nc_type xtype, char *name, PIO_Offset *sizep)
 #endif /* _PNETCDF */
 
 #ifdef _NETCDF
-        if (file->iotype != PIO_IOTYPE_PNETCDF && file->iotype != PIO_IOTYPE_ADIOS && file->do_io)
+        if (file->iotype != PIO_IOTYPE_PNETCDF && file->iotype != PIO_IOTYPE_ADIOS && file->iotype != PIO_IOTYPE_ADIOSC && file->do_io)
             ierr = nc_inq_type(file->fh, xtype, name, (size_t *)sizep);
 #endif /* _NETCDF */
         LOG((2, "PIOc_inq_type netcdf call returned %d", ierr));
@@ -719,7 +719,7 @@ int PIOc_inq_format_impl(int ncid, int *formatp)
 
     /* ADIOS: assume all procs are also IO tasks */
 #ifdef _ADIOS2
-    if (file->iotype == PIO_IOTYPE_ADIOS)
+    if ((file->iotype == PIO_IOTYPE_ADIOS) || (file->iotype == PIO_IOTYPE_ADIOSC))
     {
         *formatp = 1;
         spio_ltimer_stop(ios->io_fstats->tot_timer_name);
@@ -737,7 +737,7 @@ int PIOc_inq_format_impl(int ncid, int *formatp)
 #endif /* _PNETCDF */
 
 #ifdef _NETCDF
-        if (file->iotype != PIO_IOTYPE_PNETCDF && file->iotype != PIO_IOTYPE_ADIOS && file->do_io)
+        if (file->iotype != PIO_IOTYPE_PNETCDF && file->iotype != PIO_IOTYPE_ADIOS && file->iotype != PIO_IOTYPE_ADIOSC && file->do_io)
             ierr = nc_inq_format(file->fh, formatp);
 #endif /* _NETCDF */
         LOG((2, "PIOc_inq netcdf call returned %d", ierr));
@@ -822,7 +822,7 @@ int PIOc_inq_dim_impl(int ncid, int dimid, char *name, PIO_Offset *lenp)
 
     /* ADIOS: assume all procs are also IO tasks */
 #ifdef _ADIOS2
-    if (file->iotype == PIO_IOTYPE_ADIOS)
+    if ((file->iotype == PIO_IOTYPE_ADIOS) || (file->iotype == PIO_IOTYPE_ADIOSC))
     {
         if (0 <= dimid && dimid < file->num_dim_vars)
         {
@@ -911,7 +911,7 @@ int PIOc_inq_dim_impl(int ncid, int dimid, char *name, PIO_Offset *lenp)
 #endif /* _PNETCDF */
 
 #ifdef _NETCDF
-        if (file->iotype != PIO_IOTYPE_PNETCDF && file->iotype != PIO_IOTYPE_ADIOS && file->do_io)
+        if (file->iotype != PIO_IOTYPE_PNETCDF && file->iotype != PIO_IOTYPE_ADIOS && file->iotype != PIO_IOTYPE_ADIOSC && file->do_io)
         {
             LOG((2, "calling nc_inq_dim"));
             ierr = nc_inq_dim(file->fh, dimid, name, (size_t *)lenp);;
@@ -1072,7 +1072,7 @@ int PIOc_inq_dimid_impl(int ncid, const char *name, int *idp)
 
     /* ADIOS: assume all procs are also IO tasks */
 #ifdef _ADIOS2
-    if (file->iotype == PIO_IOTYPE_ADIOS)
+    if ((file->iotype == PIO_IOTYPE_ADIOS) || (file->iotype == PIO_IOTYPE_ADIOSC))
     {
         ierr = PIO_EBADDIM;
         for (int i = 0; i < file->num_dim_vars; i++)
@@ -1148,7 +1148,7 @@ int PIOc_inq_dimid_impl(int ncid, const char *name, int *idp)
 #endif /* _PNETCDF */
 
 #ifdef _NETCDF
-        if (file->iotype != PIO_IOTYPE_PNETCDF && file->iotype != PIO_IOTYPE_ADIOS && file->do_io)
+        if (file->iotype != PIO_IOTYPE_PNETCDF && file->iotype != PIO_IOTYPE_ADIOS && file->iotype != PIO_IOTYPE_ADIOSC && file->do_io)
             ierr = nc_inq_dimid(file->fh, name, idp);
 #endif /* _NETCDF */
     }
@@ -1251,7 +1251,7 @@ int PIOc_inq_var_impl(int ncid, int varid, char *name, int namelen, nc_type *xty
 
     /* ADIOS: assume all procs are also IO tasks */
 #ifdef _ADIOS2
-    if (file->iotype == PIO_IOTYPE_ADIOS)
+    if ((file->iotype == PIO_IOTYPE_ADIOS) || (file->iotype == PIO_IOTYPE_ADIOSC))
     {
         if (varid < file->num_vars)
         {
@@ -1376,7 +1376,7 @@ int PIOc_inq_var_impl(int ncid, int varid, char *name, int namelen, nc_type *xty
 #endif /* _PNETCDF */
 
 #ifdef _NETCDF
-        if (file->iotype != PIO_IOTYPE_PNETCDF && file->iotype != PIO_IOTYPE_ADIOS && file->do_io)
+        if (file->iotype != PIO_IOTYPE_PNETCDF && file->iotype != PIO_IOTYPE_ADIOS && file->iotype != PIO_IOTYPE_ADIOSC && file->do_io)
         {
             ndims = file->varlist[varid].ndims;
             if(ndims <= 0){
@@ -1726,7 +1726,7 @@ int PIOc_inq_varid_impl(int ncid, const char *name, int *varidp)
 
     /* ADIOS: assume all procs are also IO tasks */
 #ifdef _ADIOS2
-    if (file->iotype == PIO_IOTYPE_ADIOS)
+    if ((file->iotype == PIO_IOTYPE_ADIOS) || (file->iotype == PIO_IOTYPE_ADIOSC))
     {
         ierr = PIO_ENOTVAR;
         for (int i = 0; i < file->num_vars; i++)
@@ -1790,7 +1790,7 @@ int PIOc_inq_varid_impl(int ncid, const char *name, int *varidp)
 #endif /* _PNETCDF */
 
 #ifdef _NETCDF
-        if (file->iotype != PIO_IOTYPE_PNETCDF && file->iotype != PIO_IOTYPE_ADIOS && file->do_io)
+        if (file->iotype != PIO_IOTYPE_PNETCDF && file->iotype != PIO_IOTYPE_ADIOS && file->iotype != PIO_IOTYPE_ADIOSC && file->do_io)
             ierr = nc_inq_varid(file->fh, name, varidp);
 #endif /* _NETCDF */
     }
@@ -1945,7 +1945,7 @@ int PIOc_inq_att_impl(int ncid, int varid, const char *name, nc_type *xtypep,
 
     /* ADIOS: assume all procs are also IO tasks */
 #ifdef _ADIOS2
-    if (file->iotype == PIO_IOTYPE_ADIOS)
+    if ((file->iotype == PIO_IOTYPE_ADIOS) || (file->iotype == PIO_IOTYPE_ADIOSC))
     {
         /* Track attributes */
         ierr = PIO_ENOTATT;
@@ -2026,7 +2026,7 @@ int PIOc_inq_att_impl(int ncid, int varid, const char *name, nc_type *xtypep,
 #endif /* _PNETCDF */
 
 #ifdef _NETCDF
-        if (file->iotype != PIO_IOTYPE_PNETCDF && file->iotype != PIO_IOTYPE_ADIOS && file->do_io)
+        if (file->iotype != PIO_IOTYPE_PNETCDF && file->iotype != PIO_IOTYPE_ADIOS && file->iotype != PIO_IOTYPE_ADIOSC && file->do_io)
             ierr = nc_inq_att(file->fh, varid, name, xtypep, (size_t *)lenp);
 #endif /* _NETCDF */
         LOG((2, "PIOc_inq netcdf call returned %d", ierr));
@@ -2158,7 +2158,7 @@ int PIOc_inq_attname_impl(int ncid, int varid, int attnum, char *name)
 
     /* ADIOS: assume all procs are also IO tasks */
 #ifdef _ADIOS2
-    if (file->iotype == PIO_IOTYPE_ADIOS)
+    if ((file->iotype == PIO_IOTYPE_ADIOS) || (file->iotype == PIO_IOTYPE_ADIOSC))
     {
         if (0 <= attnum && attnum < file->num_attrs &&
             file->adios_attrs[attnum].att_varid == varid &&
@@ -2236,7 +2236,7 @@ int PIOc_inq_attname_impl(int ncid, int varid, int attnum, char *name)
 #endif /* _PNETCDF */
 
 #ifdef _NETCDF
-        if (file->iotype != PIO_IOTYPE_PNETCDF && file->iotype != PIO_IOTYPE_ADIOS && file->do_io)
+        if (file->iotype != PIO_IOTYPE_PNETCDF && file->iotype != PIO_IOTYPE_ADIOS && file->iotype != PIO_IOTYPE_ADIOSC && file->do_io)
             ierr = nc_inq_attname(file->fh, varid, attnum, name);
 #endif /* _NETCDF */
         LOG((2, "PIOc_inq_attname netcdf call returned %d", ierr));
@@ -2344,7 +2344,7 @@ int PIOc_inq_attid_impl(int ncid, int varid, const char *name, int *idp)
 
     /* ADIOS: assume all procs are also IO tasks */
 #ifdef _ADIOS2
-    if (file->iotype == PIO_IOTYPE_ADIOS)
+    if ((file->iotype == PIO_IOTYPE_ADIOS) || (file->iotype == PIO_IOTYPE_ADIOSC))
     {
         ierr = PIO_ENOTATT;
         for (int i = 0; i < file->num_attrs; i++)
@@ -2412,7 +2412,7 @@ int PIOc_inq_attid_impl(int ncid, int varid, const char *name, int *idp)
 #endif /* _PNETCDF */
 
 #ifdef _NETCDF
-        if (file->iotype != PIO_IOTYPE_PNETCDF && file->iotype != PIO_IOTYPE_ADIOS && file->do_io)
+        if (file->iotype != PIO_IOTYPE_PNETCDF && file->iotype != PIO_IOTYPE_ADIOS && file->iotype != PIO_IOTYPE_ADIOSC && file->do_io)
             ierr = nc_inq_attid(file->fh, varid, name, idp);
 #endif /* _NETCDF */
         LOG((2, "PIOc_inq_attname netcdf call returned %d", ierr));
@@ -2512,7 +2512,7 @@ int PIOc_rename_dim_impl(int ncid, int dimid, const char *name)
 
     /* ADIOS: assume all procs are also IO tasks */
 #ifdef _ADIOS2
-    if (file->iotype == PIO_IOTYPE_ADIOS)
+    if ((file->iotype == PIO_IOTYPE_ADIOS) || (file->iotype == PIO_IOTYPE_ADIOSC))
     {
         LOG((2, "ADIOS missing %s:%s", __FILE__, __func__));
         ierr = PIO_NOERR;
@@ -2528,7 +2528,7 @@ int PIOc_rename_dim_impl(int ncid, int dimid, const char *name)
 #endif /* _PNETCDF */
 
 #ifdef _NETCDF
-        if (file->iotype != PIO_IOTYPE_PNETCDF && file->iotype != PIO_IOTYPE_ADIOS && file->do_io)
+        if (file->iotype != PIO_IOTYPE_PNETCDF && file->iotype != PIO_IOTYPE_ADIOS && file->iotype != PIO_IOTYPE_ADIOSC && file->do_io)
             ierr = nc_rename_dim(file->fh, dimid, name);
 #endif /* _NETCDF */
         LOG((2, "PIOc_inq netcdf call returned %d", ierr));
@@ -2613,7 +2613,7 @@ int PIOc_rename_var_impl(int ncid, int varid, const char *name)
 
     /* ADIOS: assume all procs are also IO tasks */
 #ifdef _ADIOS2
-    if (file->iotype == PIO_IOTYPE_ADIOS)
+    if ((file->iotype == PIO_IOTYPE_ADIOS) || (file->iotype == PIO_IOTYPE_ADIOSC))
     {
         LOG((2, "ADIOS missing %s:%s", __FILE__, __func__));
         ierr = PIO_NOERR;
@@ -2629,7 +2629,7 @@ int PIOc_rename_var_impl(int ncid, int varid, const char *name)
 #endif /* _PNETCDF */
 
 #ifdef _NETCDF
-        if (file->iotype != PIO_IOTYPE_PNETCDF && file->iotype != PIO_IOTYPE_ADIOS && file->do_io)
+        if (file->iotype != PIO_IOTYPE_PNETCDF && file->iotype != PIO_IOTYPE_ADIOS && file->iotype != PIO_IOTYPE_ADIOSC && file->do_io)
             ierr = nc_rename_var(file->fh, varid, name);
 #endif /* _NETCDF */
         LOG((2, "PIOc_inq netcdf call returned %d", ierr));
@@ -2724,7 +2724,7 @@ int PIOc_rename_att_impl(int ncid, int varid, const char *name,
 
     /* ADIOS: assume all procs are also IO tasks */
 #ifdef _ADIOS2
-    if (file->iotype == PIO_IOTYPE_ADIOS)
+    if ((file->iotype == PIO_IOTYPE_ADIOS) || (file->iotype == PIO_IOTYPE_ADIOSC))
     {
         LOG((2, "ADIOS missing %s:%s", __FILE__, __func__));
         ierr = PIO_NOERR;
@@ -2740,7 +2740,7 @@ int PIOc_rename_att_impl(int ncid, int varid, const char *name,
 #endif /* _PNETCDF */
 
 #ifdef _NETCDF
-        if (file->iotype != PIO_IOTYPE_PNETCDF && file->iotype != PIO_IOTYPE_ADIOS && file->do_io)
+        if (file->iotype != PIO_IOTYPE_PNETCDF && file->iotype != PIO_IOTYPE_ADIOS && file->iotype != PIO_IOTYPE_ADIOSC && file->do_io)
             ierr = nc_rename_att(file->fh, varid, name, newname);
 #endif /* _NETCDF */
     }
@@ -2826,7 +2826,7 @@ int PIOc_del_att_impl(int ncid, int varid, const char *name)
 
     /* ADIOS: assume all procs are also IO tasks */
 #ifdef _ADIOS2
-    if (file->iotype == PIO_IOTYPE_ADIOS)
+    if ((file->iotype == PIO_IOTYPE_ADIOS) || (file->iotype == PIO_IOTYPE_ADIOSC))
     {
         LOG((2, "ADIOS missing %s:%s", __FILE__, __func__));
         ierr = PIO_NOERR;
@@ -2842,7 +2842,7 @@ int PIOc_del_att_impl(int ncid, int varid, const char *name)
 #endif /* _PNETCDF */
 
 #ifdef _NETCDF
-        if (file->iotype != PIO_IOTYPE_PNETCDF && file->iotype != PIO_IOTYPE_ADIOS && file->do_io)
+        if (file->iotype != PIO_IOTYPE_PNETCDF && file->iotype != PIO_IOTYPE_ADIOS && file->iotype != PIO_IOTYPE_ADIOSC && file->do_io)
             ierr = nc_del_att(file->fh, varid, name);
 #endif /* _NETCDF */
     }
@@ -2915,7 +2915,7 @@ int PIOc_set_fill_impl(int ncid, int fillmode, int *old_modep)
 
     /* ADIOS: assume all procs are also IO tasks */
 #ifdef _ADIOS2
-    if (file->iotype == PIO_IOTYPE_ADIOS)
+    if ((file->iotype == PIO_IOTYPE_ADIOS) || (file->iotype == PIO_IOTYPE_ADIOSC))
     {
         if (old_modep)
             *old_modep = file->fillmode;
@@ -2950,7 +2950,7 @@ int PIOc_set_fill_impl(int ncid, int fillmode, int *old_modep)
 #endif /* _PNETCDF */
 
 #ifdef _NETCDF
-        if (file->iotype != PIO_IOTYPE_PNETCDF && file->iotype != PIO_IOTYPE_ADIOS && file->iotype != PIO_IOTYPE_HDF5 && file->do_io)
+        if (file->iotype != PIO_IOTYPE_PNETCDF && file->iotype != PIO_IOTYPE_ADIOS && file->iotype != PIO_IOTYPE_ADIOSC && file->iotype != PIO_IOTYPE_HDF5 && file->do_io)
             ierr = nc_set_fill(file->fh, fillmode, old_modep);
 #endif /* _NETCDF */
     }
@@ -3092,7 +3092,7 @@ int PIOc_def_dim_impl(int ncid, const char *name, PIO_Offset len, int *idp)
 
     /* ADIOS: assume all procs are also IO tasks */
 #ifdef _ADIOS2
-    if (file->iotype == PIO_IOTYPE_ADIOS)
+    if ((file->iotype == PIO_IOTYPE_ADIOS) || (file->iotype == PIO_IOTYPE_ADIOSC))
     {
         LOG((2, "ADIOS define dimension %s with size %llu, id = %d",
                 name, (unsigned long long)len, file->num_dim_vars));
@@ -3212,7 +3212,7 @@ int PIOc_def_dim_impl(int ncid, const char *name, PIO_Offset len, int *idp)
 #endif /* _PNETCDF */
 
 #ifdef _NETCDF
-        if (file->iotype != PIO_IOTYPE_PNETCDF && file->iotype != PIO_IOTYPE_ADIOS && file->iotype != PIO_IOTYPE_HDF5 && file->do_io)
+        if (file->iotype != PIO_IOTYPE_PNETCDF && file->iotype != PIO_IOTYPE_ADIOS && file->iotype != PIO_IOTYPE_ADIOSC && file->iotype != PIO_IOTYPE_HDF5 && file->do_io)
             ierr = nc_def_dim(file->fh, name, (size_t)len, idp);
 #endif /* _NETCDF */
     }
@@ -3376,7 +3376,7 @@ int PIOc_def_var_impl(int ncid, const char *name, nc_type xtype, int ndims,
 
     /* ADIOS: assume all procs are also IO tasks */
 #ifdef _ADIOS2
-    if (file->iotype == PIO_IOTYPE_ADIOS)
+    if ((file->iotype == PIO_IOTYPE_ADIOS) || (file->iotype == PIO_IOTYPE_ADIOSC))
     {
         LOG((2, "ADIOS pre-define variable %s (%d dimensions, type %d)", name, ndims, xtype));
 
@@ -3617,7 +3617,7 @@ int PIOc_def_var_impl(int ncid, const char *name, nc_type xtype, int ndims,
 #endif /* _PNETCDF */
 
 #ifdef _NETCDF
-        if (file->iotype != PIO_IOTYPE_PNETCDF && file->iotype != PIO_IOTYPE_ADIOS && file->iotype != PIO_IOTYPE_HDF5 && file->do_io)
+        if (file->iotype != PIO_IOTYPE_PNETCDF && file->iotype != PIO_IOTYPE_ADIOS && file->iotype != PIO_IOTYPE_ADIOSC && file->iotype != PIO_IOTYPE_HDF5 && file->do_io)
         {
             ierr = nc_def_var(file->fh, name, xtype, ndims, dimidsp, varidp);
             if (ierr != PIO_NOERR)
@@ -3923,7 +3923,7 @@ int PIOc_def_var_fill_impl(int ncid, int varid, int fill_mode, const void *fill_
 
     /* ADIOS: assume all procs are also IO tasks */
 #ifdef _ADIOS2
-    if (file->iotype == PIO_IOTYPE_ADIOS)
+    if ((file->iotype == PIO_IOTYPE_ADIOS) || (file->iotype == PIO_IOTYPE_ADIOSC))
     {
         LOG((2, "ADIOS missing %s:%s", __FILE__, __func__));
         ierr = PIO_NOERR;
@@ -4120,7 +4120,7 @@ int PIOc_inq_var_fill_impl(int ncid, int varid, int *no_fill, void *fill_valuep)
 
     /* ADIOS: assume all procs are also IO tasks */
 #ifdef _ADIOS2
-    if (file->iotype == PIO_IOTYPE_ADIOS)
+    if ((file->iotype == PIO_IOTYPE_ADIOS) || (file->iotype == PIO_IOTYPE_ADIOSC))
     {
         LOG((2, "ADIOS missing %s:%s", __FILE__, __func__));
         ierr = PIO_NOERR;

--- a/src/clib/pio_print.cpp
+++ b/src/clib/pio_print.cpp
@@ -15,6 +15,8 @@ const char *pio_iotype_to_string(int iotype)
                               return "PIO_IOTYPE_NETCDF4P";
     case PIO_IOTYPE_ADIOS:
                               return "PIO_IOTYPE_ADIOS";
+    case PIO_IOTYPE_ADIOSC:
+                              return "PIO_IOTYPE_ADIOSC";
     default:
                               return "UNKNOWN";
   }

--- a/src/clib/pioc.cpp
+++ b/src/clib/pioc.cpp
@@ -272,7 +272,7 @@ int PIOc_setframe_impl(int ncid, int varid, int frame)
 
 #ifdef _ADIOS2
     /* Add end_step here. Check for frame value of the ncid. */
-    if (file->iotype == PIO_IOTYPE_ADIOS)
+    if ((file->iotype == PIO_IOTYPE_ADIOS) || (file->iotype == PIO_IOTYPE_ADIOSC))
     {
         GPTLstart("PIOc_setframe_adios2");
         if (file->adios_io_process == 1)

--- a/src/flib/pio.F90
+++ b/src/flib/pio.F90
@@ -29,7 +29,7 @@ module pio
        pio_rearr_comm_p2p, pio_rearr_comm_coll,&
        pio_int, pio_real, pio_double, pio_noerr, iotype_netcdf, &
        iotype_pnetcdf,  pio_iotype_netcdf4p, pio_iotype_netcdf4c, &
-       pio_iotype_pnetcdf,pio_iotype_netcdf, pio_iotype_adios, pio_iotype_hdf5, &
+       pio_iotype_pnetcdf,pio_iotype_netcdf, pio_iotype_adios, pio_iotype_adiosc, pio_iotype_hdf5, &
        pio_global, pio_char, pio_write, pio_nowrite, pio_clobber, pio_noclobber, &
        pio_max_name, pio_max_var_dims, pio_rearr_subset, pio_rearr_box, pio_rearr_any,&
 #if defined(_NETCDF) || defined(_PNETCDF)

--- a/src/flib/pio_types.F90
+++ b/src/flib/pio_types.F90
@@ -117,7 +117,8 @@ module pio_types
 !!   - PIO_iotype_netcdf : serial (only the root I/O process) read/write using the NetCDF library
 !!   - PIO_iotype_netcdf4c : parallel read/serial write of NetCDF4 (HDF5) files with data compression
 !!   - PIO_iotype_netcdf4p : parallel read/write of NETCDF4 (HDF5) files
-!!   - PIO_iotype_adios : parallel write of ADIOS files with subset rearrangement only
+!!   - PIO_iotype_adios : parallel read/write of ADIOS files
+!!   - PIO_iotype_adiosc : parallel read/write of ADIOS files with data compression
 !!   - PIO_iotype_hdf5 : parallel write of HDF5 files
 !>
     integer(i4), public, parameter ::  &
@@ -125,8 +126,9 @@ module pio_types
         PIO_iotype_netcdf  = 2, &   ! serial read/write of NetCDF file using 'base_node'
         PIO_iotype_netcdf4c = 3, &  ! netcdf4 (hdf5 format) file opened for compression (serial write access only)
         PIO_iotype_netcdf4p = 4, &  ! netcdf4 (hdf5 format) file opened in parallel (all netcdf4 files for read will be opened this way)
-        PIO_iotype_adios = 5, &     ! parallel write of ADIOS files (Write only, rearr subset only)
-        PIO_iotype_hdf5 = 6         ! parallel write of HDF5 files
+        PIO_iotype_adios = 5, &     ! parallel read/write of ADIOS files
+        PIO_iotype_adiosc = 6, &    ! parallel read/write of ADIOS files with compression
+        PIO_iotype_hdf5 = 7         ! parallel write of HDF5 files
 
 
 ! These are for backward compatability and should not be used or expanded upon

--- a/src/flib_legacy/pio.F90
+++ b/src/flib_legacy/pio.F90
@@ -26,7 +26,7 @@ module pio
        pio_rearr_comm_p2p, pio_rearr_comm_coll,&
        pio_int, pio_real, pio_double, pio_noerr, iotype_netcdf, &
        iotype_pnetcdf,  pio_iotype_netcdf4p, pio_iotype_netcdf4c, &
-       pio_iotype_pnetcdf,pio_iotype_netcdf, pio_iotype_adios, pio_iotype_hdf5, &
+       pio_iotype_pnetcdf,pio_iotype_netcdf, pio_iotype_adios, pio_iotype_adiosc, pio_iotype_hdf5, &
        pio_global, pio_char, pio_write, pio_nowrite, pio_clobber, pio_noclobber, &
        pio_max_name, pio_max_var_dims, pio_rearr_subset, pio_rearr_box, pio_rearr_any,&
 #if defined(_NETCDF) || defined(_PNETCDF)

--- a/src/flib_legacy/pio_types.F90
+++ b/src/flib_legacy/pio_types.F90
@@ -101,6 +101,7 @@ module pio_types
 !!   - PIO_iotype_netcdf4c : parallel read/serial write of NetCDF4 (HDF5) files with data compression
 !!   - PIO_iotype_netcdf4p : parallel read/write of NETCDF4 (HDF5) files
 !!   - PIO_iotype_adios : parallel write of ADIOS files with subset rearrangement only
+!!   - PIO_iotype_adiosc : parallel write of ADIOS files with data compression
 !!   - PIO_iotype_hdf5 : parallel write of HDF5 files
 !>
     integer(i4), public, parameter ::  &
@@ -109,7 +110,8 @@ module pio_types
         PIO_iotype_netcdf4c = 3, &  ! netcdf4 (hdf5 format) file opened for compression (serial write access only)
         PIO_iotype_netcdf4p = 4, &  ! netcdf4 (hdf5 format) file opened in parallel (all netcdf4 files for read will be opened this way)
         PIO_iotype_adios = 5, &     ! parallel write of ADIOS files (Write only, rearr subset only)
-        PIO_iotype_hdf5 = 6         ! parallel write of HDF5 files
+        PIO_iotype_adiosc = 6, &    ! parallel write of ADIOS files with data compression
+        PIO_iotype_hdf5 = 7         ! parallel write of HDF5 files
 
 
 ! These are for backward compatability and should not be used or expanded upon

--- a/tests/general/util/pio_tutil.F90
+++ b/tests/general/util/pio_tutil.F90
@@ -334,6 +334,11 @@ CONTAINS
 #ifdef _ADIOS2
       ! adios
       num_iotypes = num_iotypes + 1
+#ifdef _SPIO_ADIOS_USE_COMPRESSION
+      ! adiosc
+      num_iotypes = num_iotypes + 1
+#endif
+
 #endif
 #ifdef _HDF5
       ! hdf5
@@ -351,12 +356,20 @@ CONTAINS
       iotype_descs(i) = "PNETCDF"
       i = i + 1
 #endif
+
 #ifdef _ADIOS2
       ! adios
       iotypes(i) = PIO_iotype_adios
       iotype_descs(i) = "ADIOS"
       i = i + 1
+#ifdef _SPIO_ADIOS_USE_COMPRESSION
+      ! adiosc
+      iotypes(i) = PIO_iotype_adiosc
+      iotype_descs(i) = "ADIOSC"
+      i = i + 1
 #endif
+#endif
+
 #ifdef _HDF5
       ! hdf5
       iotypes(i) = PIO_iotype_hdf5
@@ -448,10 +461,17 @@ CONTAINS
       ! pnetcdf
       num_iotypes = num_iotypes + 1
 #endif
+
 #ifndef _ADIOS2
-      ! adios
+      ! adios, adiosc
+      num_iotypes = num_iotypes + 2
+#else
+#ifndef _SPIO_ADIOS_USE_COMPRESSION
+      ! adiosc
       num_iotypes = num_iotypes + 1
 #endif
+#endif
+
 #ifndef _HDF5
       ! hdf5
       num_iotypes = num_iotypes + 1
@@ -483,12 +503,25 @@ CONTAINS
       iotype_descs(i) = "PNETCDF"
       i = i + 1
 #endif
+
 #ifndef _ADIOS2
       ! adios
       iotypes(i) = PIO_iotype_adios
       iotype_descs(i) = "ADIOS"
       i = i + 1
+      ! adiosc
+      iotypes(i) = PIO_iotype_adiosc
+      iotype_descs(i) = "ADIOSC"
+      i = i + 1
+#else
+#ifndef _SPIO_ADIOS_USE_COMPRESSION
+      ! adiosc
+      iotypes(i) = PIO_iotype_adiosc
+      iotype_descs(i) = "ADIOSC"
+      i = i + 1
 #endif
+#endif
+
 #ifndef _HDF5
       ! hdf5
       iotypes(i) = PIO_iotype_hdf5
@@ -527,6 +560,10 @@ CONTAINS
 #ifdef _ADIOS2
       ! adios
       num_iotypes = num_iotypes + 1
+#ifdef _SPIO_ADIOS_USE_COMPRESSION
+      ! adiosc
+      num_iotypes = num_iotypes + 1
+#endif
 #endif
 #ifdef _HDF5
       ! hdf5
@@ -549,6 +586,12 @@ CONTAINS
       iotypes(i) = PIO_iotype_adios
       iotype_descs(i) = "ADIOS"
       i = i + 1
+#ifdef _SPIO_ADIOS_USE_COMPRESSION
+      ! adiosc
+      iotypes(i) = PIO_iotype_adiosc
+      iotype_descs(i) = "ADIOSC"
+      i = i + 1
+#endif
 #endif
 #ifdef _HDF5
       ! hdf5
@@ -606,8 +649,13 @@ CONTAINS
       num_iotypes = num_iotypes + 1
 #endif
 #ifndef _ADIOS2
-      ! adios
+      ! adios, adiosc
+      num_iotypes = num_iotypes + 2
+#else
+#ifndef _SPIO_ADIOS_USE_COMPRESSION
+      ! adiosc
       num_iotypes = num_iotypes + 1
+#endif
 #endif
 #ifndef _HDF5
       ! hdf5
@@ -619,12 +667,25 @@ CONTAINS
     ALLOCATE(iotype_descs(num_iotypes))
 
     i = 1
+
 #ifndef _ADIOS2
       ! adios
       iotypes(i) = PIO_iotype_adios
       iotype_descs(i) = "ADIOS"
       i = i + 1
+      ! adiosc
+      iotypes(i) = PIO_iotype_adiosc
+      iotype_descs(i) = "ADIOSC"
+      i = i + 1
+#else
+#ifndef _SPIO_ADIOS_USE_COMPRESSION
+      ! adiosc
+      iotypes(i) = PIO_iotype_adiosc
+      iotype_descs(i) = "ADIOSC"
+      i = i + 1
 #endif
+#endif
+
 #ifndef _HDF5
       ! adios
       iotypes(i) = PIO_iotype_hdf5
@@ -1299,6 +1360,11 @@ CONTAINS
         (str == "adios") .OR.&
         (str == "ADIOS")) THEN
       PIO_TF_Iotype_from_str = PIO_IOTYPE_ADIOS
+    ELSE IF((str == "PIO_IOTYPE_ADIOSC") .OR.&
+        (str == "pio_iotype_adiosc") .OR.&
+        (str == "adiosc") .OR.&
+        (str == "ADIOSC")) THEN
+      PIO_TF_Iotype_from_str = PIO_IOTYPE_ADIOSC
     ELSE IF((str == "PIO_IOTYPE_HDF5") .OR.&
         (str == "pio_iotype_hdf5") .OR.&
         (str == "hdf5") .OR.&


### PR DESCRIPTION
Adding a new I/O type, PIO_IOTYPE_ADIOSC, that can be used to
write (and read) data in ADIOS BP file format with data compression

Also modifying the testing framework to test the new I/O type.