### PR TITLE
Apply a workaround for CMake FindMPI regression on Cray systems

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -347,6 +347,18 @@ endif ()
 # ADDING SOURCE & TOOLS
 #==============================================================================
 
+# Workaround for CMake 3.22.0+ regression on Cray systems (e.g., Frontier).
+# The regression breaks the existing FindMPI logic and causes MPI detection
+# to fail or hang inside subprojects.
+# This workaround adds an additional find_package(MPI) call at the root level
+# to restore MPI detection functionality in a subproject. The fix is temporary
+# but necessary until the issue is addressed in future CMake releases.
+if (DEFINED ENV{CRAYPE_VERSION})
+  if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.22.0")
+    find_package(MPI REQUIRED)
+  endif ()
+endif ()
+
 # Libraries
 add_subdirectory (src)
 


### PR DESCRIPTION
This PR applies a temporary but necessary workaround to address a
CMake regression (3.22.0 or higher) that causes find_package(MPI)
to fail or hang when detected in subprojects on Cray systems.

This workaround ensures that find_package(MPI) is properly detected
in subprojects until the regression is resolved by CMake developers.

Fixes #517