### PR TITLE
Redirect ADIOS output symlink to md file

### DIFF
--- a/src/clib/pioc_support.cpp
+++ b/src/clib/pioc_support.cpp
@@ -19,6 +19,7 @@
 #ifdef _HDF5
 #include <sys/stat.h>
 #endif
+#include <string>
 #include "spio_io_summary.h"
 #include "spio_file_mvcache.h"
 #include "spio_hash.h"
@@ -3113,10 +3114,11 @@ int spio_createfile_int(int iosysid, int *ncidp, const int *iotype, const char *
 
             if(file->adios_rank == 0)
             {
-                ierr = symlink(file->filename, filename);
+                const std::string adios_bp_md_filename(std::string(file->filename) + "/md.0");
+                ierr = symlink(adios_bp_md_filename.c_str(), filename);
                 if(ierr != 0)
                 {
-                    fprintf(stdout, "PIO: WARNING: Creating symlink for %s file failed, ierr = %d", file->filename, ierr);
+                    fprintf(stdout, "PIO: WARNING: Creating symlink for ADIOS BP mdata file (%s) failed, ierr = %d", adios_bp_md_filename.c_str(), ierr);
                 }
             }
 


### PR DESCRIPTION
Instead of pointing to the ADIOS BP output directory (foo.nc.bp)
point the ADIOS output file symlink (foo.nc) to the meta data file
in the ADIOS BP directory (foo.nc.bp/md.0)

Fixes #625 