### PR TITLE
Adding ADIOS output symlink to md file (maint v1.6)

### DIFF
--- a/src/clib/pioc_support.c
+++ b/src/clib/pioc_support.c
@@ -3025,10 +3025,12 @@ int PIOc_createfile_int(int iosysid, int *ncidp, const int *iotype, const char *
 
             if(file->adios_rank == 0)
             {
-                ierr = symlink(file->filename, filename);
+                char adios_bp_md_filename[PIO_MAX_NAME];
+                snprintf(adios_bp_md_filename, PIO_MAX_NAME, "%s%s", file->filename, "/md.0");
+                ierr = symlink(adios_bp_md_filename, filename);
                 if(ierr != 0)
                 {
-                    fprintf(stdout, "PIO: WARNING: Creating symlink for %s file failed, ierr = %d", file->filename, ierr);
+                    fprintf(stdout, "PIO: WARNING: Creating symlink for ADIOS BP mdata file (%s) failed, ierr = %d", adios_bp_md_filename, ierr);
                 }
             }
 


### PR DESCRIPTION
Instead of pointing to the ADIOS BP output directory point the ADIOS
output file symlink (foo.nc) to the meta data file in the ADIOS BP
directory (foo.nc.bp/md.0)

Also see PR #626