### PR TITLE
Fix for potential integer under/overflow issue with reading very large files

### DIFF
--- a/src/clib/pio_rearrange.cpp
+++ b/src/clib/pio_rearrange.cpp
@@ -1964,7 +1964,10 @@ int compare_offsets(const void *a, const void *b)
     mapsort *y = (mapsort *)b;
     if (!x || !y)
         return 0;
-    return (int)(x->iomap - y->iomap);
+
+    if (x->iomap < y->iomap) { return -1; }
+    if (x->iomap > y->iomap) { return 1; }
+    return 0;
 }
 
 /**


### PR DESCRIPTION
 Fix overflow/underflow issues during qsort for the SUBSET
rearranger.

 The comparator function given to the qsort call in the rearranger
returns a 32-bit integer, but the operands can be 64-bit.  Depending
on the difference in value, you can get an overflow or underflow,
which means you read an incorrect amount of data.
