### PR TITLE
Handle ADIOS compression limitations with ZFP

### DIFF
--- a/src/clib/pio_getput_int.cpp
+++ b/src/clib/pio_getput_int.cpp
@@ -2916,6 +2916,22 @@ int spio_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
                                        "Setting (ADIOS) selection to variable (name=%s) failed (adios2_error=%s) for file (%s, ncid=%d)",
                                        av->name, convert_adios2_error_to_string(adiosErr), pio_get_fname_from_file(file), file->pio_ncid);
                     }
+
+                    #if defined(_SPIO_ADIOS_USE_LOSSY_COMPRESSION) && defined(ADIOS2_HAVE_ZFP)
+                    if (ios->adios_lossy_compression_method == ADIOS_COMPRESSION_METHOD_ZFP)
+                    {
+                        if (av_size == 1)
+                        {
+                            adiosErr = adios2_remove_operations(av->adios_varid);
+                            if (adiosErr != adios2_error_none)
+                            {
+                                return pio_err(NULL, file, PIO_EADIOS2ERR, __FILE__, __LINE__,
+                                               "Removing all current operations associated with variable (name=%s) failed (adios2_error=%s) for file (%s, ncid=%d)",
+                                               av->name, convert_adios2_error_to_string(adiosErr), pio_get_fname_from_file(file), file->pio_ncid);
+                            }
+                        }
+                    }
+                    #endif
                 }
 
                 char *mem_buffer = (char*)calloc(av_size, sizeof(char));

--- a/src/clib/pioc_support.cpp
+++ b/src/clib/pioc_support.cpp
@@ -152,6 +152,23 @@ static int flush_adios2_tracking_data(file_desc_t *file)
                                    "Setting (ADIOS) selection to variable (name=decomp_id/%s) failed (adios2_error=%s) for file (%s, ncid=%d)",
                                    av->name, convert_adios2_error_to_string(adiosErr), pio_get_fname_from_file(file), file->pio_ncid);
                 }
+
+                #if defined(_SPIO_ADIOS_USE_LOSSY_COMPRESSION) && defined(ADIOS2_HAVE_ZFP)
+                if (file->iosystem->adios_lossy_compression_method == ADIOS_COMPRESSION_METHOD_ZFP)
+                {
+                    if (count_val == 1)
+                    {
+                        adiosErr = adios2_remove_operations(av->decomp_varid);
+                        if (adiosErr != adios2_error_none)
+                        {
+                            return pio_err(NULL, file, PIO_EADIOS2ERR, __FILE__, __LINE__,
+                                           "Removing all current operations associated with variable (name=decomp_id/%s) failed (adios2_error=%s) for file (%s, ncid=%d)",
+                                           av->name, convert_adios2_error_to_string(adiosErr), pio_get_fname_from_file(file), file->pio_ncid);
+                        }
+                    }
+                }
+                #endif
+
                 adiosErr = adios2_put(file->engineH, av->decomp_varid, av->decomp_buffer, adios2_mode_sync);
                 if (adiosErr != adios2_error_none)
                 {
@@ -178,6 +195,23 @@ static int flush_adios2_tracking_data(file_desc_t *file)
                                    "Setting (ADIOS) selection to variable (name=frame_id/%s) failed (adios2_error=%s) for file (%s, ncid=%d)",
                                    av->name, convert_adios2_error_to_string(adiosErr), pio_get_fname_from_file(file), file->pio_ncid);
                 }
+
+                #if defined(_SPIO_ADIOS_USE_LOSSY_COMPRESSION) && defined(ADIOS2_HAVE_ZFP)
+                if (file->iosystem->adios_lossy_compression_method == ADIOS_COMPRESSION_METHOD_ZFP)
+                {
+                    if (count_val == 1)
+                    {
+                        adiosErr = adios2_remove_operations(av->frame_varid);
+                        if (adiosErr != adios2_error_none)
+                        {
+                            return pio_err(NULL, file, PIO_EADIOS2ERR, __FILE__, __LINE__,
+                                           "Removing all current operations associated with variable (name=frame_id/%s) failed (adios2_error=%s) for file (%s, ncid=%d)",
+                                           av->name, convert_adios2_error_to_string(adiosErr), pio_get_fname_from_file(file), file->pio_ncid);
+                        }
+                    }
+                }
+                #endif
+
                 adiosErr = adios2_put(file->engineH, av->frame_varid, av->frame_buffer, adios2_mode_sync);
                 if (adiosErr != adios2_error_none)
                 {
@@ -204,6 +238,23 @@ static int flush_adios2_tracking_data(file_desc_t *file)
                                    "Setting (ADIOS) selection to variable (name=fillval_id/%s) failed (adios2_error=%s) for file (%s, ncid=%d)",
                                    av->name, convert_adios2_error_to_string(adiosErr), pio_get_fname_from_file(file), file->pio_ncid);
                 }
+
+                #if defined(_SPIO_ADIOS_USE_LOSSY_COMPRESSION) && defined(ADIOS2_HAVE_ZFP)
+                if (file->iosystem->adios_lossy_compression_method == ADIOS_COMPRESSION_METHOD_ZFP)
+                {
+                    if (count_val == 1)
+                    {
+                        adiosErr = adios2_remove_operations(av->fillval_varid);
+                        if (adiosErr != adios2_error_none)
+                        {
+                            return pio_err(NULL, file, PIO_EADIOS2ERR, __FILE__, __LINE__,
+                                           "Removing all current operations associated with variable (name=fillval_id/%s) failed (adios2_error=%s) for file (%s, ncid=%d)",
+                                           av->name, convert_adios2_error_to_string(adiosErr), pio_get_fname_from_file(file), file->pio_ncid);
+                        }
+                    }
+                }
+                #endif
+
                 adiosErr = adios2_put(file->engineH, av->fillval_varid, av->fillval_buffer, adios2_mode_sync);
                 if (adiosErr != adios2_error_none)
                 {
@@ -230,6 +281,23 @@ static int flush_adios2_tracking_data(file_desc_t *file)
                                    "Setting (ADIOS) selection to variable (name=num_data_block_writers/%s) failed (adios2_error=%s) for file (%s, ncid=%d)",
                                    av->name, convert_adios2_error_to_string(adiosErr), pio_get_fname_from_file(file), file->pio_ncid);
                 }
+
+                #if defined(_SPIO_ADIOS_USE_LOSSY_COMPRESSION) && defined(ADIOS2_HAVE_ZFP)
+                if (file->iosystem->adios_lossy_compression_method == ADIOS_COMPRESSION_METHOD_ZFP)
+                {
+                    if (count_val == 1)
+                    {
+                        adiosErr = adios2_remove_operations(av->num_block_writers_varid);
+                        if (adiosErr != adios2_error_none)
+                        {
+                            return pio_err(NULL, file, PIO_EADIOS2ERR, __FILE__, __LINE__,
+                                           "Removing all current operations associated with variable (num_data_block_writers/%s) failed (adios2_error=%s) for file (%s, ncid=%d)",
+                                           av->name, convert_adios2_error_to_string(adiosErr), pio_get_fname_from_file(file), file->pio_ncid);
+                        }
+                    }
+                }
+                #endif
+
                 adiosErr = adios2_put(file->engineH, av->num_block_writers_varid, av->num_wb_buffer, adios2_mode_sync);
                 if (adiosErr != adios2_error_none)
                 {
@@ -570,6 +638,14 @@ adios2_variable* spio_define_adios2_variable(iosystem_desc_t *ios, file_desc_t *
         {
             /* Switch back to lossless compression method for non floating point type */
             if (type != adios2_type_float && type != adios2_type_double)
+                variable_compression_method = ios->adios_lossless_compression_method;
+        }
+        /* ZFP compressor does not support 8-bit or 16-bit integer types */
+        else if (variable_compression_method == ADIOS_COMPRESSION_METHOD_ZFP)
+        {
+            /* Switch back to lossless compression method for unsupported integer types */
+            if (type == adios2_type_int8_t || type == adios2_type_uint8_t ||
+                type == adios2_type_int16_t || type == adios2_type_uint16_t)
                 variable_compression_method = ios->adios_lossless_compression_method;
         }
         #endif


### PR DESCRIPTION
This PR adds support for writing 0D data and short integer
variables with the ZFP compression method in ADIOS.