### PR TITLE
Adding MPI decls for external GPTL

### DIFF
--- a/src/clib/CMakeLists.txt
+++ b/src/clib/CMakeLists.txt
@@ -68,6 +68,11 @@ if (PIO_ENABLE_TIMING)
       PUBLIC ${GPTL_C_INCLUDE_DIRS})
     target_link_libraries (pioc
       PUBLIC ${GPTL_C_LIBRARIES})
+
+    # GPTL expects HAVE_MPI, if MPI is available, when using GPTL header files
+    if (NOT PIO_USE_MPISERIAL)
+      target_compile_definitions (pioc PUBLIC HAVE_MPI)
+    endif ()
   else ()
     message (STATUS "Using internal GPTL C library for timing")
     target_include_directories (pioc


### PR DESCRIPTION
Adding HAVE_MPI declaration to indicate if MPI is available 
(required by the GPTL header files) to correctly use the GPTL
header files.