### PR TITLE
Updating docs directory in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -409,7 +409,7 @@ endif ()
 
 if (PIO_ENABLE_DOC)
   message(STATUS "Enabling SCORPIO Documentation...")
-  add_subdirectory (doc)
+  add_subdirectory (docs)
 else ()
   message(STATUS "Disabling SCORPIO Documentation... (default, use -DPIO_ENABLE_DOC:BOOL=ON to enable documentation)")
 endif ()

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -32,7 +32,7 @@ ${CMAKE_CURRENT_SOURCE_DIR}/../src/clib/pioc_sc.c" )
     ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile @ONLY)
 
   # Copy necessary files.
-  add_custom_target(doc
+  add_custom_target(docs
     COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/customdoxygen.css
     ${CMAKE_CURRENT_BINARY_DIR}
     COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/DoxygenLayout.xml


### PR DESCRIPTION
Updating CMake target/directory to point to new
directory for documentation ("docs" instead of "doc")

This PR fixes documentation generation broken by 
PR #641 