### PR TITLE
Adding option to remove input files after conversion in the ADIOS to NetCDF conversion tool 

### DIFF
--- a/tools/adios2pio-nm/CMakeLists.txt
+++ b/tools/adios2pio-nm/CMakeLists.txt
@@ -89,7 +89,7 @@ endif ()
 #  DEFINE THE TARGET LIBRARY
 #==============================================================================
 SET(SRC ${SCORPIO_SOURCE_DIR}/tools/util/argparser.cxx adios2pio-nm.cxx)
-add_library(adios2pio-nm-lib adios2pio-nm-lib.cxx)
+add_library(adios2pio-nm-lib ${SCORPIO_SOURCE_DIR}/tools/util/spio_misc_tool_utils.cxx adios2pio-nm-lib.cxx)
 include_directories(
   "${PROJECT_SOURCE_DIR}"   # to find foo/foo.h
   "${PROJECT_BINARY_DIR}")  # to find foo/config.h

--- a/tools/adios2pio-nm/README_conversion_tool.txt
+++ b/tools/adios2pio-nm/README_conversion_tool.txt
@@ -1,0 +1,54 @@
+This file contains some basic information on how to use the ADIOS to NetCDF conversion tool for converting SCORPIO output files in the ADIOS BP file format to NetCDF. The conversion tool reads the ADIOS BP files in parallel (using SCORPIO and ADIOS) and converts the file using SCORPIO and PnetCDF or NetCDF libraries.
+
+Running the application
+------------------------
+If SCORPIO is enabled with support for ADIOS (see the configure log of SCORPIO to see if ADIOS support is enabled), using PIO_IOTYPE_ADIOS (for uncompressed output) or PIO_IOTYPE_ADIOSC (for compressed output) will result in all SCORPIO output being written in the ADIOS BP file format. The output files in the ADIOS BP file format can be converted to NetCDF using the conversion tool in a separate batch job.
+
+The conversion tool is an MPI program and can be run with different number (i.e., fewer) of MPI processes compared to the application that generated the output.
+
+
+---------------------------------------------------------------------------------------
+EXAMPLES:
+---------------------------------------------------------------------------------------
+
+# Program options
+
+jayesh@compute-386-03:~/scorpio_build2$ ./tools/adios2pio-nm/adios2pio-nm.exe
+Usage : ./tools/adios2pio-nm/adios2pio-nm.exe --[OPTIONAL ARG1 NAME]=[OPTIONAL ARG1 VALUE] --[OPTIONAL ARG2 NAME]=[OPTIONAL ARG2 VALUE] ... 
+Optional Arguments :
+--bp-file:	data produced by SCORPIO with ADIOS format
+--idir:	Directory containing data output from SCORPIO (in ADIOS format)
+--nc-file:	output file name after conversion
+--pio-format:	output SCORPIO I/O type. Supported parameters: "pnetcdf",  "netcdf",  "netcdf4c",  "netcdf4p", "nczarr"
+--rearr:	SCORPIO rearranger. Supported parameters: "subset", "box", "any". Default "any".
+--rm-bp-file-after-conv:	remove the ADIOS BP file after conversion
+--verbose:	Turn on verbose info messages
+
+
+# Delete all ADIOS BP files after conversion
+jayesh@compute-386-03:~/scorpio_build2$ ./tools/adios2pio-nm/adios2pio-nm.exe --bp-file=/home/jayesh/scorpio_build2/tests/general/test_pio_file_simple_tests.testfile.bp --rm-bp-file-after-conv
+Converting BP file : "/home/jayesh/scorpio_build2/tests/general/test_pio_file_simple_tests.testfile.bp"
+Deleting BP file : /home/jayesh/scorpio_build2/tests/general/test_pio_file_simple_tests.testfile.bp
+
+# Delete all ADIOS BP files with name "(.*)(test_pio_file_simple)(.*)" after conversion
+jayesh@compute-386-03:~/scorpio_build2$ ./tools/adios2pio-nm/adios2pio-nm.exe --bp-file=/home/jayesh/scorpio_build2/tests/general/test_pio_file_simple_tests.testfile.bp --rm-bp-file-after-conv="(.*)(test_pio_file_simple)(.*)"
+Converting BP file : "/home/jayesh/scorpio_build2/tests/general/test_pio_file_simple_tests.testfile.bp"
+Deleting BP file : /home/jayesh/scorpio_build2/tests/general/test_pio_file_simple_tests.testfile.bp
+
+jayesh@compute-386-03:~/scorpio_build2$ ./tools/adios2pio-nm/adios2pio-nm.exe --bp-file=/home/jayesh/scorpio_build2/tests/general/test_pio_file_simple_tests.testfile.bp --rm-bp-file-after-conv="(.*)(DONT_DELETE_test_pio_file_simple)(.*)"
+Converting BP file : "/home/jayesh/scorpio_build2/tests/general/test_pio_file_simple_tests.testfile.bp"
+
+# Convert ADIOS BP output files in directory, /scratch/jayesh/e3sm/scratch/test_F2010_ne4_oQU240/run, and only delete the EAM ADIOS BP files after conversion
+jayesh@compute-386-03:~/scorpio_build2$ mpiexec -n 8 ./tools/adios2pio-nm/adios2pio-nm.exe --idir=/scratch/jayesh/e3sm/scratch/test_F2010_ne4_oQU240/run --rm-bp-file-after-conv="(.*)(.eam.)(.*)"
+Converting BP file : "/scratch/jayesh/e3sm/scratch/test_F2010_ne4_oQU240/run/test_F2010_ne4_oQU240.eam.rs.0001-01-02-00000.nc.bp"
+Deleting BP file : /scratch/jayesh/e3sm/scratch/test_F2010_ne4_oQU240/run/test_F2010_ne4_oQU240.eam.rs.0001-01-02-00000.nc.bp
+Converting BP file : "/scratch/jayesh/e3sm/scratch/test_F2010_ne4_oQU240/run/test_F2010_ne4_oQU240.mosart.rh0.0001-01-02-00000.nc.bp"
+Converting BP file : "/scratch/jayesh/e3sm/scratch/test_F2010_ne4_oQU240/run/test_F2010_ne4_oQU240.elm.rh0.0001-01-02-00000.nc.bp"
+Converting BP file : "/scratch/jayesh/e3sm/scratch/test_F2010_ne4_oQU240/run/test_F2010_ne4_oQU240.cpl.r.0001-01-02-00000.nc.bp"
+Converting BP file : "/scratch/jayesh/e3sm/scratch/test_F2010_ne4_oQU240/run/test_F2010_ne4_oQU240.elm.r.0001-01-02-00000.nc.bp"
+Converting BP file : "/scratch/jayesh/e3sm/scratch/test_F2010_ne4_oQU240/run/test_F2010_ne4_oQU240.eam.h0.0001-01-01-00000.nc.bp"
+Deleting BP file : /scratch/jayesh/e3sm/scratch/test_F2010_ne4_oQU240/run/test_F2010_ne4_oQU240.eam.h0.0001-01-01-00000.nc.bp
+Converting BP file : "/scratch/jayesh/e3sm/scratch/test_F2010_ne4_oQU240/run/test_F2010_ne4_oQU240.eam.r.0001-01-02-00000.nc.bp"
+Deleting BP file : /scratch/jayesh/e3sm/scratch/test_F2010_ne4_oQU240/run/test_F2010_ne4_oQU240.eam.r.0001-01-02-00000.nc.bp
+Converting BP file : "/scratch/jayesh/e3sm/scratch/test_F2010_ne4_oQU240/run/test_F2010_ne4_oQU240.mosart.r.0001-01-02-00000.nc.bp"
+

--- a/tools/adios2pio-nm/adios2pio-nm-lib.cxx
+++ b/tools/adios2pio-nm/adios2pio-nm-lib.cxx
@@ -2306,12 +2306,14 @@ int ConvertBPFile(const string &infilepath, const string &outfilename,
     if(ierr != BP2PIO_NOERR)
     {
         fprintf(stderr, "ERROR: Checking BP file (%s) conversion status failed\n", infilepath.c_str());
+        GPTLstop("adios2pio:ConvertBPFile");
         return BP2PIO_ERROR;
     }
 
     if(conv_done)
     {
         /* Avoid converting BP files that have already been converted */
+        GPTLstop("adios2pio:ConvertBPFile");
         return BP2PIO_NOERR;
     }
 
@@ -2326,6 +2328,7 @@ int ConvertBPFile(const string &infilepath, const string &outfilename,
         ierr = OpenAdiosFile(adios, bpIO, bpReader, file0, err_msg);
         if (ierr != PIO_NOERR)
         {
+            GPTLstop("adios2pio:ConvertBPFile");
             fprintf(stderr, "ERROR: Cannot open file: %s\n", file0.c_str());
             fflush(stderr);
             return ierr;
@@ -2344,6 +2347,7 @@ int ConvertBPFile(const string &infilepath, const string &outfilename,
         else
         {
             fprintf(stderr, "ERROR: /__pio__/info/nproc is missing.\n");
+            GPTLstop("adios2pio:ConvertBPFile");
             return BP2PIO_ERROR;
         }
 
@@ -2397,12 +2401,14 @@ int ConvertBPFile(const string &infilepath, const string &outfilename,
             if (mpierr != MPI_SUCCESS)
             {
                 fprintf(stderr, "Bcasting /__pio__/info/block_nprocs failed, mpierr = %d\n", mpierr);
+                GPTLstop("adios2pio:ConvertBPFile");
                 return BP2PIO_ERROR;
             }
         }
         else
         {
             fprintf(stderr, "ERROR: /__pio__/info/block_nprocs is missing.\n");
+            GPTLstop("adios2pio:ConvertBPFile");
             return BP2PIO_ERROR;
         }
 
@@ -2444,6 +2450,7 @@ int ConvertBPFile(const string &infilepath, const string &outfilename,
             if (mpierr != MPI_SUCCESS)
             {
                 fprintf(stderr, "Bcasting /__pio__/info/block_list failed, mpierr = %d\n", mpierr);
+                GPTLstop("adios2pio:ConvertBPFile");
                 return BP2PIO_ERROR;
             }
 
@@ -2455,6 +2462,7 @@ int ConvertBPFile(const string &infilepath, const string &outfilename,
         else
         {
             fprintf(stderr, "ERROR: /__pio__/info/block_list is missing.\n");
+            GPTLstop("adios2pio:ConvertBPFile");
             return BP2PIO_ERROR;
         }
         bpReader[0].EndStep();
@@ -2465,7 +2473,10 @@ int ConvertBPFile(const string &infilepath, const string &outfilename,
         ierr = CreateIOProcessGroup(w_comm, w_nproc, w_mpirank, block_procs, &comm, &mpirank, &nproc, &io_proc);
         GPTLstop("adios2pio:ConvertBPFile:CreateIOProcessGroup");
         if (ierr != BP2PIO_NOERR)
+        {
+            GPTLstop("adios2pio:ConvertBPFile");
             return ierr;
+        }
 
         /* Close files. Create a new ADIOS object, because the MPI processes are clustered into two groups */
         bpReader[0].Close();
@@ -2480,6 +2491,7 @@ int ConvertBPFile(const string &infilepath, const string &outfilename,
             /* Not I/O process */
             MPI_Comm_free(&comm);
             MPI_Barrier(w_comm);
+            GPTLstop("adios2pio:ConvertBPFile");
             return BP2PIO_NOERR;
         }
 
@@ -2661,6 +2673,7 @@ int ConvertBPFile(const string &infilepath, const string &outfilename,
         {
             cerr << "rank " << mpirank << ":ERROR in PIOc_finalize(), code = " << ret
                  << " at " << __func__ << ":" << __LINE__ << endl;
+           GPTLstop("adios2pio:ConvertBPFile");
            throw std::runtime_error("PIOc_finalize error.");
         }
     }
@@ -2684,7 +2697,9 @@ int ConvertBPFile(const string &infilepath, const string &outfilename,
     GPTLstop("adios2pio:ConvertBPFile");
 
     if (ierr != BP2PIO_NOERR)
+    {
         return ierr;
+    }
 
     return BP2PIO_NOERR;
 }

--- a/tools/adios2pio-nm/adios2pio-nm-lib.cxx
+++ b/tools/adios2pio-nm/adios2pio-nm-lib.cxx
@@ -2831,7 +2831,7 @@ static int FindBPDirs(const string &bppdir,
     while ((pde = readdir(pdir)) != NULL)
     {
         assert(pde);
-        string dname(pde->d_name);
+        string dname(bppdir + "/" + pde->d_name);
         /* Add dirs named "*.bp" to bpdirs */
         string dname_prefix;
         if ((pde->d_type == DT_DIR) &&

--- a/tools/adios2pio-nm/adios2pio-nm-lib.h
+++ b/tools/adios2pio-nm/adios2pio-nm-lib.h
@@ -17,9 +17,10 @@ using namespace std;
 
 int ConvertBPToNC(const string &infilepath,
                   const string &outfilename,
-                  const string &piotype, const string &rearr, MPI_Comm comm_in);
+                  const string &piotype, const string &rearr, MPI_Comm comm_in,
+                  const std::string &rm_ifname_rgx);
 int MConvertBPToNC(const string &bppdir, const string &piotype, const string &rearr,
-                    MPI_Comm comm);
+                    MPI_Comm comm, const std::string &rm_ifname_rgx);
 void SetDebugOutput(int val);
 
 #endif /* #ifndef _ADIOS2PIO_NM_LIB_H_ */

--- a/tools/adios2pio-nm/adios2pio-nm.cxx
+++ b/tools/adios2pio-nm/adios2pio-nm.cxx
@@ -9,11 +9,11 @@
 
 static void init_user_options(spio_tool_utils::ArgParser &ap)
 {
-    ap.add_opt("bp-file", "data produced by PIO with ADIOS format")
-      .add_opt("idir", "Directory containing data output from PIO (in ADIOS format)")
+    ap.add_opt("bp-file", "data produced by SCORPIO with ADIOS format")
+      .add_opt("idir", "Directory containing data output from SCORPIO (in ADIOS format)")
       .add_opt("nc-file", "output file name after conversion")
-      .add_opt("pio-format", "output PIO_IO_TYPE. Supported parameters: \"pnetcdf\",  \"netcdf\",  \"netcdf4c\",  \"netcdf4p\", \"nczarr\"")
-      .add_opt("rearr", "PIO rearranger. Supported parameters: \"subset\", \"box\", \"any\". Default \"any\".")
+      .add_opt("pio-format", "output SCORPIO I/O type. Supported parameters: \"pnetcdf\",  \"netcdf\",  \"netcdf4c\",  \"netcdf4p\", \"nczarr\"")
+      .add_opt("rearr", "SCORPIO rearranger. Supported parameters: \"subset\", \"box\", \"any\". Default \"any\".")
       .add_opt("verbose", "Turn on verbose info messages");
 }
 

--- a/tools/util/argparser.h
+++ b/tools/util/argparser.h
@@ -80,7 +80,11 @@ template<>
 inline std::string ArgParser::get_arg<std::string>(const std::string &opt) const
 {
   assert(arg_map_.count(opt) == 1);
-  return arg_map_.at(opt);
+  std::string opt_val = arg_map_.at(opt);
+  if(opt_val == NOVAL_OPT_STR){
+    throw std::runtime_error("Requested value for argument with no value");
+  }
+  return opt_val;
 }
 
 /* Get an int argument already parsed by the parser */

--- a/tools/util/spio_misc_tool_utils.cxx
+++ b/tools/util/spio_misc_tool_utils.cxx
@@ -1,5 +1,11 @@
 #include "spio_misc_tool_utils.h"
 #include <stdexcept>
+#include <stack>
+#include <iostream>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <dirent.h>
 
 namespace spio_tool_utils{
 
@@ -33,6 +39,65 @@ namespace spio_tool_utils{
     }
 
     return gsucc;
+  }
+
+  void rmdir_f(const std::string &dname)
+  {
+    struct Dir_info{
+      std::string dname;
+      DIR *dstream;
+    };
+    std::stack<Dir_info> dinfos;
+
+    /* Add directory stream of root dir to the stack */
+    DIR *ds = opendir(dname.c_str());
+    if(ds){
+      dinfos.push({dname, ds});
+    }
+
+    /* Recursively process directory streams from the stack */
+    while(!dinfos.empty()){
+      Dir_info dinfo = dinfos.top();
+      dinfos.pop();
+
+      struct dirent *dir_entry;
+      do{
+        dir_entry = readdir(dinfo.dstream);
+        if(dir_entry){
+          std::string dname = std::string(dir_entry->d_name);
+          std::string fdname = dinfo.dname + "/" + std::string(dir_entry->d_name);
+
+          /* Ignore processing "." & ".." directories */
+          if((dname == ".") || (dname == "..")) continue;
+
+          struct stat st;
+          if(!lstat(fdname.c_str(), &st)){
+            if(S_ISLNK(st.st_mode)){
+              /* Delete the symbolic link - don't follow symbolic links */
+              unlink(fdname.c_str());
+            }
+            else if(S_ISDIR(st.st_mode)){
+              /* Push details of the parent directory in stack and process this directory */
+              dinfos.push(dinfo);
+
+              dinfo.dname = fdname;
+              dinfo.dstream = opendir(fdname.c_str());
+              /* FIXME: Do we need to signal this error back to the caller */
+              if(!dinfo.dstream) break;
+
+              continue;
+            }
+            else{
+              /* Delete the file */
+              unlink(fdname.c_str());
+            }
+          }
+        }
+      }while(dir_entry != NULL);
+
+      closedir(dinfo.dstream);
+      rmdir(dinfo.dname.c_str());
+    }
   }
 
 } // namespace spio_tool_utils

--- a/tools/util/spio_misc_tool_utils.h
+++ b/tools/util/spio_misc_tool_utils.h
@@ -30,6 +30,9 @@ namespace spio_tool_utils{
   /* Global check if a Scorpio function was successful */
   bool gsuccess(MPI_Comm comm, int lspio_err);
 
+  /* Remove directory, including all subdirs/files i.e., "rm -rf" */
+  void rmdir_f(const std::string &dname);
+
 } // namespace spio_tool_utils
 
 #endif // __SPIO_MISC_TOOL_UTILS_H__


### PR DESCRIPTION
Adding a new command line argument in the ADIOS to 
NetCDF conversion tool to specify whether (and which)
to delete input files (ADIOS BP) after converting
to NetCDF

Also including a simple README to document usage of
the conversion tool