### PR TITLE
Improve handling of append operations for reopened ADIOS files

### DIFF
--- a/src/clib/pio.h
+++ b/src/clib/pio.h
@@ -1193,6 +1193,9 @@ typedef struct file_desc_t
     /** True if we need reserve some extra space in the header when
      * creating NetCDF files to accommodate anticipated changes. */
     bool reserve_extra_header_space;
+
+    /** True if this is an existing file reopened */
+    bool is_reopened;
 } file_desc_t;
 
 /**

--- a/src/clib/pio_darray.cpp
+++ b/src/clib/pio_darray.cpp
@@ -2169,6 +2169,27 @@ int PIOc_write_darray_impl(int ncid, int varid, int ioid, PIO_Offset arraylen, c
                         "Writing variable (%s, varid=%d) to file (%s, ncid=%d) failed. The file was not opened for writing, try reopening the file in write mode (use the PIO_WRITE flag)", pio_get_vname_from_file(file, varid), varid, pio_get_fname_from_file(file), file->pio_ncid);
     }
 
+    if ((file->iotype == PIO_IOTYPE_ADIOS) || (file->iotype == PIO_IOTYPE_ADIOSC))
+    {
+        /* ADIOS type does not support open to append mode */
+        if (file->is_reopened)
+        {
+            GPTLstop("PIO:PIOc_write_darray");
+            GPTLstop("PIO:write_total");
+            GPTLstop("PIO:PIOc_write_darray_adios");
+            GPTLstop("PIO:write_total_adios");
+            spio_ltimer_stop(ios->io_fstats->wr_timer_name);
+            spio_ltimer_stop(ios->io_fstats->tot_timer_name);
+            spio_ltimer_stop(file->io_fstats->wr_timer_name);
+            spio_ltimer_stop(file->io_fstats->tot_timer_name);
+            return pio_err(ios, file, PIO_EADIOS2ERR, __FILE__, __LINE__,
+                           "Writing variable (%s, varid=%d) to file (%s, ncid=%d) using ADIOS iotype failed. "
+                           "Open to append mode is not supported yet",
+                           pio_get_vname_from_file(file, varid), varid,
+                           pio_get_fname_from_file(file), ncid);
+        }
+    }
+
     /* Get decomposition information. */
     if (!(iodesc = pio_get_iodesc_from_id(ioid)))
     {

--- a/src/clib/pio_darray.cpp
+++ b/src/clib/pio_darray.cpp
@@ -2169,6 +2169,7 @@ int PIOc_write_darray_impl(int ncid, int varid, int ioid, PIO_Offset arraylen, c
                         "Writing variable (%s, varid=%d) to file (%s, ncid=%d) failed. The file was not opened for writing, try reopening the file in write mode (use the PIO_WRITE flag)", pio_get_vname_from_file(file, varid), varid, pio_get_fname_from_file(file), file->pio_ncid);
     }
 
+#ifdef _ADIOS2
     if ((file->iotype == PIO_IOTYPE_ADIOS) || (file->iotype == PIO_IOTYPE_ADIOSC))
     {
         /* ADIOS type does not support open to append mode */
@@ -2189,6 +2190,7 @@ int PIOc_write_darray_impl(int ncid, int varid, int ioid, PIO_Offset arraylen, c
                            pio_get_fname_from_file(file), ncid);
         }
     }
+#endif
 
     /* Get decomposition information. */
     if (!(iodesc = pio_get_iodesc_from_id(ioid)))

--- a/src/clib/pio_getput_int.cpp
+++ b/src/clib/pio_getput_int.cpp
@@ -62,6 +62,22 @@ int spio_put_att_tc(int ncid, int varid, const char *name, nc_type atttype,
 
     if ((file->iotype == PIO_IOTYPE_ADIOS) || (file->iotype == PIO_IOTYPE_ADIOSC))
     {
+        /* ADIOS type does not support open to append mode */
+        if (file->is_reopened)
+        {
+            GPTLstop("PIO:spio_put_att_tc");
+            GPTLstop("PIO:write_total");
+            spio_ltimer_stop(ios->io_fstats->wr_timer_name);
+            spio_ltimer_stop(ios->io_fstats->tot_timer_name);
+            spio_ltimer_stop(file->io_fstats->wr_timer_name);
+            spio_ltimer_stop(file->io_fstats->tot_timer_name);
+            return pio_err(ios, file, PIO_EADIOS2ERR, __FILE__, __LINE__,
+                           "Writing variable (%s, varid=%d) attribute (%s) to file (%s, ncid=%d) using ADIOS iotype failed. "
+                           "Open to append mode is not supported yet",
+                           pio_get_vname_from_file(file, varid), varid, PIO_IS_NULL(name),
+                           pio_get_fname_from_file(file), ncid);
+        }
+
         GPTLstart("PIO:spio_put_att_tc_adios");
         GPTLstart("PIO:write_total_adios");
     }
@@ -2465,6 +2481,22 @@ int spio_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
 
     if ((file->iotype == PIO_IOTYPE_ADIOS) || (file->iotype == PIO_IOTYPE_ADIOSC))
     {
+        /* ADIOS type does not support open to append mode */
+        if (file->is_reopened)
+        {
+            GPTLstop("PIO:spio_put_vars_tc");
+            GPTLstop("PIO:write_total");
+            spio_ltimer_stop(ios->io_fstats->wr_timer_name);
+            spio_ltimer_stop(ios->io_fstats->tot_timer_name);
+            spio_ltimer_stop(file->io_fstats->wr_timer_name);
+            spio_ltimer_stop(file->io_fstats->tot_timer_name);
+            return pio_err(ios, file, PIO_EADIOS2ERR, __FILE__, __LINE__,
+                           "Writing variable (%s, varid=%d) to file (%s, ncid=%d) using ADIOS iotype failed. "
+                           "Open to append mode is not supported yet",
+                           pio_get_vname_from_file(file, varid), varid,
+                           pio_get_fname_from_file(file), ncid);
+        }
+
         GPTLstart("PIO:spio_put_vars_tc_adios");
         GPTLstart("PIO:write_total_adios");
     }

--- a/src/clib/pio_getput_int.cpp
+++ b/src/clib/pio_getput_int.cpp
@@ -60,6 +60,7 @@ int spio_put_att_tc(int ncid, int varid, const char *name, nc_type atttype,
     spio_ltimer_start(ios->io_fstats->wr_timer_name);
     spio_ltimer_start(ios->io_fstats->tot_timer_name);
 
+#ifdef _ADIOS2
     if ((file->iotype == PIO_IOTYPE_ADIOS) || (file->iotype == PIO_IOTYPE_ADIOSC))
     {
         /* ADIOS type does not support open to append mode */
@@ -77,7 +78,11 @@ int spio_put_att_tc(int ncid, int varid, const char *name, nc_type atttype,
                            pio_get_vname_from_file(file, varid), varid, PIO_IS_NULL(name),
                            pio_get_fname_from_file(file), ncid);
         }
+    }
+#endif
 
+    if ((file->iotype == PIO_IOTYPE_ADIOS) || (file->iotype == PIO_IOTYPE_ADIOSC))
+    {
         GPTLstart("PIO:spio_put_att_tc_adios");
         GPTLstart("PIO:write_total_adios");
     }
@@ -2479,6 +2484,7 @@ int spio_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
     spio_ltimer_start(ios->io_fstats->wr_timer_name);
     spio_ltimer_start(ios->io_fstats->tot_timer_name);
 
+#ifdef _ADIOS2
     if ((file->iotype == PIO_IOTYPE_ADIOS) || (file->iotype == PIO_IOTYPE_ADIOSC))
     {
         /* ADIOS type does not support open to append mode */
@@ -2496,7 +2502,11 @@ int spio_put_vars_tc(int ncid, int varid, const PIO_Offset *start, const PIO_Off
                            pio_get_vname_from_file(file, varid), varid,
                            pio_get_fname_from_file(file), ncid);
         }
+    }
+#endif
 
+    if ((file->iotype == PIO_IOTYPE_ADIOS) || (file->iotype == PIO_IOTYPE_ADIOSC))
+    {
         GPTLstart("PIO:spio_put_vars_tc_adios");
         GPTLstart("PIO:write_total_adios");
     }

--- a/src/clib/pioc_support.cpp
+++ b/src/clib/pioc_support.cpp
@@ -4725,13 +4725,13 @@ int PIOc_openfile_retry_impl(int iosysid, int *ncidp, int *iotype, const char *f
 #ifdef _ADIOS2
     if ((file->iotype == PIO_IOTYPE_ADIOS) || (file->iotype == PIO_IOTYPE_ADIOSC))
     {
-        if (file->mode & PIO_WRITE)
+        if (mode & PIO_WRITE)
         {
             spio_ltimer_stop(ios->io_fstats->rd_timer_name);
             spio_ltimer_stop(ios->io_fstats->tot_timer_name);
             spio_ltimer_stop(file->io_fstats->rd_timer_name);
             spio_ltimer_stop(file->io_fstats->tot_timer_name);
-            return pio_err(ios, file, PIO_EADIOS2ERR, __FILE__, __LINE__,
+            return pio_err(ios, NULL, PIO_EADIOS2ERR, __FILE__, __LINE__,
                            "Opening file (%s) using ADIOS iotype failed. "
                            "Open to append mode is not supported yet",
                            filename);
@@ -4762,7 +4762,7 @@ int PIOc_openfile_retry_impl(int iosysid, int *ncidp, int *iotype, const char *f
                 spio_ltimer_stop(ios->io_fstats->tot_timer_name);
                 spio_ltimer_stop(file->io_fstats->rd_timer_name);
                 spio_ltimer_stop(file->io_fstats->tot_timer_name);
-                return pio_err(ios, file, PIO_EADIOS2ERR, __FILE__, __LINE__,
+                return pio_err(ios, NULL, PIO_EADIOS2ERR, __FILE__, __LINE__,
                                "Opening file (%s) using ADIOS iotype failed. "
                                "The low level (ADIOS) I/O library call failed to declare a new io handler",
                                filename);
@@ -4775,7 +4775,7 @@ int PIOc_openfile_retry_impl(int iosysid, int *ncidp, int *iotype, const char *f
                 spio_ltimer_stop(ios->io_fstats->tot_timer_name);
                 spio_ltimer_stop(file->io_fstats->rd_timer_name);
                 spio_ltimer_stop(file->io_fstats->tot_timer_name);
-                return pio_err(ios, file, PIO_EADIOS2ERR, __FILE__, __LINE__,
+                return pio_err(ios, NULL, PIO_EADIOS2ERR, __FILE__, __LINE__,
                                "Opening file (%s) using ADIOS iotype failed. "
                                "The low level (ADIOS) I/O library call failed to set a single parameter (adios2_error=%s)",
                                filename, convert_adios2_error_to_string(adiosErr));
@@ -4788,7 +4788,7 @@ int PIOc_openfile_retry_impl(int iosysid, int *ncidp, int *iotype, const char *f
                 spio_ltimer_stop(ios->io_fstats->tot_timer_name);
                 spio_ltimer_stop(file->io_fstats->rd_timer_name);
                 spio_ltimer_stop(file->io_fstats->tot_timer_name);
-                return pio_err(ios, file, PIO_EADIOS2ERR, __FILE__, __LINE__,
+                return pio_err(ios, NULL, PIO_EADIOS2ERR, __FILE__, __LINE__,
                                "Opening file (%s) using ADIOS iotype failed. "
                                "The low level (ADIOS) I/O library call failed to set a single parameter (adios2_error=%s)",
                                filename, convert_adios2_error_to_string(adiosErr));
@@ -4801,7 +4801,7 @@ int PIOc_openfile_retry_impl(int iosysid, int *ncidp, int *iotype, const char *f
                 spio_ltimer_stop(ios->io_fstats->tot_timer_name);
                 spio_ltimer_stop(file->io_fstats->rd_timer_name);
                 spio_ltimer_stop(file->io_fstats->tot_timer_name);
-                return pio_err(ios, file, PIO_EADIOS2ERR, __FILE__, __LINE__,
+                return pio_err(ios, NULL, PIO_EADIOS2ERR, __FILE__, __LINE__,
                                "Opening file (%s) using ADIOS iotype failed. "
                                "The low level (ADIOS) I/O library call failed to set a single parameter (adios2_error=%s)",
                                filename, convert_adios2_error_to_string(adiosErr));
@@ -4814,7 +4814,7 @@ int PIOc_openfile_retry_impl(int iosysid, int *ncidp, int *iotype, const char *f
                 spio_ltimer_stop(ios->io_fstats->tot_timer_name);
                 spio_ltimer_stop(file->io_fstats->rd_timer_name);
                 spio_ltimer_stop(file->io_fstats->tot_timer_name);
-                return pio_err(ios, file, PIO_EADIOS2ERR, __FILE__, __LINE__,
+                return pio_err(ios, NULL, PIO_EADIOS2ERR, __FILE__, __LINE__,
                                "Opening file (%s) using ADIOS iotype failed. "
                                "The low level (ADIOS) I/O library call failed to set a single parameter (adios2_error=%s)",
                                filename, convert_adios2_error_to_string(adiosErr));
@@ -4827,7 +4827,7 @@ int PIOc_openfile_retry_impl(int iosysid, int *ncidp, int *iotype, const char *f
                 spio_ltimer_stop(ios->io_fstats->tot_timer_name);
                 spio_ltimer_stop(file->io_fstats->rd_timer_name);
                 spio_ltimer_stop(file->io_fstats->tot_timer_name);
-                return pio_err(ios, file, PIO_EADIOS2ERR, __FILE__, __LINE__,
+                return pio_err(ios, NULL, PIO_EADIOS2ERR, __FILE__, __LINE__,
                                "Opening file (%s) using ADIOS iotype failed. "
                                "The low level (ADIOS) I/O library call failed to set the engine type for current io handler (adios2_error=%s)",
                                filename, convert_adios2_error_to_string(adiosErr));

--- a/src/clib/pioc_support.cpp
+++ b/src/clib/pioc_support.cpp
@@ -3045,6 +3045,7 @@ int spio_createfile_int(int iosysid, int *ncidp, const int *iotype, const char *
     /* Fill in some file values. */
     file->fh = -1;
     file->reserve_extra_header_space = true; /* Set to true for creating output NetCDF files only. */
+    file->is_reopened = false;
     strncpy(file->fname, filename, PIO_MAX_NAME);
     ierr = pio_create_uniq_str(ios, NULL, tname, SPIO_TIMER_MAX_NAME, "tmp_", "_file");
     if(ierr != PIO_NOERR)
@@ -4704,6 +4705,7 @@ int PIOc_openfile_retry_impl(int iosysid, int *ncidp, int *iotype, const char *f
     /* Fill in some file values. */
     file->fh = -1;
     file->reserve_extra_header_space = false; /* Set to true for creating output NetCDF files only. */
+    file->is_reopened = true;
     strncpy(file->fname, filename, PIO_MAX_NAME);
     ierr = pio_create_uniq_str(ios, NULL, tname, SPIO_TIMER_MAX_NAME, "tmp_", "_file");
     if(ierr != PIO_NOERR)

--- a/src/clib/pioc_support.cpp
+++ b/src/clib/pioc_support.cpp
@@ -4727,18 +4727,6 @@ int PIOc_openfile_retry_impl(int iosysid, int *ncidp, int *iotype, const char *f
 #ifdef _ADIOS2
     if ((file->iotype == PIO_IOTYPE_ADIOS) || (file->iotype == PIO_IOTYPE_ADIOSC))
     {
-        if (mode & PIO_WRITE)
-        {
-            spio_ltimer_stop(ios->io_fstats->rd_timer_name);
-            spio_ltimer_stop(ios->io_fstats->tot_timer_name);
-            spio_ltimer_stop(file->io_fstats->rd_timer_name);
-            spio_ltimer_stop(file->io_fstats->tot_timer_name);
-            return pio_err(ios, NULL, PIO_EADIOS2ERR, __FILE__, __LINE__,
-                           "Opening file (%s) using ADIOS iotype failed. "
-                           "Open to append mode is not supported yet",
-                           filename);
-        }
-
         /* Trying to open a file with adios unless ADIOS_BP2NC_TEST option is enabled for unit tests */
         bool adios2_file_exist = false;
 


### PR DESCRIPTION
Reopening files to append data is not supported by the ADIOS type.
Returning an error when the user tries to append data to an existing
file in ADIOS BP format.

However, it is common for users to reopen existing files in write
mode without performing any actual write operations, which is
acceptable. An error will only be returned if an actual append
operation is attempted on a reopened ADIOS file.