### PR TITLE
Add workaround to override ADIOS type with PnetCDF for file creation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -268,6 +268,21 @@ else()
   message(STATUS "PIO_REARR_ANY rearranger : Setting the local decomposition map length range for SUBSET rearanger (PIO_REARR_ANY_SUBSET_RANGE) to " ${PIO_REARR_ANY_SUBSET_RANGE} " (default)")
 endif()
 
+if(WITH_ADIOS2)
+  if(DEFINED SPIO_OVERRIDE_ADIOS_WITH_PNETCDF_FNAME_REGEX)
+    if(WITH_PNETCDF)
+      message(STATUS "Overriding ADIOS type with PnetCDF for creating files matching regex: ${SPIO_OVERRIDE_ADIOS_WITH_PNETCDF_FNAME_REGEX}")
+    else()
+      message(WARNING "Requested override of ADIOS with PnetCDF for file creation, but PnetCDF is not enabled. Override will be ignored.")
+    endif()
+  else()
+    # Use a regex pattern that matches nothing: \b\B (word boundary followed by non-boundary)
+    # This effectively disables overriding ADIOS type with PnetCDF for file creation by default.
+    set(SPIO_OVERRIDE_ADIOS_WITH_PNETCDF_FNAME_REGEX "\\b\\B")
+    message(STATUS "Disabling override of ADIOS type with PnetCDF for file creation (default)")
+  endif()
+endif()
+
 #==============================================================================
 #  DETECT SYSTEM/COMPILERS (and set compiler specific options)
 #==============================================================================

--- a/src/clib/pio_config.h.in
+++ b/src/clib/pio_config.h.in
@@ -64,6 +64,9 @@
 /** Range of length of the local decomposition map for SUBSET rearanger. */
 #define PIO_REARR_ANY_SUBSET_RANGE "@PIO_REARR_ANY_SUBSET_RANGE@"
 
+/** Set the regex to override ADIOS type with PnetCDF for file creation. */
+#define SPIO_OVERRIDE_ADIOS_WITH_PNETCDF_FNAME_REGEX "@SPIO_OVERRIDE_ADIOS_WITH_PNETCDF_FNAME_REGEX@"
+
 /** Set to 1 if the library is configured to use the PnetCDF library,
  *  0 otherwise */
 #define PIO_USE_PNETCDF @PIO_USE_PNETCDF@


### PR DESCRIPTION
Introduce a workaround in SCORPIO that allows overriding the
default ADIOS output type with PnetCDF for file creation,
based on filename matching via regular expressions.

In E3SM, ADIOS is typically preferred only for restart files.
Until PIO_TYPENAME_RESTART is implemented, this provides
a temporary way to use PnetCDF for history file creation.