### PR TITLE
Allow regex for specifying input files to the conversion tool

### DIFF
--- a/tools/adios2pio-nm/README_conversion_tool.txt
+++ b/tools/adios2pio-nm/README_conversion_tool.txt
@@ -13,17 +13,16 @@ EXAMPLES:
 
 # Program options
 
-jayesh@compute-386-03:~/scorpio_build2$ ./tools/adios2pio-nm/adios2pio-nm.exe
+jayesh@compute-386-03:~/scorpio_build2$ ./tools/adios2pio-nm/adios2pio-nm.exe --help
 Usage : ./tools/adios2pio-nm/adios2pio-nm.exe --[OPTIONAL ARG1 NAME]=[OPTIONAL ARG1 VALUE] --[OPTIONAL ARG2 NAME]=[OPTIONAL ARG2 VALUE] ... 
 Optional Arguments :
---bp-file:	data produced by SCORPIO with ADIOS format
---idir:	Directory containing data output from SCORPIO (in ADIOS format)
---nc-file:	output file name after conversion
+--bp-file:	input file (or regex of basename for multiple files) in ADIOS BP format
+--idir:	Directory containing the input files (in ADIOS BP format)
+--nc-file:	output file name after conversion (will be used as prefix when converting multiple files)
 --pio-format:	output SCORPIO I/O type. Supported parameters: "pnetcdf",  "netcdf",  "netcdf4c",  "netcdf4p", "nczarr"
 --rearr:	SCORPIO rearranger. Supported parameters: "subset", "box", "any". Default "any".
---rm-bp-file-after-conv:	remove the ADIOS BP file after conversion
+--rm-bp-file-after-conv:	remove the ADIOS BP file after conversion (or regex to specify which files to delete after conversion)
 --verbose:	Turn on verbose info messages
-
 
 # Delete all ADIOS BP files after conversion
 jayesh@compute-386-03:~/scorpio_build2$ ./tools/adios2pio-nm/adios2pio-nm.exe --bp-file=/home/jayesh/scorpio_build2/tests/general/test_pio_file_simple_tests.testfile.bp --rm-bp-file-after-conv
@@ -51,4 +50,17 @@ Deleting BP file : /scratch/jayesh/e3sm/scratch/test_F2010_ne4_oQU240/run/test_F
 Converting BP file : "/scratch/jayesh/e3sm/scratch/test_F2010_ne4_oQU240/run/test_F2010_ne4_oQU240.eam.r.0001-01-02-00000.nc.bp"
 Deleting BP file : /scratch/jayesh/e3sm/scratch/test_F2010_ne4_oQU240/run/test_F2010_ne4_oQU240.eam.r.0001-01-02-00000.nc.bp
 Converting BP file : "/scratch/jayesh/e3sm/scratch/test_F2010_ne4_oQU240/run/test_F2010_ne4_oQU240.mosart.r.0001-01-02-00000.nc.bp"
+
+# Convert ONLY coupler output in ADIOS BP format : Specify the regex for files to convert via "--bp-file" option
+jayesh@compute-386-03:~/scorpio_build2$ ./tools/adios2pio-nm/adios2pio-nm.exe --idir=/scratch/jayesh/e3sm/scratch/tmp_adios_bp_run_dir --bp-file=".*.cpl.*"
+WARNING: Skipping BP file (did not match specified regex): /scratch/jayesh/e3sm/scratch/tmp_adios_bp_run_dir/ERP_Ld3.ne4pg2_oQU480.F2010.anlgce-ub22_gnu.io-force_adios.20240717_210751_7we0ju.mpassi.rst.0001-01-03_00000.nc.bp
+WARNING: Skipping BP file (did not match specified regex): /scratch/jayesh/e3sm/scratch/tmp_adios_bp_run_dir/ERP_Ld3.ne4pg2_oQU480.F2010.anlgce-ub22_gnu.io-force_adios.20240717_210751_7we0ju.mosart.r.0001-01-03-00000.nc.bp
+WARNING: Skipping BP file (did not match specified regex): /scratch/jayesh/e3sm/scratch/tmp_adios_bp_run_dir/ERP_Ld3.ne4pg2_oQU480.F2010.anlgce-ub22_gnu.io-force_adios.20240717_210751_7we0ju.elm.r.0001-01-03-00000.nc.bp
+WARNING: Skipping BP file (did not match specified regex): /scratch/jayesh/e3sm/scratch/tmp_adios_bp_run_dir/ERP_Ld3.ne4pg2_oQU480.F2010.anlgce-ub22_gnu.io-force_adios.20240717_210751_7we0ju.eam.rh0.0001-01-03-00000.nc.bp
+WARNING: Skipping BP file (did not match specified regex): /scratch/jayesh/e3sm/scratch/tmp_adios_bp_run_dir/ERP_Ld3.ne4pg2_oQU480.F2010.anlgce-ub22_gnu.io-force_adios.20240717_210751_7we0ju.eam.r.0001-01-03-00000.nc.bp
+WARNING: Skipping BP file (did not match specified regex): /scratch/jayesh/e3sm/scratch/tmp_adios_bp_run_dir/ERP_Ld3.ne4pg2_oQU480.F2010.anlgce-ub22_gnu.io-force_adios.20240717_210751_7we0ju.mosart.rh0.0001-01-03-00000.nc.bp
+WARNING: Skipping BP file (did not match specified regex): /scratch/jayesh/e3sm/scratch/tmp_adios_bp_run_dir/ERP_Ld3.ne4pg2_oQU480.F2010.anlgce-ub22_gnu.io-force_adios.20240717_210751_7we0ju.elm.rh0.0001-01-03-00000.nc.bp
+WARNING: Skipping BP file (did not match specified regex): /scratch/jayesh/e3sm/scratch/tmp_adios_bp_run_dir/ERP_Ld3.ne4pg2_oQU480.F2010.anlgce-ub22_gnu.io-force_adios.20240717_210751_7we0ju.eam.rs.0001-01-03-00000.nc.bp
+Converting BP file : "/scratch/jayesh/e3sm/scratch/tmp_adios_bp_run_dir/ERP_Ld3.ne4pg2_oQU480.F2010.anlgce-ub22_gnu.io-force_adios.20240717_210751_7we0ju.cpl.hi.0001-01-04-00000.nc.bp"
+Converting BP file : "/scratch/jayesh/e3sm/scratch/tmp_adios_bp_run_dir/ERP_Ld3.ne4pg2_oQU480.F2010.anlgce-ub22_gnu.io-force_adios.20240717_210751_7we0ju.cpl.r.0001-01-03-00000.nc.bp"
 

--- a/tools/adios2pio-nm/adios2pio-nm-lib.h
+++ b/tools/adios2pio-nm/adios2pio-nm-lib.h
@@ -19,8 +19,8 @@ int ConvertBPToNC(const string &infilepath,
                   const string &outfilename,
                   const string &piotype, const string &rearr, MPI_Comm comm_in,
                   const std::string &rm_ifname_rgx);
-int MConvertBPToNC(const string &bppdir, const string &piotype, const string &rearr,
-                    MPI_Comm comm, const std::string &rm_ifname_rgx);
+int MConvertBPToNC(const string &bppdir, const string &ifname_rgx, const string &piotype,
+                    const string &rearr, MPI_Comm comm, const std::string &rm_ifname_rgx);
 void SetDebugOutput(int val);
 
 #endif /* #ifndef _ADIOS2PIO_NM_LIB_H_ */

--- a/tools/adios2pio-nm/adios2pio-nm.cxx
+++ b/tools/adios2pio-nm/adios2pio-nm.cxx
@@ -9,13 +9,13 @@
 
 static void init_user_options(spio_tool_utils::ArgParser &ap)
 {
-    ap.add_opt("bp-file", "data produced by SCORPIO with ADIOS format")
-      .add_opt("rm-bp-file-after-conv", "remove the ADIOS BP file after conversion")
-      .add_opt("idir", "Directory containing data output from SCORPIO (in ADIOS format)")
-      .add_opt("nc-file", "output file name after conversion")
-      .add_opt("pio-format", "output SCORPIO I/O type. Supported parameters: \"pnetcdf\",  \"netcdf\",  \"netcdf4c\",  \"netcdf4p\", \"nczarr\"")
-      .add_opt("rearr", "SCORPIO rearranger. Supported parameters: \"subset\", \"box\", \"any\". Default \"any\".")
-      .add_opt("verbose", "Turn on verbose info messages");
+  ap.add_opt("bp-file", "data produced by SCORPIO with ADIOS format")
+    .add_opt("rm-bp-file-after-conv", "remove the ADIOS BP file after conversion")
+    .add_opt("idir", "Directory containing data output from SCORPIO (in ADIOS format)")
+    .add_opt("nc-file", "output file name after conversion")
+    .add_opt("pio-format", "output SCORPIO I/O type. Supported parameters: \"pnetcdf\",  \"netcdf\",  \"netcdf4c\",  \"netcdf4p\", \"nczarr\"")
+    .add_opt("rearr", "SCORPIO rearranger. Supported parameters: \"subset\", \"box\", \"any\". Default \"any\".")
+    .add_opt("verbose", "Turn on verbose info messages");
 }
 
 /* Convert BP file name (<BP_FILE_NAME>.dir contains the ADIOS BP data)
@@ -29,26 +29,23 @@ static void init_user_options(spio_tool_utils::ArgParser &ap)
 static std::string strip_bp_ext(const std::string &bp_fname)
 {
 #ifdef SPIO_NO_CXX_REGEX
-    const std::string bp_ext(".bp");
-    std::size_t ext_sz = bp_ext.size();
-    if (bp_fname.size() > ext_sz)
-    {
-        if (bp_fname.substr(bp_fname.size() - ext_sz, ext_sz) ==  bp_ext)
-        {
-            return bp_fname.substr(0, bp_fname.size() - ext_sz);
-        }
+  const std::string bp_ext(".bp");
+  std::size_t ext_sz = bp_ext.size();
+  if(bp_fname.size() > ext_sz){
+    if(bp_fname.substr(bp_fname.size() - ext_sz, ext_sz) ==  bp_ext){
+      return bp_fname.substr(0, bp_fname.size() - ext_sz);
     }
+  }
 #else
-    const std::string BP_FILE_RGX_STR("(.*)[.]bp");
-    std::regex bp_file_rgx(BP_FILE_RGX_STR.c_str());
-    std::smatch match;
-    if (std::regex_search(bp_fname, match, bp_file_rgx) &&
-        match.size() == 2)
-    {
-        return match.str(1);
-    }
+  const std::string BP_FILE_RGX_STR("(.*)[.]bp");
+  std::regex bp_file_rgx(BP_FILE_RGX_STR.c_str());
+  std::smatch match;
+  if(std::regex_search(bp_fname, match, bp_file_rgx) &&
+      match.size() == 2){
+    return match.str(1);
+  }
 #endif
-    return std::string();
+  return std::string();
 }
 
 static int get_user_options(
@@ -61,157 +58,142 @@ static int get_user_options(
               std::string &rearr,
               int &debug_lvl, int rank)
 {
-    const std::string DEFAULT_PIO_FORMAT("pnetcdf");
-    const std::string DEFAULT_REARRANGER("any");
-    debug_lvl = 0;
+  const std::string DEFAULT_PIO_FORMAT("pnetcdf");
+  const std::string DEFAULT_REARRANGER("any");
+  debug_lvl = 0;
 
 #ifdef SPIO_NO_CXX_REGEX
-    ap.no_regex_parse(argc, argv);
+  ap.no_regex_parse(argc, argv);
 #else
-    ap.parse(argc, argv);
+  ap.parse(argc, argv);
 #endif
-    if (!ap.has_arg("bp-file") && !ap.has_arg("idir"))
-    {
-        ap.print_usage(std::cerr);
-        return 1;
+  if(!ap.has_arg("bp-file") && !ap.has_arg("idir")){
+    ap.print_usage(std::cerr);
+    return 1;
+  }
+  if(ap.has_arg("bp-file")){
+    ifile = ap.get_arg<std::string>("bp-file");
+    if(ap.has_arg("nc-file")){
+      ofile = ap.get_arg<std::string>("nc-file");
     }
-    if (ap.has_arg("bp-file"))
-    {
-        ifile = ap.get_arg<std::string>("bp-file");
-        if (ap.has_arg("nc-file"))
-        {
-            ofile = ap.get_arg<std::string>("nc-file");
-        }
-        else
-        {
-            ofile = strip_bp_ext(ifile);
-        }
-        if (ofile.size() == 0)
-        {
-            ap.print_usage(std::cerr);
-            return 1;
-        }
+    else{
+      ofile = strip_bp_ext(ifile);
     }
-    else
-    {
-        assert(ap.has_arg("idir"));
-        idir = ap.get_arg<std::string>("idir");
+    if(ofile.size() == 0){
+      ap.print_usage(std::cerr);
+      return 1;
     }
+  }
+  else{
+    assert(ap.has_arg("idir"));
+    idir = ap.get_arg<std::string>("idir");
+  }
 
-    if (ap.has_arg("rm-bp-file-after-conv"))
-    {
-        try{
-          /* Remove all input files matching the provided regex */
-          rm_ifname_rgx = ap.get_arg<std::string>("rm-bp-file-after-conv");
+  if(ap.has_arg("rm-bp-file-after-conv")){
+    try{
+      /* Remove all input files matching the provided regex */
+      rm_ifname_rgx = ap.get_arg<std::string>("rm-bp-file-after-conv");
 #ifdef SPIO_NO_CXX_REGEX
-          if(rank == 0){
-            std::cout << "WARNING: No C++ regex support. Ignoring specified regex for deleting files and deleting all input/BP files after conversion...\n";
-          }
-          rm_ifname_rgx = ".*";
+      if(rank == 0){
+        std::cout << "WARNING: No C++ regex support. Ignoring specified regex for deleting files and deleting all input/BP files after conversion...\n";
+      }
+      rm_ifname_rgx = ".*";
 #endif
-        } catch(...){
-          /* Remove all input files */
-          rm_ifname_rgx = ".*";
-        }
+    }catch(...){
+      /* Remove all input files */
+      rm_ifname_rgx = ".*";
     }
+  }
 
-    if (ap.has_arg("pio-format"))
-    {
-        otype = ap.get_arg<std::string>("pio-format");
-    }
-    else
-    {
-        otype = DEFAULT_PIO_FORMAT;
-    }
+  if(ap.has_arg("pio-format")){
+    otype = ap.get_arg<std::string>("pio-format");
+  }
+  else{
+    otype = DEFAULT_PIO_FORMAT;
+  }
 
-    if (ap.has_arg("rearr"))
-    {
-        rearr = ap.get_arg<std::string>("rearr");
-    }
-    else
-    {
-        rearr = DEFAULT_REARRANGER;
-    }
+  if(ap.has_arg("rearr")){
+    rearr = ap.get_arg<std::string>("rearr");
+  }
+  else{
+    rearr = DEFAULT_REARRANGER;
+  }
 
-    if (ap.has_arg("verbose"))
-    {
-        debug_lvl = 1;
-    }
+  if(ap.has_arg("verbose")){
+    debug_lvl = 1;
+  }
 
-    return 0;
+  return 0;
 }
 
 int main(int argc, char *argv[])
 {
-    int ret = 0, rank = 0;
+  int ret = 0, rank = 0;
 
-    MPI_Init(&argc, &argv);
+  MPI_Init(&argc, &argv);
 
-    MPI_Comm comm_in = MPI_COMM_WORLD;
+  MPI_Comm comm_in = MPI_COMM_WORLD;
 
-    ret = MPI_Comm_rank(comm_in, &rank);
-    if (ret != MPI_SUCCESS)
-    {
-        return ret;
-    }
-
-    spio_tool_utils::ArgParser ap(comm_in);
-
-    /* Init the standard user options for the tool */
-    init_user_options(ap);
-
-    /* Parse the user options */
-    string idir, infilepath, outfilename, piotype, rearr;
-    string rm_ifname_rgx;
-    int debug_lvl = 0;
-    ret = get_user_options(ap, argc, argv,
-                            idir, infilepath, outfilename,
-                            rm_ifname_rgx, piotype, rearr, debug_lvl, rank);
-
-    if (ret != 0)
-    {
-        return ret;
-    }
-
-#ifdef SPIO_ENABLE_GPTL_TIMING
-    /* Initialize the GPTL timing library. */
-    if ((ret = GPTLinitialize()))
-        return ret;
-#endif
-
-    GPTLstart("adios2pio:main");
-
-    SetDebugOutput(debug_lvl);
-    MPI_Barrier(comm_in);
-    if (idir.size() == 0)
-    {
-        ret = ConvertBPToNC(infilepath, outfilename, piotype, rearr, comm_in, rm_ifname_rgx);
-    }
-    else
-    {
-        ret = MConvertBPToNC(idir, piotype, rearr, comm_in, rm_ifname_rgx);
-    }
-    MPI_Barrier(comm_in);
-
-    GPTLstop("adios2pio:main");
-
-#ifdef SPIO_ENABLE_GPTL_TIMING
-    /* Write the GPTL summary/rank_0 output */
-    std::string summary_file("spioconvtoolrwgptlsummaryinfo0wrank.dat");
-    GPTLpr_summary_file(comm_in, summary_file.c_str());
-
-    if(rank == 0)
-    {
-        std::string rank0_file("spioconvtoolrwgptlinfo0wrank.dat");
-        GPTLpr_file(rank0_file.c_str());
-    }
-
-    /* Finalize the GPTL timing library. */
-    if ((ret = GPTLfinalize()))
-        return ret;
-#endif
-
-    MPI_Finalize();
-
+  ret = MPI_Comm_rank(comm_in, &rank);
+  if(ret != MPI_SUCCESS){
     return ret;
+  }
+
+  spio_tool_utils::ArgParser ap(comm_in);
+
+  /* Init the standard user options for the tool */
+  init_user_options(ap);
+
+  /* Parse the user options */
+  string idir, infilepath, outfilename, piotype, rearr;
+  string rm_ifname_rgx;
+  int debug_lvl = 0;
+  ret = get_user_options(ap, argc, argv,
+                          idir, infilepath, outfilename,
+                          rm_ifname_rgx, piotype, rearr, debug_lvl, rank);
+
+  if(ret != 0){
+    return ret;
+  }
+
+#ifdef SPIO_ENABLE_GPTL_TIMING
+  /* Initialize the GPTL timing library. */
+  if((ret = GPTLinitialize())){
+      return ret;
+  }
+#endif
+
+  GPTLstart("adios2pio:main");
+
+  SetDebugOutput(debug_lvl);
+  MPI_Barrier(comm_in);
+  if(idir.size() == 0){
+    ret = ConvertBPToNC(infilepath, outfilename, piotype, rearr, comm_in, rm_ifname_rgx);
+  }
+  else{
+    ret = MConvertBPToNC(idir, piotype, rearr, comm_in, rm_ifname_rgx);
+  }
+  MPI_Barrier(comm_in);
+
+  GPTLstop("adios2pio:main");
+
+#ifdef SPIO_ENABLE_GPTL_TIMING
+  /* Write the GPTL summary/rank_0 output */
+  std::string summary_file("spioconvtoolrwgptlsummaryinfo0wrank.dat");
+  GPTLpr_summary_file(comm_in, summary_file.c_str());
+
+  if(rank == 0){
+    std::string rank0_file("spioconvtoolrwgptlinfo0wrank.dat");
+    GPTLpr_file(rank0_file.c_str());
+  }
+
+  /* Finalize the GPTL timing library. */
+  if((ret = GPTLfinalize())){
+    return ret;
+  }
+#endif
+
+  MPI_Finalize();
+
+  return ret;
 }


### PR DESCRIPTION
Allow users to specify input files (in ADIOS BP format) via
a regular expression.

Users can now specify a regular expression for the basename
of the input files to be convered via the "--bp-file" command
line option (the directory of the input files can be specified
via "--idir" option)